### PR TITLE
Use 1.20.1 protocol constant in server status

### DIFF
--- a/src/lib/net/src/conn_init/status.rs
+++ b/src/lib/net/src/conn_init/status.rs
@@ -1,4 +1,5 @@
 use crate::conn_init::LoginResult;
+use crate::conn_init::PROTOCOL_VERSION_1_20_1;
 use crate::connection::StreamWriter;
 use crate::errors::{NetError, PacketError};
 use crate::packets::incoming::packet_skeleton::PacketSkeleton;
@@ -159,7 +160,7 @@ fn get_server_status(state: &GlobalState) -> String {
     // Protocol info
     let version = structs::Version {
         name: "1.20.1",
-        protocol: crate::conn_init::PROTOCOL_VERSION_1_20_1 as u16,
+        protocol: PROTOCOL_VERSION_1_20_1 as u16,
     };
 
     // Collect up to 5 players from the active player list


### PR DESCRIPTION
## Summary
- Reference `PROTOCOL_VERSION_1_20_1` when building server status JSON

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_b_68932c8851a48329ba7b48759cd76f96