### PR TITLE
docs: update version references to 1.20.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## 📖 About
 
-FerrumC is a **1.21.5** Minecraft server implementation written from the ground up in Rust. Leveraging the power of the
+FerrumC is a **1.20.1** Minecraft server implementation written from the ground up in Rust. Leveraging the power of the
 Rust programming language, it is completely multithreaded and offers high performance as well as amazing memory
 efficiency!
 
@@ -74,7 +74,7 @@ our [Discord server](https://discord.gg/qT5J8EMjwk) for help or to discuss the p
       <img src="https://github.com/ferrumc-rs/ferrumc/blob/master/assets/README/chunk_importing.gif?raw=true" alt="Configuration">
     </li>
     <li>
-      <h4>🌐 Compatible with vanilla Minecraft clients (Version 1.21.5)</h4>
+      <h4>🌐 Compatible with vanilla Minecraft clients (Version 1.20.1)</h4>
     </li>
     <li>
       <h4>📦 Fully multithreaded; Utilizes all available CPU cores, instead of a single "main" thread</h4>

--- a/src/lib/net/src/packets/incoming/handshake.rs
+++ b/src/lib/net/src/packets/incoming/handshake.rs
@@ -27,13 +27,12 @@ mod tests {
             next_state: VarInt,
         }
         let mut data = Cursor::new(vec![
-            255, 5, 9, 108, 111, 99, 97, 108, 104, 111, 115, 116, 99, 221, 1,
+            251, 5, 9, 108, 111, 99, 97, 108, 104, 111, 115, 116, 99, 221, 1,
         ]);
 
         let handshake = Handshake::decode(&mut data, &NetDecodeOpts::None).unwrap();
-        // Although the 1.21.5 protocol version is 770, we don't need to actually account for that here,
-        // so using the 767 version is fine for testing purposes.
-        assert_eq!(handshake.protocol_version, VarInt::new(767));
+        // The 1.20.1 protocol version is 763; this test uses that value.
+        assert_eq!(handshake.protocol_version, VarInt::new(763));
         assert_eq!(handshake.server_address, "localhost".to_string());
         assert_eq!(handshake.server_port, 25565);
         assert_eq!(handshake.next_state, VarInt::new(1));


### PR DESCRIPTION
## Summary
- update docs to reference Minecraft 1.20.1
- align handshake test with 1.20.1 protocol version

## Testing
- `cargo +nightly test` *(fails: src/lib/utils/src/lib.rs - root (line 16))*
- `cargo +nightly test --lib --bins`


------
https://chatgpt.com/codex/tasks/task_b_68933c3ee4b08329985d6d88e3c0b7d5