### PR TITLE
Fix protocol version reference in macro panic message

### DIFF
--- a/src/lib/derive_macros/src/static_loading/packets.rs
+++ b/src/lib/derive_macros/src/static_loading/packets.rs
@@ -60,7 +60,7 @@ pub(crate) fn get_packet_id(
         PacketBoundiness::Serverbound => &packets.serverbound,
     };
     let id = packets.get(&format!("minecraft:{packet_name}"))
-        .unwrap_or_else(|| panic!("Could not find key: `minecraft:{packet_name}` in the packet registry. Example: `add_entity`, would be 0x01 in the 1.21.1 protocol"));
+        .unwrap_or_else(|| panic!("Could not find key: `minecraft:{packet_name}` in the packet registry. Example: `add_entity`, would be 0x01 in the 1.20.1 protocol"));
 
     id.protocol_id
 }


### PR DESCRIPTION
## Summary
- correct packet lookup panic message to reference Minecraft protocol 1.20.1
- ensure no other hard-coded version references remain in derive macros crate

## Testing
- `cargo +nightly test -p ferrumc-macros`


------
https://chatgpt.com/codex/tasks/task_b_689331c8c69c8329b62ca73b26e494b3