### PR TITLE
chore: update block mapping comment for 1.20.1

### DIFF
--- a/src/lib/world/src/chunk_format.rs
+++ b/src/lib/world/src/chunk_format.rs
@@ -14,9 +14,9 @@ use vanilla_chunk_format::BlockData;
 // #[cfg(test)]
 // const BLOCKSFILE: &[u8] = &[0];
 
-// If this file doesn't exist, you'll have to create it yourself. Download the 1.21.1 server from the
-// minecraft launcher, extract the blocks data (info here https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Data_Generators#Blocks_report)
-// , put the blocks.json file in the .etc folder, and run the blocks_parser.py script in the scripts
+// If this file doesn't exist, you'll have to create it yourself. Download the 1.20.1 server JAR from the
+// Minecraft launcher, extract the blocks data (info here https://minecraft.wiki/w/Minecraft_Wiki:Projects/wiki.vg_merge/Data_Generators#Blocks_report),
+// put the blocks.json file in the .etc folder, and run the block_parser.py script in the scripts
 // folder. This will generate the blockmappings.json file that is compressed with bzip2 and included
 // in the binary.
 // #[cfg(not(test))]


### PR DESCRIPTION
## Summary
- clarify block mapping instructions to download the 1.20.1 server JAR and run the `block_parser.py` script

## Testing
- `cargo +nightly test -p ferrumc-world`
- `java -DbundlerMainClass=net.minecraft.data.Main -jar server-1.20.1.jar --reports`
- `python scripts/block_parser.py`


------
https://chatgpt.com/codex/tasks/task_b_6893384e461483299854f8d79b311564