### PR TITLE
Use Minecraft 1.20.1 core pack

### DIFF
--- a/src/lib/net/src/packets/outgoing/client_bound_known_packs.rs
+++ b/src/lib/net/src/packets/outgoing/client_bound_known_packs.rs
@@ -1,4 +1,4 @@
-use ferrumc_macros::{packet, NetEncode};
+use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
 use std::io::Write;
 
@@ -24,7 +24,7 @@ impl Default for ClientBoundKnownPacksPacket<'_> {
 impl ClientBoundKnownPacksPacket<'_> {
     pub fn new() -> Self {
         Self {
-            packs: LengthPrefixedVec::new(vec![Pack::new("minecraft", "core", "1.21")]),
+            packs: LengthPrefixedVec::new(vec![Pack::new("minecraft", "core", "1.20.1")]),
         }
     }
 }


### PR DESCRIPTION
## Summary
- use the 1.20.1 core resource pack during known pack negotiation

## Testing
- `cargo +nightly test` *(fails: src/lib/utils/src/lib.rs - root (line 16))*

------
https://chatgpt.com/codex/tasks/task_b_68932ee5ebc483299a6bd21d16177865