### PR TITLE
Update protocol and registry data for 1.20.1

### DIFF
--- a/assets/data/packets.json
+++ b/assets/data/packets.json
@@ -1,133 +1,54 @@
 {
   "configuration": {
-    "clientbound": {
-      "minecraft:cookie_request": {
-        "protocol_id": 0
-      },
-      "minecraft:custom_payload": {
-        "protocol_id": 1
-      },
-      "minecraft:custom_report_details": {
-        "protocol_id": 15
-      },
-      "minecraft:disconnect": {
-        "protocol_id": 2
-      },
-      "minecraft:finish_configuration": {
-        "protocol_id": 3
-      },
-      "minecraft:keep_alive": {
-        "protocol_id": 4
-      },
-      "minecraft:ping": {
-        "protocol_id": 5
-      },
-      "minecraft:registry_data": {
-        "protocol_id": 7
-      },
-      "minecraft:reset_chat": {
-        "protocol_id": 6
-      },
-      "minecraft:resource_pack_pop": {
-        "protocol_id": 8
-      },
-      "minecraft:resource_pack_push": {
-        "protocol_id": 9
-      },
-      "minecraft:select_known_packs": {
-        "protocol_id": 14
-      },
-      "minecraft:server_links": {
-        "protocol_id": 16
-      },
-      "minecraft:store_cookie": {
-        "protocol_id": 10
-      },
-      "minecraft:transfer": {
-        "protocol_id": 11
-      },
-      "minecraft:update_enabled_features": {
-        "protocol_id": 12
-      },
-      "minecraft:update_tags": {
-        "protocol_id": 13
-      }
-    },
-    "serverbound": {
-      "minecraft:client_information": {
-        "protocol_id": 0
-      },
-      "minecraft:cookie_response": {
-        "protocol_id": 1
-      },
-      "minecraft:custom_payload": {
-        "protocol_id": 2
-      },
-      "minecraft:finish_configuration": {
-        "protocol_id": 3
-      },
-      "minecraft:keep_alive": {
-        "protocol_id": 4
-      },
-      "minecraft:pong": {
-        "protocol_id": 5
-      },
-      "minecraft:resource_pack": {
-        "protocol_id": 6
-      },
-      "minecraft:select_known_packs": {
-        "protocol_id": 7
-      }
-    }
+    "clientbound": {},
+    "serverbound": {}
   },
   "handshake": {
+    "clientbound": {},
     "serverbound": {
       "minecraft:intention": {
         "protocol_id": 0
+      },
+      "minecraft:legacy_server_list_ping": {
+        "protocol_id": 254
       }
     }
   },
   "login": {
     "clientbound": {
-      "minecraft:cookie_request": {
-        "protocol_id": 5
-      },
-      "minecraft:custom_query": {
-        "protocol_id": 4
+      "minecraft:login_disconnect": {
+        "protocol_id": 0
       },
       "minecraft:hello": {
         "protocol_id": 1
       },
+      "minecraft:login_finished": {
+        "protocol_id": 2
+      },
       "minecraft:login_compression": {
         "protocol_id": 3
       },
-      "minecraft:login_disconnect": {
-        "protocol_id": 0
-      },
-      "minecraft:login_finished": {
-        "protocol_id": 2
+      "minecraft:custom_query": {
+        "protocol_id": 4
       }
     },
     "serverbound": {
-      "minecraft:cookie_response": {
-        "protocol_id": 4
-      },
-      "minecraft:custom_query_answer": {
-        "protocol_id": 2
-      },
       "minecraft:hello": {
         "protocol_id": 0
       },
       "minecraft:key": {
         "protocol_id": 1
       },
-      "minecraft:login_acknowledged": {
-        "protocol_id": 3
+      "minecraft:custom_query_answer": {
+        "protocol_id": 2
       }
     }
   },
   "play": {
     "clientbound": {
+      "minecraft:bundle_delimiter": {
+        "protocol_id": 0
+      },
       "minecraft:add_entity": {
         "protocol_id": 1
       },
@@ -154,9 +75,6 @@
       },
       "minecraft:boss_event": {
         "protocol_id": 9
-      },
-      "minecraft:bundle_delimiter": {
-        "protocol_id": 0
       },
       "minecraft:change_difficulty": {
         "protocol_id": 10
@@ -202,9 +120,6 @@
       },
       "minecraft:custom_payload": {
         "protocol_id": 24
-      },
-      "minecraft:custom_report_details": {
-        "protocol_id": 129
       },
       "minecraft:damage_event": {
         "protocol_id": 25
@@ -275,11 +190,11 @@
       "minecraft:move_entity_pos_rot": {
         "protocol_id": 47
       },
-      "minecraft:move_entity_rot": {
-        "protocol_id": 49
-      },
       "minecraft:move_minecart_along_track": {
         "protocol_id": 48
+      },
+      "minecraft:move_entity_rot": {
+        "protocol_id": 49
       },
       "minecraft:move_vehicle": {
         "protocol_id": 50
@@ -295,6 +210,9 @@
       },
       "minecraft:ping": {
         "protocol_id": 54
+      },
+      "minecraft:pong_response": {
+        "protocol_id": 55
       },
       "minecraft:place_ghost_recipe": {
         "protocol_id": 56
@@ -328,12 +246,6 @@
       },
       "minecraft:player_rotation": {
         "protocol_id": 66
-      },
-      "minecraft:pong_response": {
-        "protocol_id": 55
-      },
-      "minecraft:projectile_power": {
-        "protocol_id": 128
       },
       "minecraft:recipe_book_add": {
         "protocol_id": 67
@@ -373,9 +285,6 @@
       },
       "minecraft:server_data": {
         "protocol_id": 79
-      },
-      "minecraft:server_links": {
-        "protocol_id": 130
       },
       "minecraft:set_action_bar_text": {
         "protocol_id": 80
@@ -464,62 +373,11 @@
       "minecraft:set_titles_animation": {
         "protocol_id": 108
       },
-      "minecraft:sound": {
-        "protocol_id": 110
-      },
       "minecraft:sound_entity": {
         "protocol_id": 109
       },
-      "minecraft:start_configuration": {
-        "protocol_id": 111
-      },
-      "minecraft:stop_sound": {
-        "protocol_id": 112
-      },
-      "minecraft:store_cookie": {
-        "protocol_id": 113
-      },
-      "minecraft:system_chat": {
-        "protocol_id": 114
-      },
-      "minecraft:tab_list": {
-        "protocol_id": 115
-      },
-      "minecraft:tag_query": {
-        "protocol_id": 116
-      },
-      "minecraft:take_item_entity": {
-        "protocol_id": 117
-      },
-      "minecraft:teleport_entity": {
-        "protocol_id": 118
-      },
-      "minecraft:test_instance_block_status": {
-        "protocol_id": 119
-      },
-      "minecraft:ticking_state": {
-        "protocol_id": 120
-      },
-      "minecraft:ticking_step": {
-        "protocol_id": 121
-      },
-      "minecraft:transfer": {
-        "protocol_id": 122
-      },
-      "minecraft:update_advancements": {
-        "protocol_id": 123
-      },
-      "minecraft:update_attributes": {
-        "protocol_id": 124
-      },
-      "minecraft:update_mob_effect": {
-        "protocol_id": 125
-      },
-      "minecraft:update_recipes": {
-        "protocol_id": 126
-      },
-      "minecraft:update_tags": {
-        "protocol_id": 127
+      "minecraft:sound": {
+        "protocol_id": 110
       }
     },
     "serverbound": {
@@ -535,9 +393,6 @@
       "minecraft:change_difficulty": {
         "protocol_id": 3
       },
-      "minecraft:chat": {
-        "protocol_id": 7
-      },
       "minecraft:chat_ack": {
         "protocol_id": 4
       },
@@ -546,6 +401,9 @@
       },
       "minecraft:chat_command_signed": {
         "protocol_id": 6
+      },
+      "minecraft:chat": {
+        "protocol_id": 7
       },
       "minecraft:chat_session_update": {
         "protocol_id": 8
@@ -556,11 +414,11 @@
       "minecraft:client_command": {
         "protocol_id": 10
       },
-      "minecraft:client_information": {
-        "protocol_id": 12
-      },
       "minecraft:client_tick_end": {
         "protocol_id": 11
+      },
+      "minecraft:client_information": {
+        "protocol_id": 12
       },
       "minecraft:command_suggestion": {
         "protocol_id": 13
@@ -675,63 +533,24 @@
       },
       "minecraft:set_beacon": {
         "protocol_id": 50
-      },
-      "minecraft:set_carried_item": {
-        "protocol_id": 51
-      },
-      "minecraft:set_command_block": {
-        "protocol_id": 52
-      },
-      "minecraft:set_command_minecart": {
-        "protocol_id": 53
-      },
-      "minecraft:set_creative_mode_slot": {
-        "protocol_id": 54
-      },
-      "minecraft:set_jigsaw_block": {
-        "protocol_id": 55
-      },
-      "minecraft:set_structure_block": {
-        "protocol_id": 56
-      },
-      "minecraft:set_test_block": {
-        "protocol_id": 57
-      },
-      "minecraft:sign_update": {
-        "protocol_id": 58
-      },
-      "minecraft:swing": {
-        "protocol_id": 59
-      },
-      "minecraft:teleport_to_entity": {
-        "protocol_id": 60
-      },
-      "minecraft:test_instance_block_action": {
-        "protocol_id": 61
-      },
-      "minecraft:use_item": {
-        "protocol_id": 63
-      },
-      "minecraft:use_item_on": {
-        "protocol_id": 62
       }
     }
   },
   "status": {
     "clientbound": {
-      "minecraft:pong_response": {
-        "protocol_id": 1
-      },
       "minecraft:status_response": {
         "protocol_id": 0
+      },
+      "minecraft:pong_response": {
+        "protocol_id": 1
       }
     },
     "serverbound": {
-      "minecraft:ping_request": {
-        "protocol_id": 1
-      },
       "minecraft:status_request": {
         "protocol_id": 0
+      },
+      "minecraft:ping_request": {
+        "protocol_id": 1
       }
     }
   }

--- a/assets/data/registries.json
+++ b/assets/data/registries.json
@@ -80,3423 +80,3191 @@
         "protocol_id": 2
       }
     },
-    "protocol_id": 28
+    "protocol_id": 30
   },
   "minecraft:attribute": {
     "entries": {
-      "minecraft:armor": {
-        "protocol_id": 0
-      },
-      "minecraft:armor_toughness": {
-        "protocol_id": 1
-      },
-      "minecraft:attack_damage": {
-        "protocol_id": 2
-      },
-      "minecraft:attack_knockback": {
-        "protocol_id": 3
-      },
-      "minecraft:attack_speed": {
-        "protocol_id": 4
-      },
-      "minecraft:block_break_speed": {
-        "protocol_id": 5
-      },
-      "minecraft:block_interaction_range": {
-        "protocol_id": 6
-      },
-      "minecraft:burning_time": {
-        "protocol_id": 7
-      },
-      "minecraft:entity_interaction_range": {
-        "protocol_id": 9
-      },
-      "minecraft:explosion_knockback_resistance": {
+      "minecraft:generic.armor": {
         "protocol_id": 8
       },
-      "minecraft:fall_damage_multiplier": {
+      "minecraft:generic.armor_toughness": {
+        "protocol_id": 9
+      },
+      "minecraft:generic.attack_damage": {
+        "protocol_id": 5
+      },
+      "minecraft:generic.attack_knockback": {
+        "protocol_id": 6
+      },
+      "minecraft:generic.attack_speed": {
+        "protocol_id": 7
+      },
+      "minecraft:generic.flying_speed": {
+        "protocol_id": 4
+      },
+      "minecraft:generic.follow_range": {
+        "protocol_id": 1
+      },
+      "minecraft:generic.knockback_resistance": {
+        "protocol_id": 2
+      },
+      "minecraft:generic.luck": {
         "protocol_id": 10
       },
-      "minecraft:flying_speed": {
-        "protocol_id": 11
+      "minecraft:generic.max_health": {
+        "protocol_id": 0
       },
-      "minecraft:follow_range": {
+      "minecraft:generic.movement_speed": {
+        "protocol_id": 3
+      },
+      "minecraft:horse.jump_strength": {
         "protocol_id": 12
       },
-      "minecraft:gravity": {
-        "protocol_id": 13
-      },
-      "minecraft:jump_strength": {
-        "protocol_id": 14
-      },
-      "minecraft:knockback_resistance": {
-        "protocol_id": 15
-      },
-      "minecraft:luck": {
-        "protocol_id": 16
-      },
-      "minecraft:max_absorption": {
-        "protocol_id": 17
-      },
-      "minecraft:max_health": {
-        "protocol_id": 18
-      },
-      "minecraft:mining_efficiency": {
-        "protocol_id": 19
-      },
-      "minecraft:movement_efficiency": {
-        "protocol_id": 20
-      },
-      "minecraft:movement_speed": {
-        "protocol_id": 21
-      },
-      "minecraft:oxygen_bonus": {
-        "protocol_id": 22
-      },
-      "minecraft:safe_fall_distance": {
-        "protocol_id": 23
-      },
-      "minecraft:scale": {
-        "protocol_id": 24
-      },
-      "minecraft:sneaking_speed": {
-        "protocol_id": 25
-      },
-      "minecraft:spawn_reinforcements": {
-        "protocol_id": 26
-      },
-      "minecraft:step_height": {
-        "protocol_id": 27
-      },
-      "minecraft:submerged_mining_speed": {
-        "protocol_id": 28
-      },
-      "minecraft:sweeping_damage_ratio": {
-        "protocol_id": 29
-      },
-      "minecraft:tempt_range": {
-        "protocol_id": 30
-      },
-      "minecraft:water_movement_efficiency": {
-        "protocol_id": 31
+      "minecraft:zombie.spawn_reinforcements": {
+        "protocol_id": 11
       }
     },
-    "protocol_id": 18
+    "protocol_id": 20
+  },
+  "minecraft:banner_pattern": {
+    "entries": {
+      "minecraft:base": {
+        "protocol_id": 0
+      },
+      "minecraft:border": {
+        "protocol_id": 30
+      },
+      "minecraft:bricks": {
+        "protocol_id": 34
+      },
+      "minecraft:circle": {
+        "protocol_id": 24
+      },
+      "minecraft:creeper": {
+        "protocol_id": 36
+      },
+      "minecraft:cross": {
+        "protocol_id": 14
+      },
+      "minecraft:curly_border": {
+        "protocol_id": 31
+      },
+      "minecraft:diagonal_left": {
+        "protocol_id": 20
+      },
+      "minecraft:diagonal_right": {
+        "protocol_id": 23
+      },
+      "minecraft:diagonal_up_left": {
+        "protocol_id": 22
+      },
+      "minecraft:diagonal_up_right": {
+        "protocol_id": 21
+      },
+      "minecraft:flower": {
+        "protocol_id": 38
+      },
+      "minecraft:globe": {
+        "protocol_id": 35
+      },
+      "minecraft:gradient": {
+        "protocol_id": 32
+      },
+      "minecraft:gradient_up": {
+        "protocol_id": 33
+      },
+      "minecraft:half_horizontal": {
+        "protocol_id": 27
+      },
+      "minecraft:half_horizontal_bottom": {
+        "protocol_id": 29
+      },
+      "minecraft:half_vertical": {
+        "protocol_id": 26
+      },
+      "minecraft:half_vertical_right": {
+        "protocol_id": 28
+      },
+      "minecraft:mojang": {
+        "protocol_id": 39
+      },
+      "minecraft:piglin": {
+        "protocol_id": 40
+      },
+      "minecraft:rhombus": {
+        "protocol_id": 25
+      },
+      "minecraft:skull": {
+        "protocol_id": 37
+      },
+      "minecraft:small_stripes": {
+        "protocol_id": 13
+      },
+      "minecraft:square_bottom_left": {
+        "protocol_id": 1
+      },
+      "minecraft:square_bottom_right": {
+        "protocol_id": 2
+      },
+      "minecraft:square_top_left": {
+        "protocol_id": 3
+      },
+      "minecraft:square_top_right": {
+        "protocol_id": 4
+      },
+      "minecraft:straight_cross": {
+        "protocol_id": 15
+      },
+      "minecraft:stripe_bottom": {
+        "protocol_id": 5
+      },
+      "minecraft:stripe_center": {
+        "protocol_id": 9
+      },
+      "minecraft:stripe_downleft": {
+        "protocol_id": 12
+      },
+      "minecraft:stripe_downright": {
+        "protocol_id": 11
+      },
+      "minecraft:stripe_left": {
+        "protocol_id": 7
+      },
+      "minecraft:stripe_middle": {
+        "protocol_id": 10
+      },
+      "minecraft:stripe_right": {
+        "protocol_id": 8
+      },
+      "minecraft:stripe_top": {
+        "protocol_id": 6
+      },
+      "minecraft:triangle_bottom": {
+        "protocol_id": 16
+      },
+      "minecraft:triangle_top": {
+        "protocol_id": 17
+      },
+      "minecraft:triangles_bottom": {
+        "protocol_id": 18
+      },
+      "minecraft:triangles_top": {
+        "protocol_id": 19
+      }
+    },
+    "protocol_id": 62
   },
   "minecraft:block": {
     "default": "minecraft:air",
     "entries": {
       "minecraft:acacia_button": {
-        "protocol_id": 415
+        "protocol_id": 389
       },
       "minecraft:acacia_door": {
-        "protocol_id": 617
+        "protocol_id": 586
       },
       "minecraft:acacia_fence": {
-        "protocol_id": 608
+        "protocol_id": 578
       },
       "minecraft:acacia_fence_gate": {
-        "protocol_id": 599
+        "protocol_id": 570
       },
       "minecraft:acacia_hanging_sign": {
-        "protocol_id": 224
+        "protocol_id": 211
       },
       "minecraft:acacia_leaves": {
-        "protocol_id": 92
+        "protocol_id": 86
       },
       "minecraft:acacia_log": {
-        "protocol_id": 53
+        "protocol_id": 50
       },
       "minecraft:acacia_planks": {
         "protocol_id": 17
       },
       "minecraft:acacia_pressure_plate": {
-        "protocol_id": 252
+        "protocol_id": 237
       },
       "minecraft:acacia_sapling": {
-        "protocol_id": 29
+        "protocol_id": 27
       },
       "minecraft:acacia_sign": {
-        "protocol_id": 200
+        "protocol_id": 189
       },
       "minecraft:acacia_slab": {
-        "protocol_id": 571
+        "protocol_id": 543
       },
       "minecraft:acacia_stairs": {
-        "protocol_id": 484
+        "protocol_id": 457
       },
       "minecraft:acacia_trapdoor": {
-        "protocol_id": 305
+        "protocol_id": 289
       },
       "minecraft:acacia_wall_hanging_sign": {
-        "protocol_id": 236
+        "protocol_id": 222
       },
       "minecraft:acacia_wall_sign": {
-        "protocol_id": 214
+        "protocol_id": 202
       },
       "minecraft:acacia_wood": {
-        "protocol_id": 75
+        "protocol_id": 70
       },
       "minecraft:activator_rail": {
-        "protocol_id": 450
+        "protocol_id": 423
       },
       "minecraft:air": {
         "protocol_id": 0
       },
       "minecraft:allium": {
-        "protocol_id": 161
+        "protocol_id": 151
       },
       "minecraft:amethyst_block": {
-        "protocol_id": 937
+        "protocol_id": 903
       },
       "minecraft:amethyst_cluster": {
-        "protocol_id": 939
+        "protocol_id": 905
       },
       "minecraft:ancient_debris": {
-        "protocol_id": 875
+        "protocol_id": 841
       },
       "minecraft:andesite": {
         "protocol_id": 6
       },
       "minecraft:andesite_slab": {
-        "protocol_id": 787
+        "protocol_id": 755
       },
       "minecraft:andesite_stairs": {
-        "protocol_id": 774
+        "protocol_id": 742
       },
       "minecraft:andesite_wall": {
-        "protocol_id": 799
+        "protocol_id": 767
       },
       "minecraft:anvil": {
-        "protocol_id": 435
+        "protocol_id": 408
       },
       "minecraft:attached_melon_stem": {
-        "protocol_id": 332
+        "protocol_id": 314
       },
       "minecraft:attached_pumpkin_stem": {
-        "protocol_id": 331
+        "protocol_id": 313
       },
       "minecraft:azalea": {
-        "protocol_id": 1046
+        "protocol_id": 959
       },
       "minecraft:azalea_leaves": {
-        "protocol_id": 97
-      },
-      "minecraft:azure_bluet": {
-        "protocol_id": 162
-      },
-      "minecraft:bamboo": {
-        "protocol_id": 759
-      },
-      "minecraft:bamboo_block": {
-        "protocol_id": 60
-      },
-      "minecraft:bamboo_button": {
-        "protocol_id": 420
-      },
-      "minecraft:bamboo_door": {
-        "protocol_id": 622
-      },
-      "minecraft:bamboo_fence": {
-        "protocol_id": 613
-      },
-      "minecraft:bamboo_fence_gate": {
-        "protocol_id": 604
-      },
-      "minecraft:bamboo_hanging_sign": {
-        "protocol_id": 232
-      },
-      "minecraft:bamboo_mosaic": {
-        "protocol_id": 24
-      },
-      "minecraft:bamboo_mosaic_slab": {
-        "protocol_id": 577
-      },
-      "minecraft:bamboo_mosaic_stairs": {
-        "protocol_id": 490
-      },
-      "minecraft:bamboo_planks": {
-        "protocol_id": 23
-      },
-      "minecraft:bamboo_pressure_plate": {
-        "protocol_id": 257
-      },
-      "minecraft:bamboo_sapling": {
-        "protocol_id": 758
-      },
-      "minecraft:bamboo_sign": {
-        "protocol_id": 206
-      },
-      "minecraft:bamboo_slab": {
-        "protocol_id": 576
-      },
-      "minecraft:bamboo_stairs": {
-        "protocol_id": 489
-      },
-      "minecraft:bamboo_trapdoor": {
-        "protocol_id": 310
-      },
-      "minecraft:bamboo_wall_hanging_sign": {
-        "protocol_id": 244
-      },
-      "minecraft:bamboo_wall_sign": {
-        "protocol_id": 220
-      },
-      "minecraft:barrel": {
-        "protocol_id": 806
-      },
-      "minecraft:barrier": {
-        "protocol_id": 492
-      },
-      "minecraft:basalt": {
-        "protocol_id": 275
-      },
-      "minecraft:beacon": {
-        "protocol_id": 377
-      },
-      "minecraft:bedrock": {
-        "protocol_id": 34
-      },
-      "minecraft:bee_nest": {
-        "protocol_id": 870
-      },
-      "minecraft:beehive": {
-        "protocol_id": 871
-      },
-      "minecraft:beetroots": {
-        "protocol_id": 633
-      },
-      "minecraft:bell": {
-        "protocol_id": 815
-      },
-      "minecraft:big_dripleaf": {
-        "protocol_id": 1053
-      },
-      "minecraft:big_dripleaf_stem": {
-        "protocol_id": 1054
-      },
-      "minecraft:birch_button": {
-        "protocol_id": 413
-      },
-      "minecraft:birch_door": {
-        "protocol_id": 615
-      },
-      "minecraft:birch_fence": {
-        "protocol_id": 606
-      },
-      "minecraft:birch_fence_gate": {
-        "protocol_id": 597
-      },
-      "minecraft:birch_hanging_sign": {
-        "protocol_id": 223
-      },
-      "minecraft:birch_leaves": {
         "protocol_id": 90
       },
+      "minecraft:azure_bluet": {
+        "protocol_id": 152
+      },
+      "minecraft:bamboo": {
+        "protocol_id": 727
+      },
+      "minecraft:bamboo_block": {
+        "protocol_id": 56
+      },
+      "minecraft:bamboo_button": {
+        "protocol_id": 393
+      },
+      "minecraft:bamboo_door": {
+        "protocol_id": 590
+      },
+      "minecraft:bamboo_fence": {
+        "protocol_id": 582
+      },
+      "minecraft:bamboo_fence_gate": {
+        "protocol_id": 574
+      },
+      "minecraft:bamboo_hanging_sign": {
+        "protocol_id": 218
+      },
+      "minecraft:bamboo_mosaic": {
+        "protocol_id": 22
+      },
+      "minecraft:bamboo_mosaic_slab": {
+        "protocol_id": 548
+      },
+      "minecraft:bamboo_mosaic_stairs": {
+        "protocol_id": 462
+      },
+      "minecraft:bamboo_planks": {
+        "protocol_id": 21
+      },
+      "minecraft:bamboo_pressure_plate": {
+        "protocol_id": 241
+      },
+      "minecraft:bamboo_sapling": {
+        "protocol_id": 726
+      },
+      "minecraft:bamboo_sign": {
+        "protocol_id": 194
+      },
+      "minecraft:bamboo_slab": {
+        "protocol_id": 547
+      },
+      "minecraft:bamboo_stairs": {
+        "protocol_id": 461
+      },
+      "minecraft:bamboo_trapdoor": {
+        "protocol_id": 293
+      },
+      "minecraft:bamboo_wall_hanging_sign": {
+        "protocol_id": 229
+      },
+      "minecraft:bamboo_wall_sign": {
+        "protocol_id": 207
+      },
+      "minecraft:barrel": {
+        "protocol_id": 774
+      },
+      "minecraft:barrier": {
+        "protocol_id": 464
+      },
+      "minecraft:basalt": {
+        "protocol_id": 259
+      },
+      "minecraft:beacon": {
+        "protocol_id": 352
+      },
+      "minecraft:bedrock": {
+        "protocol_id": 31
+      },
+      "minecraft:bee_nest": {
+        "protocol_id": 836
+      },
+      "minecraft:beehive": {
+        "protocol_id": 837
+      },
+      "minecraft:beetroots": {
+        "protocol_id": 601
+      },
+      "minecraft:bell": {
+        "protocol_id": 783
+      },
+      "minecraft:big_dripleaf": {
+        "protocol_id": 964
+      },
+      "minecraft:big_dripleaf_stem": {
+        "protocol_id": 965
+      },
+      "minecraft:birch_button": {
+        "protocol_id": 387
+      },
+      "minecraft:birch_door": {
+        "protocol_id": 584
+      },
+      "minecraft:birch_fence": {
+        "protocol_id": 576
+      },
+      "minecraft:birch_fence_gate": {
+        "protocol_id": 568
+      },
+      "minecraft:birch_hanging_sign": {
+        "protocol_id": 210
+      },
+      "minecraft:birch_leaves": {
+        "protocol_id": 84
+      },
       "minecraft:birch_log": {
-        "protocol_id": 51
+        "protocol_id": 48
       },
       "minecraft:birch_planks": {
         "protocol_id": 15
       },
       "minecraft:birch_pressure_plate": {
-        "protocol_id": 250
-      },
-      "minecraft:birch_sapling": {
-        "protocol_id": 27
-      },
-      "minecraft:birch_sign": {
-        "protocol_id": 199
-      },
-      "minecraft:birch_slab": {
-        "protocol_id": 569
-      },
-      "minecraft:birch_stairs": {
-        "protocol_id": 374
-      },
-      "minecraft:birch_trapdoor": {
-        "protocol_id": 303
-      },
-      "minecraft:birch_wall_hanging_sign": {
         "protocol_id": 235
       },
+      "minecraft:birch_sapling": {
+        "protocol_id": 25
+      },
+      "minecraft:birch_sign": {
+        "protocol_id": 188
+      },
+      "minecraft:birch_slab": {
+        "protocol_id": 541
+      },
+      "minecraft:birch_stairs": {
+        "protocol_id": 349
+      },
+      "minecraft:birch_trapdoor": {
+        "protocol_id": 287
+      },
+      "minecraft:birch_wall_hanging_sign": {
+        "protocol_id": 221
+      },
       "minecraft:birch_wall_sign": {
-        "protocol_id": 213
+        "protocol_id": 201
       },
       "minecraft:birch_wood": {
-        "protocol_id": 73
+        "protocol_id": 68
       },
       "minecraft:black_banner": {
-        "protocol_id": 546
-      },
-      "minecraft:black_bed": {
-        "protocol_id": 125
-      },
-      "minecraft:black_candle": {
-        "protocol_id": 919
-      },
-      "minecraft:black_candle_cake": {
-        "protocol_id": 936
-      },
-      "minecraft:black_carpet": {
-        "protocol_id": 521
-      },
-      "minecraft:black_concrete": {
-        "protocol_id": 693
-      },
-      "minecraft:black_concrete_powder": {
-        "protocol_id": 709
-      },
-      "minecraft:black_glazed_terracotta": {
-        "protocol_id": 677
-      },
-      "minecraft:black_shulker_box": {
-        "protocol_id": 661
-      },
-      "minecraft:black_stained_glass": {
-        "protocol_id": 300
-      },
-      "minecraft:black_stained_glass_pane": {
-        "protocol_id": 483
-      },
-      "minecraft:black_terracotta": {
-        "protocol_id": 467
-      },
-      "minecraft:black_wall_banner": {
-        "protocol_id": 562
-      },
-      "minecraft:black_wool": {
-        "protocol_id": 155
-      },
-      "minecraft:blackstone": {
-        "protocol_id": 883
-      },
-      "minecraft:blackstone_slab": {
-        "protocol_id": 886
-      },
-      "minecraft:blackstone_stairs": {
-        "protocol_id": 884
-      },
-      "minecraft:blackstone_wall": {
-        "protocol_id": 885
-      },
-      "minecraft:blast_furnace": {
-        "protocol_id": 808
-      },
-      "minecraft:blue_banner": {
-        "protocol_id": 542
-      },
-      "minecraft:blue_bed": {
-        "protocol_id": 121
-      },
-      "minecraft:blue_candle": {
-        "protocol_id": 915
-      },
-      "minecraft:blue_candle_cake": {
-        "protocol_id": 932
-      },
-      "minecraft:blue_carpet": {
-        "protocol_id": 517
-      },
-      "minecraft:blue_concrete": {
-        "protocol_id": 689
-      },
-      "minecraft:blue_concrete_powder": {
-        "protocol_id": 705
-      },
-      "minecraft:blue_glazed_terracotta": {
-        "protocol_id": 673
-      },
-      "minecraft:blue_ice": {
-        "protocol_id": 756
-      },
-      "minecraft:blue_orchid": {
-        "protocol_id": 160
-      },
-      "minecraft:blue_shulker_box": {
-        "protocol_id": 657
-      },
-      "minecraft:blue_stained_glass": {
-        "protocol_id": 296
-      },
-      "minecraft:blue_stained_glass_pane": {
-        "protocol_id": 479
-      },
-      "minecraft:blue_terracotta": {
-        "protocol_id": 463
-      },
-      "minecraft:blue_wall_banner": {
-        "protocol_id": 558
-      },
-      "minecraft:blue_wool": {
-        "protocol_id": 151
-      },
-      "minecraft:bone_block": {
-        "protocol_id": 642
-      },
-      "minecraft:bookshelf": {
-        "protocol_id": 177
-      },
-      "minecraft:brain_coral": {
-        "protocol_id": 731
-      },
-      "minecraft:brain_coral_block": {
-        "protocol_id": 721
-      },
-      "minecraft:brain_coral_fan": {
-        "protocol_id": 741
-      },
-      "minecraft:brain_coral_wall_fan": {
-        "protocol_id": 751
-      },
-      "minecraft:brewing_stand": {
-        "protocol_id": 355
-      },
-      "minecraft:brick_slab": {
-        "protocol_id": 584
-      },
-      "minecraft:brick_stairs": {
-        "protocol_id": 339
-      },
-      "minecraft:brick_wall": {
-        "protocol_id": 791
-      },
-      "minecraft:bricks": {
-        "protocol_id": 175
-      },
-      "minecraft:brown_banner": {
-        "protocol_id": 543
-      },
-      "minecraft:brown_bed": {
-        "protocol_id": 122
-      },
-      "minecraft:brown_candle": {
-        "protocol_id": 916
-      },
-      "minecraft:brown_candle_cake": {
-        "protocol_id": 933
-      },
-      "minecraft:brown_carpet": {
         "protocol_id": 518
       },
+      "minecraft:black_bed": {
+        "protocol_id": 118
+      },
+      "minecraft:black_candle": {
+        "protocol_id": 885
+      },
+      "minecraft:black_candle_cake": {
+        "protocol_id": 902
+      },
+      "minecraft:black_carpet": {
+        "protocol_id": 493
+      },
+      "minecraft:black_concrete": {
+        "protocol_id": 661
+      },
+      "minecraft:black_concrete_powder": {
+        "protocol_id": 677
+      },
+      "minecraft:black_glazed_terracotta": {
+        "protocol_id": 645
+      },
+      "minecraft:black_shulker_box": {
+        "protocol_id": 629
+      },
+      "minecraft:black_stained_glass": {
+        "protocol_id": 284
+      },
+      "minecraft:black_stained_glass_pane": {
+        "protocol_id": 456
+      },
+      "minecraft:black_terracotta": {
+        "protocol_id": 440
+      },
+      "minecraft:black_wall_banner": {
+        "protocol_id": 534
+      },
+      "minecraft:black_wool": {
+        "protocol_id": 145
+      },
+      "minecraft:blackstone": {
+        "protocol_id": 849
+      },
+      "minecraft:blackstone_slab": {
+        "protocol_id": 852
+      },
+      "minecraft:blackstone_stairs": {
+        "protocol_id": 850
+      },
+      "minecraft:blackstone_wall": {
+        "protocol_id": 851
+      },
+      "minecraft:blast_furnace": {
+        "protocol_id": 776
+      },
+      "minecraft:blue_banner": {
+        "protocol_id": 514
+      },
+      "minecraft:blue_bed": {
+        "protocol_id": 114
+      },
+      "minecraft:blue_candle": {
+        "protocol_id": 881
+      },
+      "minecraft:blue_candle_cake": {
+        "protocol_id": 898
+      },
+      "minecraft:blue_carpet": {
+        "protocol_id": 489
+      },
+      "minecraft:blue_concrete": {
+        "protocol_id": 657
+      },
+      "minecraft:blue_concrete_powder": {
+        "protocol_id": 673
+      },
+      "minecraft:blue_glazed_terracotta": {
+        "protocol_id": 641
+      },
+      "minecraft:blue_ice": {
+        "protocol_id": 724
+      },
+      "minecraft:blue_orchid": {
+        "protocol_id": 150
+      },
+      "minecraft:blue_shulker_box": {
+        "protocol_id": 625
+      },
+      "minecraft:blue_stained_glass": {
+        "protocol_id": 280
+      },
+      "minecraft:blue_stained_glass_pane": {
+        "protocol_id": 452
+      },
+      "minecraft:blue_terracotta": {
+        "protocol_id": 436
+      },
+      "minecraft:blue_wall_banner": {
+        "protocol_id": 530
+      },
+      "minecraft:blue_wool": {
+        "protocol_id": 141
+      },
+      "minecraft:bone_block": {
+        "protocol_id": 610
+      },
+      "minecraft:bookshelf": {
+        "protocol_id": 167
+      },
+      "minecraft:brain_coral": {
+        "protocol_id": 699
+      },
+      "minecraft:brain_coral_block": {
+        "protocol_id": 689
+      },
+      "minecraft:brain_coral_fan": {
+        "protocol_id": 709
+      },
+      "minecraft:brain_coral_wall_fan": {
+        "protocol_id": 719
+      },
+      "minecraft:brewing_stand": {
+        "protocol_id": 330
+      },
+      "minecraft:brick_slab": {
+        "protocol_id": 555
+      },
+      "minecraft:brick_stairs": {
+        "protocol_id": 320
+      },
+      "minecraft:brick_wall": {
+        "protocol_id": 759
+      },
+      "minecraft:bricks": {
+        "protocol_id": 165
+      },
+      "minecraft:brown_banner": {
+        "protocol_id": 515
+      },
+      "minecraft:brown_bed": {
+        "protocol_id": 115
+      },
+      "minecraft:brown_candle": {
+        "protocol_id": 882
+      },
+      "minecraft:brown_candle_cake": {
+        "protocol_id": 899
+      },
+      "minecraft:brown_carpet": {
+        "protocol_id": 490
+      },
       "minecraft:brown_concrete": {
-        "protocol_id": 690
-      },
-      "minecraft:brown_concrete_powder": {
-        "protocol_id": 706
-      },
-      "minecraft:brown_glazed_terracotta": {
-        "protocol_id": 674
-      },
-      "minecraft:brown_mushroom": {
-        "protocol_id": 171
-      },
-      "minecraft:brown_mushroom_block": {
-        "protocol_id": 323
-      },
-      "minecraft:brown_shulker_box": {
         "protocol_id": 658
       },
+      "minecraft:brown_concrete_powder": {
+        "protocol_id": 674
+      },
+      "minecraft:brown_glazed_terracotta": {
+        "protocol_id": 642
+      },
+      "minecraft:brown_mushroom": {
+        "protocol_id": 161
+      },
+      "minecraft:brown_mushroom_block": {
+        "protocol_id": 306
+      },
+      "minecraft:brown_shulker_box": {
+        "protocol_id": 626
+      },
       "minecraft:brown_stained_glass": {
-        "protocol_id": 297
-      },
-      "minecraft:brown_stained_glass_pane": {
-        "protocol_id": 480
-      },
-      "minecraft:brown_terracotta": {
-        "protocol_id": 464
-      },
-      "minecraft:brown_wall_banner": {
-        "protocol_id": 559
-      },
-      "minecraft:brown_wool": {
-        "protocol_id": 152
-      },
-      "minecraft:bubble_column": {
-        "protocol_id": 763
-      },
-      "minecraft:bubble_coral": {
-        "protocol_id": 732
-      },
-      "minecraft:bubble_coral_block": {
-        "protocol_id": 722
-      },
-      "minecraft:bubble_coral_fan": {
-        "protocol_id": 742
-      },
-      "minecraft:bubble_coral_wall_fan": {
-        "protocol_id": 752
-      },
-      "minecraft:budding_amethyst": {
-        "protocol_id": 938
-      },
-      "minecraft:bush": {
-        "protocol_id": 133
-      },
-      "minecraft:cactus": {
-        "protocol_id": 266
-      },
-      "minecraft:cactus_flower": {
-        "protocol_id": 267
-      },
-      "minecraft:cake": {
-        "protocol_id": 283
-      },
-      "minecraft:calcite": {
-        "protocol_id": 957
-      },
-      "minecraft:calibrated_sculk_sensor": {
-        "protocol_id": 961
-      },
-      "minecraft:campfire": {
-        "protocol_id": 818
-      },
-      "minecraft:candle": {
-        "protocol_id": 903
-      },
-      "minecraft:candle_cake": {
-        "protocol_id": 920
-      },
-      "minecraft:carrots": {
-        "protocol_id": 409
-      },
-      "minecraft:cartography_table": {
-        "protocol_id": 809
-      },
-      "minecraft:carved_pumpkin": {
         "protocol_id": 281
       },
+      "minecraft:brown_stained_glass_pane": {
+        "protocol_id": 453
+      },
+      "minecraft:brown_terracotta": {
+        "protocol_id": 437
+      },
+      "minecraft:brown_wall_banner": {
+        "protocol_id": 531
+      },
+      "minecraft:brown_wool": {
+        "protocol_id": 142
+      },
+      "minecraft:bubble_column": {
+        "protocol_id": 731
+      },
+      "minecraft:bubble_coral": {
+        "protocol_id": 700
+      },
+      "minecraft:bubble_coral_block": {
+        "protocol_id": 690
+      },
+      "minecraft:bubble_coral_fan": {
+        "protocol_id": 710
+      },
+      "minecraft:bubble_coral_wall_fan": {
+        "protocol_id": 720
+      },
+      "minecraft:budding_amethyst": {
+        "protocol_id": 904
+      },
+      "minecraft:cactus": {
+        "protocol_id": 250
+      },
+      "minecraft:cake": {
+        "protocol_id": 267
+      },
+      "minecraft:calcite": {
+        "protocol_id": 910
+      },
+      "minecraft:calibrated_sculk_sensor": {
+        "protocol_id": 914
+      },
+      "minecraft:campfire": {
+        "protocol_id": 786
+      },
+      "minecraft:candle": {
+        "protocol_id": 869
+      },
+      "minecraft:candle_cake": {
+        "protocol_id": 886
+      },
+      "minecraft:carrots": {
+        "protocol_id": 383
+      },
+      "minecraft:cartography_table": {
+        "protocol_id": 777
+      },
+      "minecraft:carved_pumpkin": {
+        "protocol_id": 265
+      },
       "minecraft:cauldron": {
-        "protocol_id": 356
+        "protocol_id": 331
       },
       "minecraft:cave_air": {
-        "protocol_id": 762
+        "protocol_id": 730
       },
       "minecraft:cave_vines": {
-        "protocol_id": 1043
+        "protocol_id": 956
       },
       "minecraft:cave_vines_plant": {
-        "protocol_id": 1044
+        "protocol_id": 957
       },
       "minecraft:chain": {
-        "protocol_id": 327
+        "protocol_id": 310
       },
       "minecraft:chain_command_block": {
-        "protocol_id": 637
+        "protocol_id": 605
       },
       "minecraft:cherry_button": {
-        "protocol_id": 416
+        "protocol_id": 390
       },
       "minecraft:cherry_door": {
-        "protocol_id": 618
+        "protocol_id": 587
       },
       "minecraft:cherry_fence": {
-        "protocol_id": 609
+        "protocol_id": 579
       },
       "minecraft:cherry_fence_gate": {
-        "protocol_id": 600
+        "protocol_id": 571
       },
       "minecraft:cherry_hanging_sign": {
-        "protocol_id": 225
+        "protocol_id": 212
       },
       "minecraft:cherry_leaves": {
-        "protocol_id": 93
+        "protocol_id": 87
       },
       "minecraft:cherry_log": {
-        "protocol_id": 54
+        "protocol_id": 51
       },
       "minecraft:cherry_planks": {
         "protocol_id": 18
       },
       "minecraft:cherry_pressure_plate": {
-        "protocol_id": 253
+        "protocol_id": 238
       },
       "minecraft:cherry_sapling": {
-        "protocol_id": 30
+        "protocol_id": 28
       },
       "minecraft:cherry_sign": {
-        "protocol_id": 201
+        "protocol_id": 190
       },
       "minecraft:cherry_slab": {
-        "protocol_id": 572
+        "protocol_id": 544
       },
       "minecraft:cherry_stairs": {
-        "protocol_id": 485
+        "protocol_id": 458
       },
       "minecraft:cherry_trapdoor": {
-        "protocol_id": 306
+        "protocol_id": 290
       },
       "minecraft:cherry_wall_hanging_sign": {
-        "protocol_id": 237
+        "protocol_id": 223
       },
       "minecraft:cherry_wall_sign": {
-        "protocol_id": 215
+        "protocol_id": 203
       },
       "minecraft:cherry_wood": {
-        "protocol_id": 76
+        "protocol_id": 71
       },
       "minecraft:chest": {
-        "protocol_id": 188
+        "protocol_id": 177
       },
       "minecraft:chipped_anvil": {
-        "protocol_id": 436
+        "protocol_id": 409
       },
       "minecraft:chiseled_bookshelf": {
-        "protocol_id": 178
-      },
-      "minecraft:chiseled_copper": {
-        "protocol_id": 979
+        "protocol_id": 168
       },
       "minecraft:chiseled_deepslate": {
-        "protocol_id": 1076
+        "protocol_id": 987
       },
       "minecraft:chiseled_nether_bricks": {
-        "protocol_id": 900
+        "protocol_id": 866
       },
       "minecraft:chiseled_polished_blackstone": {
-        "protocol_id": 890
+        "protocol_id": 856
       },
       "minecraft:chiseled_quartz_block": {
-        "protocol_id": 447
+        "protocol_id": 420
       },
       "minecraft:chiseled_red_sandstone": {
-        "protocol_id": 564
-      },
-      "minecraft:chiseled_resin_bricks": {
-        "protocol_id": 349
+        "protocol_id": 536
       },
       "minecraft:chiseled_sandstone": {
-        "protocol_id": 107
+        "protocol_id": 100
       },
       "minecraft:chiseled_stone_bricks": {
-        "protocol_id": 314
-      },
-      "minecraft:chiseled_tuff": {
-        "protocol_id": 951
-      },
-      "minecraft:chiseled_tuff_bricks": {
-        "protocol_id": 956
+        "protocol_id": 297
       },
       "minecraft:chorus_flower": {
-        "protocol_id": 625
+        "protocol_id": 593
       },
       "minecraft:chorus_plant": {
-        "protocol_id": 624
+        "protocol_id": 592
       },
       "minecraft:clay": {
-        "protocol_id": 268
-      },
-      "minecraft:closed_eyeblossom": {
-        "protocol_id": 1100
+        "protocol_id": 251
       },
       "minecraft:coal_block": {
-        "protocol_id": 523
+        "protocol_id": 495
       },
       "minecraft:coal_ore": {
-        "protocol_id": 46
+        "protocol_id": 43
       },
       "minecraft:coarse_dirt": {
         "protocol_id": 10
       },
       "minecraft:cobbled_deepslate": {
-        "protocol_id": 1060
+        "protocol_id": 971
       },
       "minecraft:cobbled_deepslate_slab": {
-        "protocol_id": 1062
+        "protocol_id": 973
       },
       "minecraft:cobbled_deepslate_stairs": {
-        "protocol_id": 1061
+        "protocol_id": 972
       },
       "minecraft:cobbled_deepslate_wall": {
-        "protocol_id": 1063
+        "protocol_id": 974
       },
       "minecraft:cobblestone": {
         "protocol_id": 12
       },
       "minecraft:cobblestone_slab": {
-        "protocol_id": 583
+        "protocol_id": 554
       },
       "minecraft:cobblestone_stairs": {
-        "protocol_id": 210
+        "protocol_id": 198
       },
       "minecraft:cobblestone_wall": {
-        "protocol_id": 378
+        "protocol_id": 353
       },
       "minecraft:cobweb": {
-        "protocol_id": 129
+        "protocol_id": 122
       },
       "minecraft:cocoa": {
-        "protocol_id": 365
+        "protocol_id": 340
       },
       "minecraft:command_block": {
-        "protocol_id": 376
+        "protocol_id": 351
       },
       "minecraft:comparator": {
-        "protocol_id": 441
+        "protocol_id": 414
       },
       "minecraft:composter": {
-        "protocol_id": 868
-      },
-      "minecraft:conduit": {
-        "protocol_id": 757
-      },
-      "minecraft:copper_block": {
-        "protocol_id": 966
-      },
-      "minecraft:copper_bulb": {
-        "protocol_id": 1032
-      },
-      "minecraft:copper_door": {
-        "protocol_id": 1008
-      },
-      "minecraft:copper_grate": {
-        "protocol_id": 1024
-      },
-      "minecraft:copper_ore": {
-        "protocol_id": 970
-      },
-      "minecraft:copper_trapdoor": {
-        "protocol_id": 1016
-      },
-      "minecraft:cornflower": {
-        "protocol_id": 168
-      },
-      "minecraft:cracked_deepslate_bricks": {
-        "protocol_id": 1077
-      },
-      "minecraft:cracked_deepslate_tiles": {
-        "protocol_id": 1078
-      },
-      "minecraft:cracked_nether_bricks": {
-        "protocol_id": 901
-      },
-      "minecraft:cracked_polished_blackstone_bricks": {
-        "protocol_id": 889
-      },
-      "minecraft:cracked_stone_bricks": {
-        "protocol_id": 313
-      },
-      "minecraft:crafter": {
-        "protocol_id": 1092
-      },
-      "minecraft:crafting_table": {
-        "protocol_id": 193
-      },
-      "minecraft:creaking_heart": {
-        "protocol_id": 186
-      },
-      "minecraft:creeper_head": {
-        "protocol_id": 429
-      },
-      "minecraft:creeper_wall_head": {
-        "protocol_id": 430
-      },
-      "minecraft:crimson_button": {
-        "protocol_id": 856
-      },
-      "minecraft:crimson_door": {
-        "protocol_id": 858
-      },
-      "minecraft:crimson_fence": {
-        "protocol_id": 848
-      },
-      "minecraft:crimson_fence_gate": {
-        "protocol_id": 852
-      },
-      "minecraft:crimson_fungus": {
-        "protocol_id": 835
-      },
-      "minecraft:crimson_hanging_sign": {
-        "protocol_id": 229
-      },
-      "minecraft:crimson_hyphae": {
-        "protocol_id": 832
-      },
-      "minecraft:crimson_nylium": {
         "protocol_id": 834
       },
+      "minecraft:conduit": {
+        "protocol_id": 725
+      },
+      "minecraft:copper_block": {
+        "protocol_id": 922
+      },
+      "minecraft:copper_ore": {
+        "protocol_id": 923
+      },
+      "minecraft:cornflower": {
+        "protocol_id": 158
+      },
+      "minecraft:cracked_deepslate_bricks": {
+        "protocol_id": 988
+      },
+      "minecraft:cracked_deepslate_tiles": {
+        "protocol_id": 989
+      },
+      "minecraft:cracked_nether_bricks": {
+        "protocol_id": 867
+      },
+      "minecraft:cracked_polished_blackstone_bricks": {
+        "protocol_id": 855
+      },
+      "minecraft:cracked_stone_bricks": {
+        "protocol_id": 296
+      },
+      "minecraft:crafting_table": {
+        "protocol_id": 182
+      },
+      "minecraft:creeper_head": {
+        "protocol_id": 402
+      },
+      "minecraft:creeper_wall_head": {
+        "protocol_id": 403
+      },
+      "minecraft:crimson_button": {
+        "protocol_id": 824
+      },
+      "minecraft:crimson_door": {
+        "protocol_id": 826
+      },
+      "minecraft:crimson_fence": {
+        "protocol_id": 816
+      },
+      "minecraft:crimson_fence_gate": {
+        "protocol_id": 820
+      },
+      "minecraft:crimson_fungus": {
+        "protocol_id": 803
+      },
+      "minecraft:crimson_hanging_sign": {
+        "protocol_id": 215
+      },
+      "minecraft:crimson_hyphae": {
+        "protocol_id": 800
+      },
+      "minecraft:crimson_nylium": {
+        "protocol_id": 802
+      },
       "minecraft:crimson_planks": {
-        "protocol_id": 842
+        "protocol_id": 810
       },
       "minecraft:crimson_pressure_plate": {
-        "protocol_id": 846
+        "protocol_id": 814
       },
       "minecraft:crimson_roots": {
-        "protocol_id": 841
+        "protocol_id": 809
       },
       "minecraft:crimson_sign": {
-        "protocol_id": 860
+        "protocol_id": 828
       },
       "minecraft:crimson_slab": {
-        "protocol_id": 844
+        "protocol_id": 812
       },
       "minecraft:crimson_stairs": {
-        "protocol_id": 854
+        "protocol_id": 822
       },
       "minecraft:crimson_stem": {
-        "protocol_id": 830
+        "protocol_id": 798
       },
       "minecraft:crimson_trapdoor": {
-        "protocol_id": 850
+        "protocol_id": 818
       },
       "minecraft:crimson_wall_hanging_sign": {
-        "protocol_id": 242
-      },
-      "minecraft:crimson_wall_sign": {
-        "protocol_id": 862
-      },
-      "minecraft:crying_obsidian": {
-        "protocol_id": 876
-      },
-      "minecraft:cut_copper": {
-        "protocol_id": 975
-      },
-      "minecraft:cut_copper_slab": {
-        "protocol_id": 991
-      },
-      "minecraft:cut_copper_stairs": {
-        "protocol_id": 987
-      },
-      "minecraft:cut_red_sandstone": {
-        "protocol_id": 565
-      },
-      "minecraft:cut_red_sandstone_slab": {
-        "protocol_id": 590
-      },
-      "minecraft:cut_sandstone": {
-        "protocol_id": 108
-      },
-      "minecraft:cut_sandstone_slab": {
-        "protocol_id": 581
-      },
-      "minecraft:cyan_banner": {
-        "protocol_id": 540
-      },
-      "minecraft:cyan_bed": {
-        "protocol_id": 119
-      },
-      "minecraft:cyan_candle": {
-        "protocol_id": 913
-      },
-      "minecraft:cyan_candle_cake": {
-        "protocol_id": 930
-      },
-      "minecraft:cyan_carpet": {
-        "protocol_id": 515
-      },
-      "minecraft:cyan_concrete": {
-        "protocol_id": 687
-      },
-      "minecraft:cyan_concrete_powder": {
-        "protocol_id": 703
-      },
-      "minecraft:cyan_glazed_terracotta": {
-        "protocol_id": 671
-      },
-      "minecraft:cyan_shulker_box": {
-        "protocol_id": 655
-      },
-      "minecraft:cyan_stained_glass": {
-        "protocol_id": 294
-      },
-      "minecraft:cyan_stained_glass_pane": {
-        "protocol_id": 477
-      },
-      "minecraft:cyan_terracotta": {
-        "protocol_id": 461
-      },
-      "minecraft:cyan_wall_banner": {
-        "protocol_id": 556
-      },
-      "minecraft:cyan_wool": {
-        "protocol_id": 149
-      },
-      "minecraft:damaged_anvil": {
-        "protocol_id": 437
-      },
-      "minecraft:dandelion": {
-        "protocol_id": 157
-      },
-      "minecraft:dark_oak_button": {
-        "protocol_id": 417
-      },
-      "minecraft:dark_oak_door": {
-        "protocol_id": 619
-      },
-      "minecraft:dark_oak_fence": {
-        "protocol_id": 610
-      },
-      "minecraft:dark_oak_fence_gate": {
-        "protocol_id": 601
-      },
-      "minecraft:dark_oak_hanging_sign": {
         "protocol_id": 227
       },
+      "minecraft:crimson_wall_sign": {
+        "protocol_id": 830
+      },
+      "minecraft:crying_obsidian": {
+        "protocol_id": 842
+      },
+      "minecraft:cut_copper": {
+        "protocol_id": 928
+      },
+      "minecraft:cut_copper_slab": {
+        "protocol_id": 936
+      },
+      "minecraft:cut_copper_stairs": {
+        "protocol_id": 932
+      },
+      "minecraft:cut_red_sandstone": {
+        "protocol_id": 537
+      },
+      "minecraft:cut_red_sandstone_slab": {
+        "protocol_id": 561
+      },
+      "minecraft:cut_sandstone": {
+        "protocol_id": 101
+      },
+      "minecraft:cut_sandstone_slab": {
+        "protocol_id": 552
+      },
+      "minecraft:cyan_banner": {
+        "protocol_id": 512
+      },
+      "minecraft:cyan_bed": {
+        "protocol_id": 112
+      },
+      "minecraft:cyan_candle": {
+        "protocol_id": 879
+      },
+      "minecraft:cyan_candle_cake": {
+        "protocol_id": 896
+      },
+      "minecraft:cyan_carpet": {
+        "protocol_id": 487
+      },
+      "minecraft:cyan_concrete": {
+        "protocol_id": 655
+      },
+      "minecraft:cyan_concrete_powder": {
+        "protocol_id": 671
+      },
+      "minecraft:cyan_glazed_terracotta": {
+        "protocol_id": 639
+      },
+      "minecraft:cyan_shulker_box": {
+        "protocol_id": 623
+      },
+      "minecraft:cyan_stained_glass": {
+        "protocol_id": 278
+      },
+      "minecraft:cyan_stained_glass_pane": {
+        "protocol_id": 450
+      },
+      "minecraft:cyan_terracotta": {
+        "protocol_id": 434
+      },
+      "minecraft:cyan_wall_banner": {
+        "protocol_id": 528
+      },
+      "minecraft:cyan_wool": {
+        "protocol_id": 139
+      },
+      "minecraft:damaged_anvil": {
+        "protocol_id": 410
+      },
+      "minecraft:dandelion": {
+        "protocol_id": 147
+      },
+      "minecraft:dark_oak_button": {
+        "protocol_id": 391
+      },
+      "minecraft:dark_oak_door": {
+        "protocol_id": 588
+      },
+      "minecraft:dark_oak_fence": {
+        "protocol_id": 580
+      },
+      "minecraft:dark_oak_fence_gate": {
+        "protocol_id": 572
+      },
+      "minecraft:dark_oak_hanging_sign": {
+        "protocol_id": 214
+      },
       "minecraft:dark_oak_leaves": {
-        "protocol_id": 94
+        "protocol_id": 88
       },
       "minecraft:dark_oak_log": {
-        "protocol_id": 55
+        "protocol_id": 52
       },
       "minecraft:dark_oak_planks": {
         "protocol_id": 19
       },
       "minecraft:dark_oak_pressure_plate": {
-        "protocol_id": 254
-      },
-      "minecraft:dark_oak_sapling": {
-        "protocol_id": 31
-      },
-      "minecraft:dark_oak_sign": {
-        "protocol_id": 203
-      },
-      "minecraft:dark_oak_slab": {
-        "protocol_id": 573
-      },
-      "minecraft:dark_oak_stairs": {
-        "protocol_id": 486
-      },
-      "minecraft:dark_oak_trapdoor": {
-        "protocol_id": 307
-      },
-      "minecraft:dark_oak_wall_hanging_sign": {
         "protocol_id": 239
       },
-      "minecraft:dark_oak_wall_sign": {
-        "protocol_id": 217
+      "minecraft:dark_oak_sapling": {
+        "protocol_id": 29
       },
-      "minecraft:dark_oak_wood": {
-        "protocol_id": 77
-      },
-      "minecraft:dark_prismarine": {
-        "protocol_id": 497
-      },
-      "minecraft:dark_prismarine_slab": {
-        "protocol_id": 503
-      },
-      "minecraft:dark_prismarine_stairs": {
-        "protocol_id": 500
-      },
-      "minecraft:daylight_detector": {
-        "protocol_id": 442
-      },
-      "minecraft:dead_brain_coral": {
-        "protocol_id": 726
-      },
-      "minecraft:dead_brain_coral_block": {
-        "protocol_id": 716
-      },
-      "minecraft:dead_brain_coral_fan": {
-        "protocol_id": 736
-      },
-      "minecraft:dead_brain_coral_wall_fan": {
-        "protocol_id": 746
-      },
-      "minecraft:dead_bubble_coral": {
-        "protocol_id": 727
-      },
-      "minecraft:dead_bubble_coral_block": {
-        "protocol_id": 717
-      },
-      "minecraft:dead_bubble_coral_fan": {
-        "protocol_id": 737
-      },
-      "minecraft:dead_bubble_coral_wall_fan": {
-        "protocol_id": 747
-      },
-      "minecraft:dead_bush": {
-        "protocol_id": 132
-      },
-      "minecraft:dead_fire_coral": {
-        "protocol_id": 728
-      },
-      "minecraft:dead_fire_coral_block": {
-        "protocol_id": 718
-      },
-      "minecraft:dead_fire_coral_fan": {
-        "protocol_id": 738
-      },
-      "minecraft:dead_fire_coral_wall_fan": {
-        "protocol_id": 748
-      },
-      "minecraft:dead_horn_coral": {
-        "protocol_id": 729
-      },
-      "minecraft:dead_horn_coral_block": {
-        "protocol_id": 719
-      },
-      "minecraft:dead_horn_coral_fan": {
-        "protocol_id": 739
-      },
-      "minecraft:dead_horn_coral_wall_fan": {
-        "protocol_id": 749
-      },
-      "minecraft:dead_tube_coral": {
-        "protocol_id": 725
-      },
-      "minecraft:dead_tube_coral_block": {
-        "protocol_id": 715
-      },
-      "minecraft:dead_tube_coral_fan": {
-        "protocol_id": 735
-      },
-      "minecraft:dead_tube_coral_wall_fan": {
-        "protocol_id": 745
-      },
-      "minecraft:decorated_pot": {
-        "protocol_id": 1091
-      },
-      "minecraft:deepslate": {
-        "protocol_id": 1059
-      },
-      "minecraft:deepslate_brick_slab": {
-        "protocol_id": 1074
-      },
-      "minecraft:deepslate_brick_stairs": {
-        "protocol_id": 1073
-      },
-      "minecraft:deepslate_brick_wall": {
-        "protocol_id": 1075
-      },
-      "minecraft:deepslate_bricks": {
-        "protocol_id": 1072
-      },
-      "minecraft:deepslate_coal_ore": {
-        "protocol_id": 47
-      },
-      "minecraft:deepslate_copper_ore": {
-        "protocol_id": 971
-      },
-      "minecraft:deepslate_diamond_ore": {
-        "protocol_id": 191
-      },
-      "minecraft:deepslate_emerald_ore": {
-        "protocol_id": 368
-      },
-      "minecraft:deepslate_gold_ore": {
-        "protocol_id": 43
-      },
-      "minecraft:deepslate_iron_ore": {
-        "protocol_id": 45
-      },
-      "minecraft:deepslate_lapis_ore": {
-        "protocol_id": 103
-      },
-      "minecraft:deepslate_redstone_ore": {
-        "protocol_id": 259
-      },
-      "minecraft:deepslate_tile_slab": {
-        "protocol_id": 1070
-      },
-      "minecraft:deepslate_tile_stairs": {
-        "protocol_id": 1069
-      },
-      "minecraft:deepslate_tile_wall": {
-        "protocol_id": 1071
-      },
-      "minecraft:deepslate_tiles": {
-        "protocol_id": 1068
-      },
-      "minecraft:detector_rail": {
-        "protocol_id": 127
-      },
-      "minecraft:diamond_block": {
+      "minecraft:dark_oak_sign": {
         "protocol_id": 192
       },
+      "minecraft:dark_oak_slab": {
+        "protocol_id": 545
+      },
+      "minecraft:dark_oak_stairs": {
+        "protocol_id": 459
+      },
+      "minecraft:dark_oak_trapdoor": {
+        "protocol_id": 291
+      },
+      "minecraft:dark_oak_wall_hanging_sign": {
+        "protocol_id": 225
+      },
+      "minecraft:dark_oak_wall_sign": {
+        "protocol_id": 205
+      },
+      "minecraft:dark_oak_wood": {
+        "protocol_id": 72
+      },
+      "minecraft:dark_prismarine": {
+        "protocol_id": 469
+      },
+      "minecraft:dark_prismarine_slab": {
+        "protocol_id": 475
+      },
+      "minecraft:dark_prismarine_stairs": {
+        "protocol_id": 472
+      },
+      "minecraft:daylight_detector": {
+        "protocol_id": 415
+      },
+      "minecraft:dead_brain_coral": {
+        "protocol_id": 694
+      },
+      "minecraft:dead_brain_coral_block": {
+        "protocol_id": 684
+      },
+      "minecraft:dead_brain_coral_fan": {
+        "protocol_id": 704
+      },
+      "minecraft:dead_brain_coral_wall_fan": {
+        "protocol_id": 714
+      },
+      "minecraft:dead_bubble_coral": {
+        "protocol_id": 695
+      },
+      "minecraft:dead_bubble_coral_block": {
+        "protocol_id": 685
+      },
+      "minecraft:dead_bubble_coral_fan": {
+        "protocol_id": 705
+      },
+      "minecraft:dead_bubble_coral_wall_fan": {
+        "protocol_id": 715
+      },
+      "minecraft:dead_bush": {
+        "protocol_id": 125
+      },
+      "minecraft:dead_fire_coral": {
+        "protocol_id": 696
+      },
+      "minecraft:dead_fire_coral_block": {
+        "protocol_id": 686
+      },
+      "minecraft:dead_fire_coral_fan": {
+        "protocol_id": 706
+      },
+      "minecraft:dead_fire_coral_wall_fan": {
+        "protocol_id": 716
+      },
+      "minecraft:dead_horn_coral": {
+        "protocol_id": 697
+      },
+      "minecraft:dead_horn_coral_block": {
+        "protocol_id": 687
+      },
+      "minecraft:dead_horn_coral_fan": {
+        "protocol_id": 707
+      },
+      "minecraft:dead_horn_coral_wall_fan": {
+        "protocol_id": 717
+      },
+      "minecraft:dead_tube_coral": {
+        "protocol_id": 693
+      },
+      "minecraft:dead_tube_coral_block": {
+        "protocol_id": 683
+      },
+      "minecraft:dead_tube_coral_fan": {
+        "protocol_id": 703
+      },
+      "minecraft:dead_tube_coral_wall_fan": {
+        "protocol_id": 713
+      },
+      "minecraft:decorated_pot": {
+        "protocol_id": 1002
+      },
+      "minecraft:deepslate": {
+        "protocol_id": 970
+      },
+      "minecraft:deepslate_brick_slab": {
+        "protocol_id": 985
+      },
+      "minecraft:deepslate_brick_stairs": {
+        "protocol_id": 984
+      },
+      "minecraft:deepslate_brick_wall": {
+        "protocol_id": 986
+      },
+      "minecraft:deepslate_bricks": {
+        "protocol_id": 983
+      },
+      "minecraft:deepslate_coal_ore": {
+        "protocol_id": 44
+      },
+      "minecraft:deepslate_copper_ore": {
+        "protocol_id": 924
+      },
+      "minecraft:deepslate_diamond_ore": {
+        "protocol_id": 180
+      },
+      "minecraft:deepslate_emerald_ore": {
+        "protocol_id": 343
+      },
+      "minecraft:deepslate_gold_ore": {
+        "protocol_id": 40
+      },
+      "minecraft:deepslate_iron_ore": {
+        "protocol_id": 42
+      },
+      "minecraft:deepslate_lapis_ore": {
+        "protocol_id": 96
+      },
+      "minecraft:deepslate_redstone_ore": {
+        "protocol_id": 243
+      },
+      "minecraft:deepslate_tile_slab": {
+        "protocol_id": 981
+      },
+      "minecraft:deepslate_tile_stairs": {
+        "protocol_id": 980
+      },
+      "minecraft:deepslate_tile_wall": {
+        "protocol_id": 982
+      },
+      "minecraft:deepslate_tiles": {
+        "protocol_id": 979
+      },
+      "minecraft:detector_rail": {
+        "protocol_id": 120
+      },
+      "minecraft:diamond_block": {
+        "protocol_id": 181
+      },
       "minecraft:diamond_ore": {
-        "protocol_id": 190
+        "protocol_id": 179
       },
       "minecraft:diorite": {
         "protocol_id": 4
       },
       "minecraft:diorite_slab": {
-        "protocol_id": 790
+        "protocol_id": 758
       },
       "minecraft:diorite_stairs": {
-        "protocol_id": 777
+        "protocol_id": 745
       },
       "minecraft:diorite_wall": {
-        "protocol_id": 803
+        "protocol_id": 771
       },
       "minecraft:dirt": {
         "protocol_id": 9
       },
       "minecraft:dirt_path": {
-        "protocol_id": 634
+        "protocol_id": 602
       },
       "minecraft:dispenser": {
-        "protocol_id": 105
-      },
-      "minecraft:dragon_egg": {
-        "protocol_id": 363
-      },
-      "minecraft:dragon_head": {
-        "protocol_id": 431
-      },
-      "minecraft:dragon_wall_head": {
-        "protocol_id": 432
-      },
-      "minecraft:dried_kelp_block": {
-        "protocol_id": 712
-      },
-      "minecraft:dripstone_block": {
-        "protocol_id": 1042
-      },
-      "minecraft:dropper": {
-        "protocol_id": 451
-      },
-      "minecraft:emerald_block": {
-        "protocol_id": 372
-      },
-      "minecraft:emerald_ore": {
-        "protocol_id": 367
-      },
-      "minecraft:enchanting_table": {
-        "protocol_id": 354
-      },
-      "minecraft:end_gateway": {
-        "protocol_id": 635
-      },
-      "minecraft:end_portal": {
-        "protocol_id": 360
-      },
-      "minecraft:end_portal_frame": {
-        "protocol_id": 361
-      },
-      "minecraft:end_rod": {
-        "protocol_id": 623
-      },
-      "minecraft:end_stone": {
-        "protocol_id": 362
-      },
-      "minecraft:end_stone_brick_slab": {
-        "protocol_id": 783
-      },
-      "minecraft:end_stone_brick_stairs": {
-        "protocol_id": 769
-      },
-      "minecraft:end_stone_brick_wall": {
-        "protocol_id": 802
-      },
-      "minecraft:end_stone_bricks": {
-        "protocol_id": 629
-      },
-      "minecraft:ender_chest": {
-        "protocol_id": 369
-      },
-      "minecraft:exposed_chiseled_copper": {
-        "protocol_id": 978
-      },
-      "minecraft:exposed_copper": {
-        "protocol_id": 967
-      },
-      "minecraft:exposed_copper_bulb": {
-        "protocol_id": 1033
-      },
-      "minecraft:exposed_copper_door": {
-        "protocol_id": 1009
-      },
-      "minecraft:exposed_copper_grate": {
-        "protocol_id": 1025
-      },
-      "minecraft:exposed_copper_trapdoor": {
-        "protocol_id": 1017
-      },
-      "minecraft:exposed_cut_copper": {
-        "protocol_id": 974
-      },
-      "minecraft:exposed_cut_copper_slab": {
-        "protocol_id": 990
-      },
-      "minecraft:exposed_cut_copper_stairs": {
-        "protocol_id": 986
-      },
-      "minecraft:farmland": {
-        "protocol_id": 195
-      },
-      "minecraft:fern": {
-        "protocol_id": 131
-      },
-      "minecraft:fire": {
-        "protocol_id": 183
-      },
-      "minecraft:fire_coral": {
-        "protocol_id": 733
-      },
-      "minecraft:fire_coral_block": {
-        "protocol_id": 723
-      },
-      "minecraft:fire_coral_fan": {
-        "protocol_id": 743
-      },
-      "minecraft:fire_coral_wall_fan": {
-        "protocol_id": 753
-      },
-      "minecraft:firefly_bush": {
-        "protocol_id": 1103
-      },
-      "minecraft:fletching_table": {
-        "protocol_id": 810
-      },
-      "minecraft:flower_pot": {
-        "protocol_id": 380
-      },
-      "minecraft:flowering_azalea": {
-        "protocol_id": 1047
-      },
-      "minecraft:flowering_azalea_leaves": {
         "protocol_id": 98
       },
-      "minecraft:frogspawn": {
-        "protocol_id": 1089
+      "minecraft:dragon_egg": {
+        "protocol_id": 338
       },
-      "minecraft:frosted_ice": {
-        "protocol_id": 638
+      "minecraft:dragon_head": {
+        "protocol_id": 404
       },
-      "minecraft:furnace": {
-        "protocol_id": 196
+      "minecraft:dragon_wall_head": {
+        "protocol_id": 405
       },
-      "minecraft:gilded_blackstone": {
-        "protocol_id": 894
+      "minecraft:dried_kelp_block": {
+        "protocol_id": 680
       },
-      "minecraft:glass": {
-        "protocol_id": 101
+      "minecraft:dripstone_block": {
+        "protocol_id": 955
       },
-      "minecraft:glass_pane": {
-        "protocol_id": 328
+      "minecraft:dropper": {
+        "protocol_id": 424
       },
-      "minecraft:glow_lichen": {
+      "minecraft:emerald_block": {
+        "protocol_id": 347
+      },
+      "minecraft:emerald_ore": {
+        "protocol_id": 342
+      },
+      "minecraft:enchanting_table": {
+        "protocol_id": 329
+      },
+      "minecraft:end_gateway": {
+        "protocol_id": 603
+      },
+      "minecraft:end_portal": {
+        "protocol_id": 335
+      },
+      "minecraft:end_portal_frame": {
         "protocol_id": 336
       },
-      "minecraft:glowstone": {
-        "protocol_id": 279
+      "minecraft:end_rod": {
+        "protocol_id": 591
       },
-      "minecraft:gold_block": {
+      "minecraft:end_stone": {
+        "protocol_id": 337
+      },
+      "minecraft:end_stone_brick_slab": {
+        "protocol_id": 751
+      },
+      "minecraft:end_stone_brick_stairs": {
+        "protocol_id": 737
+      },
+      "minecraft:end_stone_brick_wall": {
+        "protocol_id": 770
+      },
+      "minecraft:end_stone_bricks": {
+        "protocol_id": 597
+      },
+      "minecraft:ender_chest": {
+        "protocol_id": 344
+      },
+      "minecraft:exposed_copper": {
+        "protocol_id": 921
+      },
+      "minecraft:exposed_cut_copper": {
+        "protocol_id": 927
+      },
+      "minecraft:exposed_cut_copper_slab": {
+        "protocol_id": 935
+      },
+      "minecraft:exposed_cut_copper_stairs": {
+        "protocol_id": 931
+      },
+      "minecraft:farmland": {
+        "protocol_id": 184
+      },
+      "minecraft:fern": {
+        "protocol_id": 124
+      },
+      "minecraft:fire": {
         "protocol_id": 173
       },
+      "minecraft:fire_coral": {
+        "protocol_id": 701
+      },
+      "minecraft:fire_coral_block": {
+        "protocol_id": 691
+      },
+      "minecraft:fire_coral_fan": {
+        "protocol_id": 711
+      },
+      "minecraft:fire_coral_wall_fan": {
+        "protocol_id": 721
+      },
+      "minecraft:fletching_table": {
+        "protocol_id": 778
+      },
+      "minecraft:flower_pot": {
+        "protocol_id": 355
+      },
+      "minecraft:flowering_azalea": {
+        "protocol_id": 960
+      },
+      "minecraft:flowering_azalea_leaves": {
+        "protocol_id": 91
+      },
+      "minecraft:frogspawn": {
+        "protocol_id": 1000
+      },
+      "minecraft:frosted_ice": {
+        "protocol_id": 606
+      },
+      "minecraft:furnace": {
+        "protocol_id": 185
+      },
+      "minecraft:gilded_blackstone": {
+        "protocol_id": 860
+      },
+      "minecraft:glass": {
+        "protocol_id": 94
+      },
+      "minecraft:glass_pane": {
+        "protocol_id": 311
+      },
+      "minecraft:glow_lichen": {
+        "protocol_id": 318
+      },
+      "minecraft:glowstone": {
+        "protocol_id": 263
+      },
+      "minecraft:gold_block": {
+        "protocol_id": 163
+      },
       "minecraft:gold_ore": {
-        "protocol_id": 42
+        "protocol_id": 39
       },
       "minecraft:granite": {
         "protocol_id": 2
       },
       "minecraft:granite_slab": {
-        "protocol_id": 786
+        "protocol_id": 754
       },
       "minecraft:granite_stairs": {
-        "protocol_id": 773
+        "protocol_id": 741
       },
       "minecraft:granite_wall": {
-        "protocol_id": 795
+        "protocol_id": 763
+      },
+      "minecraft:grass": {
+        "protocol_id": 123
       },
       "minecraft:grass_block": {
         "protocol_id": 8
       },
       "minecraft:gravel": {
-        "protocol_id": 40
+        "protocol_id": 37
       },
       "minecraft:gray_banner": {
-        "protocol_id": 538
+        "protocol_id": 510
       },
       "minecraft:gray_bed": {
-        "protocol_id": 117
+        "protocol_id": 110
       },
       "minecraft:gray_candle": {
-        "protocol_id": 911
+        "protocol_id": 877
       },
       "minecraft:gray_candle_cake": {
-        "protocol_id": 928
+        "protocol_id": 894
       },
       "minecraft:gray_carpet": {
-        "protocol_id": 513
+        "protocol_id": 485
       },
       "minecraft:gray_concrete": {
-        "protocol_id": 685
-      },
-      "minecraft:gray_concrete_powder": {
-        "protocol_id": 701
-      },
-      "minecraft:gray_glazed_terracotta": {
-        "protocol_id": 669
-      },
-      "minecraft:gray_shulker_box": {
         "protocol_id": 653
       },
+      "minecraft:gray_concrete_powder": {
+        "protocol_id": 669
+      },
+      "minecraft:gray_glazed_terracotta": {
+        "protocol_id": 637
+      },
+      "minecraft:gray_shulker_box": {
+        "protocol_id": 621
+      },
       "minecraft:gray_stained_glass": {
-        "protocol_id": 292
+        "protocol_id": 276
       },
       "minecraft:gray_stained_glass_pane": {
-        "protocol_id": 475
+        "protocol_id": 448
       },
       "minecraft:gray_terracotta": {
-        "protocol_id": 459
+        "protocol_id": 432
       },
       "minecraft:gray_wall_banner": {
-        "protocol_id": 554
+        "protocol_id": 526
       },
       "minecraft:gray_wool": {
-        "protocol_id": 147
+        "protocol_id": 137
       },
       "minecraft:green_banner": {
-        "protocol_id": 544
+        "protocol_id": 516
       },
       "minecraft:green_bed": {
-        "protocol_id": 123
+        "protocol_id": 116
       },
       "minecraft:green_candle": {
-        "protocol_id": 917
+        "protocol_id": 883
       },
       "minecraft:green_candle_cake": {
-        "protocol_id": 934
+        "protocol_id": 900
       },
       "minecraft:green_carpet": {
-        "protocol_id": 519
+        "protocol_id": 491
       },
       "minecraft:green_concrete": {
-        "protocol_id": 691
-      },
-      "minecraft:green_concrete_powder": {
-        "protocol_id": 707
-      },
-      "minecraft:green_glazed_terracotta": {
-        "protocol_id": 675
-      },
-      "minecraft:green_shulker_box": {
         "protocol_id": 659
       },
+      "minecraft:green_concrete_powder": {
+        "protocol_id": 675
+      },
+      "minecraft:green_glazed_terracotta": {
+        "protocol_id": 643
+      },
+      "minecraft:green_shulker_box": {
+        "protocol_id": 627
+      },
       "minecraft:green_stained_glass": {
-        "protocol_id": 298
-      },
-      "minecraft:green_stained_glass_pane": {
-        "protocol_id": 481
-      },
-      "minecraft:green_terracotta": {
-        "protocol_id": 465
-      },
-      "minecraft:green_wall_banner": {
-        "protocol_id": 560
-      },
-      "minecraft:green_wool": {
-        "protocol_id": 153
-      },
-      "minecraft:grindstone": {
-        "protocol_id": 811
-      },
-      "minecraft:hanging_roots": {
-        "protocol_id": 1056
-      },
-      "minecraft:hay_block": {
-        "protocol_id": 505
-      },
-      "minecraft:heavy_core": {
-        "protocol_id": 1095
-      },
-      "minecraft:heavy_weighted_pressure_plate": {
-        "protocol_id": 440
-      },
-      "minecraft:honey_block": {
-        "protocol_id": 872
-      },
-      "minecraft:honeycomb_block": {
-        "protocol_id": 873
-      },
-      "minecraft:hopper": {
-        "protocol_id": 445
-      },
-      "minecraft:horn_coral": {
-        "protocol_id": 734
-      },
-      "minecraft:horn_coral_block": {
-        "protocol_id": 724
-      },
-      "minecraft:horn_coral_fan": {
-        "protocol_id": 744
-      },
-      "minecraft:horn_coral_wall_fan": {
-        "protocol_id": 754
-      },
-      "minecraft:ice": {
-        "protocol_id": 264
-      },
-      "minecraft:infested_chiseled_stone_bricks": {
-        "protocol_id": 322
-      },
-      "minecraft:infested_cobblestone": {
-        "protocol_id": 318
-      },
-      "minecraft:infested_cracked_stone_bricks": {
-        "protocol_id": 321
-      },
-      "minecraft:infested_deepslate": {
-        "protocol_id": 1079
-      },
-      "minecraft:infested_mossy_stone_bricks": {
-        "protocol_id": 320
-      },
-      "minecraft:infested_stone": {
-        "protocol_id": 317
-      },
-      "minecraft:infested_stone_bricks": {
-        "protocol_id": 319
-      },
-      "minecraft:iron_bars": {
-        "protocol_id": 326
-      },
-      "minecraft:iron_block": {
-        "protocol_id": 174
-      },
-      "minecraft:iron_door": {
-        "protocol_id": 247
-      },
-      "minecraft:iron_ore": {
-        "protocol_id": 44
-      },
-      "minecraft:iron_trapdoor": {
-        "protocol_id": 494
-      },
-      "minecraft:jack_o_lantern": {
         "protocol_id": 282
       },
+      "minecraft:green_stained_glass_pane": {
+        "protocol_id": 454
+      },
+      "minecraft:green_terracotta": {
+        "protocol_id": 438
+      },
+      "minecraft:green_wall_banner": {
+        "protocol_id": 532
+      },
+      "minecraft:green_wool": {
+        "protocol_id": 143
+      },
+      "minecraft:grindstone": {
+        "protocol_id": 779
+      },
+      "minecraft:hanging_roots": {
+        "protocol_id": 967
+      },
+      "minecraft:hay_block": {
+        "protocol_id": 477
+      },
+      "minecraft:heavy_weighted_pressure_plate": {
+        "protocol_id": 413
+      },
+      "minecraft:honey_block": {
+        "protocol_id": 838
+      },
+      "minecraft:honeycomb_block": {
+        "protocol_id": 839
+      },
+      "minecraft:hopper": {
+        "protocol_id": 418
+      },
+      "minecraft:horn_coral": {
+        "protocol_id": 702
+      },
+      "minecraft:horn_coral_block": {
+        "protocol_id": 692
+      },
+      "minecraft:horn_coral_fan": {
+        "protocol_id": 712
+      },
+      "minecraft:horn_coral_wall_fan": {
+        "protocol_id": 722
+      },
+      "minecraft:ice": {
+        "protocol_id": 248
+      },
+      "minecraft:infested_chiseled_stone_bricks": {
+        "protocol_id": 305
+      },
+      "minecraft:infested_cobblestone": {
+        "protocol_id": 301
+      },
+      "minecraft:infested_cracked_stone_bricks": {
+        "protocol_id": 304
+      },
+      "minecraft:infested_deepslate": {
+        "protocol_id": 990
+      },
+      "minecraft:infested_mossy_stone_bricks": {
+        "protocol_id": 303
+      },
+      "minecraft:infested_stone": {
+        "protocol_id": 300
+      },
+      "minecraft:infested_stone_bricks": {
+        "protocol_id": 302
+      },
+      "minecraft:iron_bars": {
+        "protocol_id": 309
+      },
+      "minecraft:iron_block": {
+        "protocol_id": 164
+      },
+      "minecraft:iron_door": {
+        "protocol_id": 232
+      },
+      "minecraft:iron_ore": {
+        "protocol_id": 41
+      },
+      "minecraft:iron_trapdoor": {
+        "protocol_id": 466
+      },
+      "minecraft:jack_o_lantern": {
+        "protocol_id": 266
+      },
       "minecraft:jigsaw": {
-        "protocol_id": 865
+        "protocol_id": 833
       },
       "minecraft:jukebox": {
-        "protocol_id": 270
+        "protocol_id": 253
       },
       "minecraft:jungle_button": {
-        "protocol_id": 414
+        "protocol_id": 388
       },
       "minecraft:jungle_door": {
-        "protocol_id": 616
+        "protocol_id": 585
       },
       "minecraft:jungle_fence": {
-        "protocol_id": 607
+        "protocol_id": 577
       },
       "minecraft:jungle_fence_gate": {
-        "protocol_id": 598
+        "protocol_id": 569
       },
       "minecraft:jungle_hanging_sign": {
-        "protocol_id": 226
+        "protocol_id": 213
       },
       "minecraft:jungle_leaves": {
-        "protocol_id": 91
+        "protocol_id": 85
       },
       "minecraft:jungle_log": {
-        "protocol_id": 52
+        "protocol_id": 49
       },
       "minecraft:jungle_planks": {
         "protocol_id": 16
       },
       "minecraft:jungle_pressure_plate": {
-        "protocol_id": 251
+        "protocol_id": 236
       },
       "minecraft:jungle_sapling": {
-        "protocol_id": 28
+        "protocol_id": 26
       },
       "minecraft:jungle_sign": {
-        "protocol_id": 202
+        "protocol_id": 191
       },
       "minecraft:jungle_slab": {
-        "protocol_id": 570
+        "protocol_id": 542
       },
       "minecraft:jungle_stairs": {
-        "protocol_id": 375
-      },
-      "minecraft:jungle_trapdoor": {
-        "protocol_id": 304
-      },
-      "minecraft:jungle_wall_hanging_sign": {
-        "protocol_id": 238
-      },
-      "minecraft:jungle_wall_sign": {
-        "protocol_id": 216
-      },
-      "minecraft:jungle_wood": {
-        "protocol_id": 74
-      },
-      "minecraft:kelp": {
-        "protocol_id": 710
-      },
-      "minecraft:kelp_plant": {
-        "protocol_id": 711
-      },
-      "minecraft:ladder": {
-        "protocol_id": 208
-      },
-      "minecraft:lantern": {
-        "protocol_id": 816
-      },
-      "minecraft:lapis_block": {
-        "protocol_id": 104
-      },
-      "minecraft:lapis_ore": {
-        "protocol_id": 102
-      },
-      "minecraft:large_amethyst_bud": {
-        "protocol_id": 940
-      },
-      "minecraft:large_fern": {
-        "protocol_id": 530
-      },
-      "minecraft:lava": {
-        "protocol_id": 36
-      },
-      "minecraft:lava_cauldron": {
-        "protocol_id": 358
-      },
-      "minecraft:leaf_litter": {
-        "protocol_id": 1051
-      },
-      "minecraft:lectern": {
-        "protocol_id": 812
-      },
-      "minecraft:lever": {
-        "protocol_id": 245
-      },
-      "minecraft:light": {
-        "protocol_id": 493
-      },
-      "minecraft:light_blue_banner": {
-        "protocol_id": 534
-      },
-      "minecraft:light_blue_bed": {
-        "protocol_id": 113
-      },
-      "minecraft:light_blue_candle": {
-        "protocol_id": 907
-      },
-      "minecraft:light_blue_candle_cake": {
-        "protocol_id": 924
-      },
-      "minecraft:light_blue_carpet": {
-        "protocol_id": 509
-      },
-      "minecraft:light_blue_concrete": {
-        "protocol_id": 681
-      },
-      "minecraft:light_blue_concrete_powder": {
-        "protocol_id": 697
-      },
-      "minecraft:light_blue_glazed_terracotta": {
-        "protocol_id": 665
-      },
-      "minecraft:light_blue_shulker_box": {
-        "protocol_id": 649
-      },
-      "minecraft:light_blue_stained_glass": {
-        "protocol_id": 288
-      },
-      "minecraft:light_blue_stained_glass_pane": {
-        "protocol_id": 471
-      },
-      "minecraft:light_blue_terracotta": {
-        "protocol_id": 455
-      },
-      "minecraft:light_blue_wall_banner": {
-        "protocol_id": 550
-      },
-      "minecraft:light_blue_wool": {
-        "protocol_id": 143
-      },
-      "minecraft:light_gray_banner": {
-        "protocol_id": 539
-      },
-      "minecraft:light_gray_bed": {
-        "protocol_id": 118
-      },
-      "minecraft:light_gray_candle": {
-        "protocol_id": 912
-      },
-      "minecraft:light_gray_candle_cake": {
-        "protocol_id": 929
-      },
-      "minecraft:light_gray_carpet": {
-        "protocol_id": 514
-      },
-      "minecraft:light_gray_concrete": {
-        "protocol_id": 686
-      },
-      "minecraft:light_gray_concrete_powder": {
-        "protocol_id": 702
-      },
-      "minecraft:light_gray_glazed_terracotta": {
-        "protocol_id": 670
-      },
-      "minecraft:light_gray_shulker_box": {
-        "protocol_id": 654
-      },
-      "minecraft:light_gray_stained_glass": {
-        "protocol_id": 293
-      },
-      "minecraft:light_gray_stained_glass_pane": {
-        "protocol_id": 476
-      },
-      "minecraft:light_gray_terracotta": {
-        "protocol_id": 460
-      },
-      "minecraft:light_gray_wall_banner": {
-        "protocol_id": 555
-      },
-      "minecraft:light_gray_wool": {
-        "protocol_id": 148
-      },
-      "minecraft:light_weighted_pressure_plate": {
-        "protocol_id": 439
-      },
-      "minecraft:lightning_rod": {
-        "protocol_id": 1040
-      },
-      "minecraft:lilac": {
-        "protocol_id": 526
-      },
-      "minecraft:lily_of_the_valley": {
-        "protocol_id": 170
-      },
-      "minecraft:lily_pad": {
-        "protocol_id": 343
-      },
-      "minecraft:lime_banner": {
-        "protocol_id": 536
-      },
-      "minecraft:lime_bed": {
-        "protocol_id": 115
-      },
-      "minecraft:lime_candle": {
-        "protocol_id": 909
-      },
-      "minecraft:lime_candle_cake": {
-        "protocol_id": 926
-      },
-      "minecraft:lime_carpet": {
-        "protocol_id": 511
-      },
-      "minecraft:lime_concrete": {
-        "protocol_id": 683
-      },
-      "minecraft:lime_concrete_powder": {
-        "protocol_id": 699
-      },
-      "minecraft:lime_glazed_terracotta": {
-        "protocol_id": 667
-      },
-      "minecraft:lime_shulker_box": {
-        "protocol_id": 651
-      },
-      "minecraft:lime_stained_glass": {
-        "protocol_id": 290
-      },
-      "minecraft:lime_stained_glass_pane": {
-        "protocol_id": 473
-      },
-      "minecraft:lime_terracotta": {
-        "protocol_id": 457
-      },
-      "minecraft:lime_wall_banner": {
-        "protocol_id": 552
-      },
-      "minecraft:lime_wool": {
-        "protocol_id": 145
-      },
-      "minecraft:lodestone": {
-        "protocol_id": 882
-      },
-      "minecraft:loom": {
-        "protocol_id": 805
-      },
-      "minecraft:magenta_banner": {
-        "protocol_id": 533
-      },
-      "minecraft:magenta_bed": {
-        "protocol_id": 112
-      },
-      "minecraft:magenta_candle": {
-        "protocol_id": 906
-      },
-      "minecraft:magenta_candle_cake": {
-        "protocol_id": 923
-      },
-      "minecraft:magenta_carpet": {
-        "protocol_id": 508
-      },
-      "minecraft:magenta_concrete": {
-        "protocol_id": 680
-      },
-      "minecraft:magenta_concrete_powder": {
-        "protocol_id": 696
-      },
-      "minecraft:magenta_glazed_terracotta": {
-        "protocol_id": 664
-      },
-      "minecraft:magenta_shulker_box": {
-        "protocol_id": 648
-      },
-      "minecraft:magenta_stained_glass": {
-        "protocol_id": 287
-      },
-      "minecraft:magenta_stained_glass_pane": {
-        "protocol_id": 470
-      },
-      "minecraft:magenta_terracotta": {
-        "protocol_id": 454
-      },
-      "minecraft:magenta_wall_banner": {
-        "protocol_id": 549
-      },
-      "minecraft:magenta_wool": {
-        "protocol_id": 142
-      },
-      "minecraft:magma_block": {
-        "protocol_id": 639
-      },
-      "minecraft:mangrove_button": {
-        "protocol_id": 419
-      },
-      "minecraft:mangrove_door": {
-        "protocol_id": 621
-      },
-      "minecraft:mangrove_fence": {
-        "protocol_id": 612
-      },
-      "minecraft:mangrove_fence_gate": {
-        "protocol_id": 603
-      },
-      "minecraft:mangrove_hanging_sign": {
-        "protocol_id": 231
-      },
-      "minecraft:mangrove_leaves": {
-        "protocol_id": 96
-      },
-      "minecraft:mangrove_log": {
-        "protocol_id": 57
-      },
-      "minecraft:mangrove_planks": {
-        "protocol_id": 22
-      },
-      "minecraft:mangrove_pressure_plate": {
-        "protocol_id": 256
-      },
-      "minecraft:mangrove_propagule": {
-        "protocol_id": 33
-      },
-      "minecraft:mangrove_roots": {
-        "protocol_id": 58
-      },
-      "minecraft:mangrove_sign": {
-        "protocol_id": 205
-      },
-      "minecraft:mangrove_slab": {
-        "protocol_id": 575
-      },
-      "minecraft:mangrove_stairs": {
-        "protocol_id": 488
-      },
-      "minecraft:mangrove_trapdoor": {
-        "protocol_id": 309
-      },
-      "minecraft:mangrove_wall_hanging_sign": {
-        "protocol_id": 241
-      },
-      "minecraft:mangrove_wall_sign": {
-        "protocol_id": 219
-      },
-      "minecraft:mangrove_wood": {
-        "protocol_id": 78
-      },
-      "minecraft:medium_amethyst_bud": {
-        "protocol_id": 941
-      },
-      "minecraft:melon": {
-        "protocol_id": 330
-      },
-      "minecraft:melon_stem": {
-        "protocol_id": 334
-      },
-      "minecraft:moss_block": {
-        "protocol_id": 1052
-      },
-      "minecraft:moss_carpet": {
-        "protocol_id": 1048
-      },
-      "minecraft:mossy_cobblestone": {
-        "protocol_id": 179
-      },
-      "minecraft:mossy_cobblestone_slab": {
-        "protocol_id": 782
-      },
-      "minecraft:mossy_cobblestone_stairs": {
-        "protocol_id": 768
-      },
-      "minecraft:mossy_cobblestone_wall": {
-        "protocol_id": 379
-      },
-      "minecraft:mossy_stone_brick_slab": {
-        "protocol_id": 780
-      },
-      "minecraft:mossy_stone_brick_stairs": {
-        "protocol_id": 766
-      },
-      "minecraft:mossy_stone_brick_wall": {
-        "protocol_id": 794
-      },
-      "minecraft:mossy_stone_bricks": {
-        "protocol_id": 312
-      },
-      "minecraft:moving_piston": {
-        "protocol_id": 156
-      },
-      "minecraft:mud": {
-        "protocol_id": 1058
-      },
-      "minecraft:mud_brick_slab": {
-        "protocol_id": 586
-      },
-      "minecraft:mud_brick_stairs": {
-        "protocol_id": 341
-      },
-      "minecraft:mud_brick_wall": {
-        "protocol_id": 797
-      },
-      "minecraft:mud_bricks": {
-        "protocol_id": 316
-      },
-      "minecraft:muddy_mangrove_roots": {
-        "protocol_id": 59
-      },
-      "minecraft:mushroom_stem": {
-        "protocol_id": 325
-      },
-      "minecraft:mycelium": {
-        "protocol_id": 342
-      },
-      "minecraft:nether_brick_fence": {
-        "protocol_id": 351
-      },
-      "minecraft:nether_brick_slab": {
-        "protocol_id": 587
-      },
-      "minecraft:nether_brick_stairs": {
-        "protocol_id": 352
-      },
-      "minecraft:nether_brick_wall": {
-        "protocol_id": 798
-      },
-      "minecraft:nether_bricks": {
         "protocol_id": 350
       },
-      "minecraft:nether_gold_ore": {
-        "protocol_id": 48
+      "minecraft:jungle_trapdoor": {
+        "protocol_id": 288
       },
-      "minecraft:nether_portal": {
-        "protocol_id": 280
+      "minecraft:jungle_wall_hanging_sign": {
+        "protocol_id": 224
       },
-      "minecraft:nether_quartz_ore": {
-        "protocol_id": 444
+      "minecraft:jungle_wall_sign": {
+        "protocol_id": 204
       },
-      "minecraft:nether_sprouts": {
-        "protocol_id": 829
+      "minecraft:jungle_wood": {
+        "protocol_id": 69
       },
-      "minecraft:nether_wart": {
-        "protocol_id": 353
+      "minecraft:kelp": {
+        "protocol_id": 678
       },
-      "minecraft:nether_wart_block": {
-        "protocol_id": 640
+      "minecraft:kelp_plant": {
+        "protocol_id": 679
       },
-      "minecraft:netherite_block": {
-        "protocol_id": 874
+      "minecraft:ladder": {
+        "protocol_id": 196
       },
-      "minecraft:netherrack": {
+      "minecraft:lantern": {
+        "protocol_id": 784
+      },
+      "minecraft:lapis_block": {
+        "protocol_id": 97
+      },
+      "minecraft:lapis_ore": {
+        "protocol_id": 95
+      },
+      "minecraft:large_amethyst_bud": {
+        "protocol_id": 906
+      },
+      "minecraft:large_fern": {
+        "protocol_id": 502
+      },
+      "minecraft:lava": {
+        "protocol_id": 33
+      },
+      "minecraft:lava_cauldron": {
+        "protocol_id": 333
+      },
+      "minecraft:lectern": {
+        "protocol_id": 780
+      },
+      "minecraft:lever": {
+        "protocol_id": 230
+      },
+      "minecraft:light": {
+        "protocol_id": 465
+      },
+      "minecraft:light_blue_banner": {
+        "protocol_id": 506
+      },
+      "minecraft:light_blue_bed": {
+        "protocol_id": 106
+      },
+      "minecraft:light_blue_candle": {
+        "protocol_id": 873
+      },
+      "minecraft:light_blue_candle_cake": {
+        "protocol_id": 890
+      },
+      "minecraft:light_blue_carpet": {
+        "protocol_id": 481
+      },
+      "minecraft:light_blue_concrete": {
+        "protocol_id": 649
+      },
+      "minecraft:light_blue_concrete_powder": {
+        "protocol_id": 665
+      },
+      "minecraft:light_blue_glazed_terracotta": {
+        "protocol_id": 633
+      },
+      "minecraft:light_blue_shulker_box": {
+        "protocol_id": 617
+      },
+      "minecraft:light_blue_stained_glass": {
         "protocol_id": 272
       },
-      "minecraft:note_block": {
-        "protocol_id": 109
+      "minecraft:light_blue_stained_glass_pane": {
+        "protocol_id": 444
       },
-      "minecraft:oak_button": {
-        "protocol_id": 411
+      "minecraft:light_blue_terracotta": {
+        "protocol_id": 428
       },
-      "minecraft:oak_door": {
-        "protocol_id": 207
+      "minecraft:light_blue_wall_banner": {
+        "protocol_id": 522
       },
-      "minecraft:oak_fence": {
+      "minecraft:light_blue_wool": {
+        "protocol_id": 133
+      },
+      "minecraft:light_gray_banner": {
+        "protocol_id": 511
+      },
+      "minecraft:light_gray_bed": {
+        "protocol_id": 111
+      },
+      "minecraft:light_gray_candle": {
+        "protocol_id": 878
+      },
+      "minecraft:light_gray_candle_cake": {
+        "protocol_id": 895
+      },
+      "minecraft:light_gray_carpet": {
+        "protocol_id": 486
+      },
+      "minecraft:light_gray_concrete": {
+        "protocol_id": 654
+      },
+      "minecraft:light_gray_concrete_powder": {
+        "protocol_id": 670
+      },
+      "minecraft:light_gray_glazed_terracotta": {
+        "protocol_id": 638
+      },
+      "minecraft:light_gray_shulker_box": {
+        "protocol_id": 622
+      },
+      "minecraft:light_gray_stained_glass": {
+        "protocol_id": 277
+      },
+      "minecraft:light_gray_stained_glass_pane": {
+        "protocol_id": 449
+      },
+      "minecraft:light_gray_terracotta": {
+        "protocol_id": 433
+      },
+      "minecraft:light_gray_wall_banner": {
+        "protocol_id": 527
+      },
+      "minecraft:light_gray_wool": {
+        "protocol_id": 138
+      },
+      "minecraft:light_weighted_pressure_plate": {
+        "protocol_id": 412
+      },
+      "minecraft:lightning_rod": {
+        "protocol_id": 953
+      },
+      "minecraft:lilac": {
+        "protocol_id": 498
+      },
+      "minecraft:lily_of_the_valley": {
+        "protocol_id": 160
+      },
+      "minecraft:lily_pad": {
+        "protocol_id": 324
+      },
+      "minecraft:lime_banner": {
+        "protocol_id": 508
+      },
+      "minecraft:lime_bed": {
+        "protocol_id": 108
+      },
+      "minecraft:lime_candle": {
+        "protocol_id": 875
+      },
+      "minecraft:lime_candle_cake": {
+        "protocol_id": 892
+      },
+      "minecraft:lime_carpet": {
+        "protocol_id": 483
+      },
+      "minecraft:lime_concrete": {
+        "protocol_id": 651
+      },
+      "minecraft:lime_concrete_powder": {
+        "protocol_id": 667
+      },
+      "minecraft:lime_glazed_terracotta": {
+        "protocol_id": 635
+      },
+      "minecraft:lime_shulker_box": {
+        "protocol_id": 619
+      },
+      "minecraft:lime_stained_glass": {
+        "protocol_id": 274
+      },
+      "minecraft:lime_stained_glass_pane": {
+        "protocol_id": 446
+      },
+      "minecraft:lime_terracotta": {
+        "protocol_id": 430
+      },
+      "minecraft:lime_wall_banner": {
+        "protocol_id": 524
+      },
+      "minecraft:lime_wool": {
+        "protocol_id": 135
+      },
+      "minecraft:lodestone": {
+        "protocol_id": 848
+      },
+      "minecraft:loom": {
+        "protocol_id": 773
+      },
+      "minecraft:magenta_banner": {
+        "protocol_id": 505
+      },
+      "minecraft:magenta_bed": {
+        "protocol_id": 105
+      },
+      "minecraft:magenta_candle": {
+        "protocol_id": 872
+      },
+      "minecraft:magenta_candle_cake": {
+        "protocol_id": 889
+      },
+      "minecraft:magenta_carpet": {
+        "protocol_id": 480
+      },
+      "minecraft:magenta_concrete": {
+        "protocol_id": 648
+      },
+      "minecraft:magenta_concrete_powder": {
+        "protocol_id": 664
+      },
+      "minecraft:magenta_glazed_terracotta": {
+        "protocol_id": 632
+      },
+      "minecraft:magenta_shulker_box": {
+        "protocol_id": 616
+      },
+      "minecraft:magenta_stained_glass": {
         "protocol_id": 271
       },
+      "minecraft:magenta_stained_glass_pane": {
+        "protocol_id": 443
+      },
+      "minecraft:magenta_terracotta": {
+        "protocol_id": 427
+      },
+      "minecraft:magenta_wall_banner": {
+        "protocol_id": 521
+      },
+      "minecraft:magenta_wool": {
+        "protocol_id": 132
+      },
+      "minecraft:magma_block": {
+        "protocol_id": 607
+      },
+      "minecraft:mangrove_button": {
+        "protocol_id": 392
+      },
+      "minecraft:mangrove_door": {
+        "protocol_id": 589
+      },
+      "minecraft:mangrove_fence": {
+        "protocol_id": 581
+      },
+      "minecraft:mangrove_fence_gate": {
+        "protocol_id": 573
+      },
+      "minecraft:mangrove_hanging_sign": {
+        "protocol_id": 217
+      },
+      "minecraft:mangrove_leaves": {
+        "protocol_id": 89
+      },
+      "minecraft:mangrove_log": {
+        "protocol_id": 53
+      },
+      "minecraft:mangrove_planks": {
+        "protocol_id": 20
+      },
+      "minecraft:mangrove_pressure_plate": {
+        "protocol_id": 240
+      },
+      "minecraft:mangrove_propagule": {
+        "protocol_id": 30
+      },
+      "minecraft:mangrove_roots": {
+        "protocol_id": 54
+      },
+      "minecraft:mangrove_sign": {
+        "protocol_id": 193
+      },
+      "minecraft:mangrove_slab": {
+        "protocol_id": 546
+      },
+      "minecraft:mangrove_stairs": {
+        "protocol_id": 460
+      },
+      "minecraft:mangrove_trapdoor": {
+        "protocol_id": 292
+      },
+      "minecraft:mangrove_wall_hanging_sign": {
+        "protocol_id": 226
+      },
+      "minecraft:mangrove_wall_sign": {
+        "protocol_id": 206
+      },
+      "minecraft:mangrove_wood": {
+        "protocol_id": 73
+      },
+      "minecraft:medium_amethyst_bud": {
+        "protocol_id": 907
+      },
+      "minecraft:melon": {
+        "protocol_id": 312
+      },
+      "minecraft:melon_stem": {
+        "protocol_id": 316
+      },
+      "minecraft:moss_block": {
+        "protocol_id": 963
+      },
+      "minecraft:moss_carpet": {
+        "protocol_id": 961
+      },
+      "minecraft:mossy_cobblestone": {
+        "protocol_id": 169
+      },
+      "minecraft:mossy_cobblestone_slab": {
+        "protocol_id": 750
+      },
+      "minecraft:mossy_cobblestone_stairs": {
+        "protocol_id": 736
+      },
+      "minecraft:mossy_cobblestone_wall": {
+        "protocol_id": 354
+      },
+      "minecraft:mossy_stone_brick_slab": {
+        "protocol_id": 748
+      },
+      "minecraft:mossy_stone_brick_stairs": {
+        "protocol_id": 734
+      },
+      "minecraft:mossy_stone_brick_wall": {
+        "protocol_id": 762
+      },
+      "minecraft:mossy_stone_bricks": {
+        "protocol_id": 295
+      },
+      "minecraft:moving_piston": {
+        "protocol_id": 146
+      },
+      "minecraft:mud": {
+        "protocol_id": 969
+      },
+      "minecraft:mud_brick_slab": {
+        "protocol_id": 557
+      },
+      "minecraft:mud_brick_stairs": {
+        "protocol_id": 322
+      },
+      "minecraft:mud_brick_wall": {
+        "protocol_id": 765
+      },
+      "minecraft:mud_bricks": {
+        "protocol_id": 299
+      },
+      "minecraft:muddy_mangrove_roots": {
+        "protocol_id": 55
+      },
+      "minecraft:mushroom_stem": {
+        "protocol_id": 308
+      },
+      "minecraft:mycelium": {
+        "protocol_id": 323
+      },
+      "minecraft:nether_brick_fence": {
+        "protocol_id": 326
+      },
+      "minecraft:nether_brick_slab": {
+        "protocol_id": 558
+      },
+      "minecraft:nether_brick_stairs": {
+        "protocol_id": 327
+      },
+      "minecraft:nether_brick_wall": {
+        "protocol_id": 766
+      },
+      "minecraft:nether_bricks": {
+        "protocol_id": 325
+      },
+      "minecraft:nether_gold_ore": {
+        "protocol_id": 45
+      },
+      "minecraft:nether_portal": {
+        "protocol_id": 264
+      },
+      "minecraft:nether_quartz_ore": {
+        "protocol_id": 417
+      },
+      "minecraft:nether_sprouts": {
+        "protocol_id": 797
+      },
+      "minecraft:nether_wart": {
+        "protocol_id": 328
+      },
+      "minecraft:nether_wart_block": {
+        "protocol_id": 608
+      },
+      "minecraft:netherite_block": {
+        "protocol_id": 840
+      },
+      "minecraft:netherrack": {
+        "protocol_id": 256
+      },
+      "minecraft:note_block": {
+        "protocol_id": 102
+      },
+      "minecraft:oak_button": {
+        "protocol_id": 385
+      },
+      "minecraft:oak_door": {
+        "protocol_id": 195
+      },
+      "minecraft:oak_fence": {
+        "protocol_id": 254
+      },
       "minecraft:oak_fence_gate": {
-        "protocol_id": 338
+        "protocol_id": 319
       },
       "minecraft:oak_hanging_sign": {
-        "protocol_id": 221
+        "protocol_id": 208
       },
       "minecraft:oak_leaves": {
-        "protocol_id": 88
+        "protocol_id": 82
       },
       "minecraft:oak_log": {
-        "protocol_id": 49
+        "protocol_id": 46
       },
       "minecraft:oak_planks": {
         "protocol_id": 13
       },
       "minecraft:oak_pressure_plate": {
-        "protocol_id": 248
-      },
-      "minecraft:oak_sapling": {
-        "protocol_id": 25
-      },
-      "minecraft:oak_sign": {
-        "protocol_id": 197
-      },
-      "minecraft:oak_slab": {
-        "protocol_id": 567
-      },
-      "minecraft:oak_stairs": {
-        "protocol_id": 187
-      },
-      "minecraft:oak_trapdoor": {
-        "protocol_id": 301
-      },
-      "minecraft:oak_wall_hanging_sign": {
         "protocol_id": 233
       },
+      "minecraft:oak_sapling": {
+        "protocol_id": 23
+      },
+      "minecraft:oak_sign": {
+        "protocol_id": 186
+      },
+      "minecraft:oak_slab": {
+        "protocol_id": 539
+      },
+      "minecraft:oak_stairs": {
+        "protocol_id": 176
+      },
+      "minecraft:oak_trapdoor": {
+        "protocol_id": 285
+      },
+      "minecraft:oak_wall_hanging_sign": {
+        "protocol_id": 219
+      },
       "minecraft:oak_wall_sign": {
-        "protocol_id": 211
+        "protocol_id": 199
       },
       "minecraft:oak_wood": {
-        "protocol_id": 71
+        "protocol_id": 66
       },
       "minecraft:observer": {
-        "protocol_id": 644
+        "protocol_id": 612
       },
       "minecraft:obsidian": {
-        "protocol_id": 180
+        "protocol_id": 170
       },
       "minecraft:ochre_froglight": {
-        "protocol_id": 1086
-      },
-      "minecraft:open_eyeblossom": {
-        "protocol_id": 1099
+        "protocol_id": 997
       },
       "minecraft:orange_banner": {
-        "protocol_id": 532
+        "protocol_id": 504
       },
       "minecraft:orange_bed": {
-        "protocol_id": 111
+        "protocol_id": 104
       },
       "minecraft:orange_candle": {
-        "protocol_id": 905
+        "protocol_id": 871
       },
       "minecraft:orange_candle_cake": {
-        "protocol_id": 922
+        "protocol_id": 888
       },
       "minecraft:orange_carpet": {
-        "protocol_id": 507
+        "protocol_id": 479
       },
       "minecraft:orange_concrete": {
-        "protocol_id": 679
-      },
-      "minecraft:orange_concrete_powder": {
-        "protocol_id": 695
-      },
-      "minecraft:orange_glazed_terracotta": {
-        "protocol_id": 663
-      },
-      "minecraft:orange_shulker_box": {
         "protocol_id": 647
       },
-      "minecraft:orange_stained_glass": {
-        "protocol_id": 286
+      "minecraft:orange_concrete_powder": {
+        "protocol_id": 663
       },
-      "minecraft:orange_stained_glass_pane": {
-        "protocol_id": 469
-      },
-      "minecraft:orange_terracotta": {
-        "protocol_id": 453
-      },
-      "minecraft:orange_tulip": {
-        "protocol_id": 164
-      },
-      "minecraft:orange_wall_banner": {
-        "protocol_id": 548
-      },
-      "minecraft:orange_wool": {
-        "protocol_id": 141
-      },
-      "minecraft:oxeye_daisy": {
-        "protocol_id": 167
-      },
-      "minecraft:oxidized_chiseled_copper": {
-        "protocol_id": 976
-      },
-      "minecraft:oxidized_copper": {
-        "protocol_id": 969
-      },
-      "minecraft:oxidized_copper_bulb": {
-        "protocol_id": 1035
-      },
-      "minecraft:oxidized_copper_door": {
-        "protocol_id": 1010
-      },
-      "minecraft:oxidized_copper_grate": {
-        "protocol_id": 1027
-      },
-      "minecraft:oxidized_copper_trapdoor": {
-        "protocol_id": 1018
-      },
-      "minecraft:oxidized_cut_copper": {
-        "protocol_id": 972
-      },
-      "minecraft:oxidized_cut_copper_slab": {
-        "protocol_id": 988
-      },
-      "minecraft:oxidized_cut_copper_stairs": {
-        "protocol_id": 984
-      },
-      "minecraft:packed_ice": {
-        "protocol_id": 524
-      },
-      "minecraft:packed_mud": {
-        "protocol_id": 315
-      },
-      "minecraft:pale_hanging_moss": {
-        "protocol_id": 1098
-      },
-      "minecraft:pale_moss_block": {
-        "protocol_id": 1096
-      },
-      "minecraft:pale_moss_carpet": {
-        "protocol_id": 1097
-      },
-      "minecraft:pale_oak_button": {
-        "protocol_id": 418
-      },
-      "minecraft:pale_oak_door": {
-        "protocol_id": 620
-      },
-      "minecraft:pale_oak_fence": {
-        "protocol_id": 611
-      },
-      "minecraft:pale_oak_fence_gate": {
-        "protocol_id": 602
-      },
-      "minecraft:pale_oak_hanging_sign": {
-        "protocol_id": 228
-      },
-      "minecraft:pale_oak_leaves": {
-        "protocol_id": 95
-      },
-      "minecraft:pale_oak_log": {
-        "protocol_id": 56
-      },
-      "minecraft:pale_oak_planks": {
-        "protocol_id": 21
-      },
-      "minecraft:pale_oak_pressure_plate": {
-        "protocol_id": 255
-      },
-      "minecraft:pale_oak_sapling": {
-        "protocol_id": 32
-      },
-      "minecraft:pale_oak_sign": {
-        "protocol_id": 204
-      },
-      "minecraft:pale_oak_slab": {
-        "protocol_id": 574
-      },
-      "minecraft:pale_oak_stairs": {
-        "protocol_id": 487
-      },
-      "minecraft:pale_oak_trapdoor": {
-        "protocol_id": 308
-      },
-      "minecraft:pale_oak_wall_hanging_sign": {
-        "protocol_id": 240
-      },
-      "minecraft:pale_oak_wall_sign": {
-        "protocol_id": 218
-      },
-      "minecraft:pale_oak_wood": {
-        "protocol_id": 20
-      },
-      "minecraft:pearlescent_froglight": {
-        "protocol_id": 1088
-      },
-      "minecraft:peony": {
-        "protocol_id": 528
-      },
-      "minecraft:petrified_oak_slab": {
-        "protocol_id": 582
-      },
-      "minecraft:piglin_head": {
-        "protocol_id": 433
-      },
-      "minecraft:piglin_wall_head": {
-        "protocol_id": 434
-      },
-      "minecraft:pink_banner": {
-        "protocol_id": 537
-      },
-      "minecraft:pink_bed": {
-        "protocol_id": 116
-      },
-      "minecraft:pink_candle": {
-        "protocol_id": 910
-      },
-      "minecraft:pink_candle_cake": {
-        "protocol_id": 927
-      },
-      "minecraft:pink_carpet": {
-        "protocol_id": 512
-      },
-      "minecraft:pink_concrete": {
-        "protocol_id": 684
-      },
-      "minecraft:pink_concrete_powder": {
-        "protocol_id": 700
-      },
-      "minecraft:pink_glazed_terracotta": {
-        "protocol_id": 668
-      },
-      "minecraft:pink_petals": {
-        "protocol_id": 1049
-      },
-      "minecraft:pink_shulker_box": {
-        "protocol_id": 652
-      },
-      "minecraft:pink_stained_glass": {
-        "protocol_id": 291
-      },
-      "minecraft:pink_stained_glass_pane": {
-        "protocol_id": 474
-      },
-      "minecraft:pink_terracotta": {
-        "protocol_id": 458
-      },
-      "minecraft:pink_tulip": {
-        "protocol_id": 166
-      },
-      "minecraft:pink_wall_banner": {
-        "protocol_id": 553
-      },
-      "minecraft:pink_wool": {
-        "protocol_id": 146
-      },
-      "minecraft:piston": {
-        "protocol_id": 138
-      },
-      "minecraft:piston_head": {
-        "protocol_id": 139
-      },
-      "minecraft:pitcher_crop": {
+      "minecraft:orange_glazed_terracotta": {
         "protocol_id": 631
       },
+      "minecraft:orange_shulker_box": {
+        "protocol_id": 615
+      },
+      "minecraft:orange_stained_glass": {
+        "protocol_id": 270
+      },
+      "minecraft:orange_stained_glass_pane": {
+        "protocol_id": 442
+      },
+      "minecraft:orange_terracotta": {
+        "protocol_id": 426
+      },
+      "minecraft:orange_tulip": {
+        "protocol_id": 154
+      },
+      "minecraft:orange_wall_banner": {
+        "protocol_id": 520
+      },
+      "minecraft:orange_wool": {
+        "protocol_id": 131
+      },
+      "minecraft:oxeye_daisy": {
+        "protocol_id": 157
+      },
+      "minecraft:oxidized_copper": {
+        "protocol_id": 919
+      },
+      "minecraft:oxidized_cut_copper": {
+        "protocol_id": 925
+      },
+      "minecraft:oxidized_cut_copper_slab": {
+        "protocol_id": 933
+      },
+      "minecraft:oxidized_cut_copper_stairs": {
+        "protocol_id": 929
+      },
+      "minecraft:packed_ice": {
+        "protocol_id": 496
+      },
+      "minecraft:packed_mud": {
+        "protocol_id": 298
+      },
+      "minecraft:pearlescent_froglight": {
+        "protocol_id": 999
+      },
+      "minecraft:peony": {
+        "protocol_id": 500
+      },
+      "minecraft:petrified_oak_slab": {
+        "protocol_id": 553
+      },
+      "minecraft:piglin_head": {
+        "protocol_id": 406
+      },
+      "minecraft:piglin_wall_head": {
+        "protocol_id": 407
+      },
+      "minecraft:pink_banner": {
+        "protocol_id": 509
+      },
+      "minecraft:pink_bed": {
+        "protocol_id": 109
+      },
+      "minecraft:pink_candle": {
+        "protocol_id": 876
+      },
+      "minecraft:pink_candle_cake": {
+        "protocol_id": 893
+      },
+      "minecraft:pink_carpet": {
+        "protocol_id": 484
+      },
+      "minecraft:pink_concrete": {
+        "protocol_id": 652
+      },
+      "minecraft:pink_concrete_powder": {
+        "protocol_id": 668
+      },
+      "minecraft:pink_glazed_terracotta": {
+        "protocol_id": 636
+      },
+      "minecraft:pink_petals": {
+        "protocol_id": 962
+      },
+      "minecraft:pink_shulker_box": {
+        "protocol_id": 620
+      },
+      "minecraft:pink_stained_glass": {
+        "protocol_id": 275
+      },
+      "minecraft:pink_stained_glass_pane": {
+        "protocol_id": 447
+      },
+      "minecraft:pink_terracotta": {
+        "protocol_id": 431
+      },
+      "minecraft:pink_tulip": {
+        "protocol_id": 156
+      },
+      "minecraft:pink_wall_banner": {
+        "protocol_id": 525
+      },
+      "minecraft:pink_wool": {
+        "protocol_id": 136
+      },
+      "minecraft:piston": {
+        "protocol_id": 128
+      },
+      "minecraft:piston_head": {
+        "protocol_id": 129
+      },
+      "minecraft:pitcher_crop": {
+        "protocol_id": 599
+      },
       "minecraft:pitcher_plant": {
-        "protocol_id": 632
+        "protocol_id": 600
       },
       "minecraft:player_head": {
-        "protocol_id": 427
+        "protocol_id": 400
       },
       "minecraft:player_wall_head": {
-        "protocol_id": 428
+        "protocol_id": 401
       },
       "minecraft:podzol": {
         "protocol_id": 11
       },
       "minecraft:pointed_dripstone": {
-        "protocol_id": 1041
+        "protocol_id": 954
       },
       "minecraft:polished_andesite": {
         "protocol_id": 7
       },
       "minecraft:polished_andesite_slab": {
-        "protocol_id": 789
+        "protocol_id": 757
       },
       "minecraft:polished_andesite_stairs": {
-        "protocol_id": 776
+        "protocol_id": 744
       },
       "minecraft:polished_basalt": {
-        "protocol_id": 276
+        "protocol_id": 260
       },
       "minecraft:polished_blackstone": {
-        "protocol_id": 887
+        "protocol_id": 853
       },
       "minecraft:polished_blackstone_brick_slab": {
-        "protocol_id": 891
+        "protocol_id": 857
       },
       "minecraft:polished_blackstone_brick_stairs": {
-        "protocol_id": 892
+        "protocol_id": 858
       },
       "minecraft:polished_blackstone_brick_wall": {
-        "protocol_id": 893
+        "protocol_id": 859
       },
       "minecraft:polished_blackstone_bricks": {
-        "protocol_id": 888
+        "protocol_id": 854
       },
       "minecraft:polished_blackstone_button": {
-        "protocol_id": 898
+        "protocol_id": 864
       },
       "minecraft:polished_blackstone_pressure_plate": {
-        "protocol_id": 897
+        "protocol_id": 863
       },
       "minecraft:polished_blackstone_slab": {
-        "protocol_id": 896
+        "protocol_id": 862
       },
       "minecraft:polished_blackstone_stairs": {
-        "protocol_id": 895
+        "protocol_id": 861
       },
       "minecraft:polished_blackstone_wall": {
-        "protocol_id": 899
+        "protocol_id": 865
       },
       "minecraft:polished_deepslate": {
-        "protocol_id": 1064
+        "protocol_id": 975
       },
       "minecraft:polished_deepslate_slab": {
-        "protocol_id": 1066
+        "protocol_id": 977
       },
       "minecraft:polished_deepslate_stairs": {
-        "protocol_id": 1065
+        "protocol_id": 976
       },
       "minecraft:polished_deepslate_wall": {
-        "protocol_id": 1067
+        "protocol_id": 978
       },
       "minecraft:polished_diorite": {
         "protocol_id": 5
       },
       "minecraft:polished_diorite_slab": {
-        "protocol_id": 781
+        "protocol_id": 749
       },
       "minecraft:polished_diorite_stairs": {
-        "protocol_id": 767
+        "protocol_id": 735
       },
       "minecraft:polished_granite": {
         "protocol_id": 3
       },
       "minecraft:polished_granite_slab": {
-        "protocol_id": 778
+        "protocol_id": 746
       },
       "minecraft:polished_granite_stairs": {
-        "protocol_id": 764
-      },
-      "minecraft:polished_tuff": {
-        "protocol_id": 947
-      },
-      "minecraft:polished_tuff_slab": {
-        "protocol_id": 948
-      },
-      "minecraft:polished_tuff_stairs": {
-        "protocol_id": 949
-      },
-      "minecraft:polished_tuff_wall": {
-        "protocol_id": 950
+        "protocol_id": 732
       },
       "minecraft:poppy": {
-        "protocol_id": 159
+        "protocol_id": 149
       },
       "minecraft:potatoes": {
-        "protocol_id": 410
-      },
-      "minecraft:potted_acacia_sapling": {
-        "protocol_id": 386
-      },
-      "minecraft:potted_allium": {
-        "protocol_id": 395
-      },
-      "minecraft:potted_azalea_bush": {
-        "protocol_id": 1084
-      },
-      "minecraft:potted_azure_bluet": {
-        "protocol_id": 396
-      },
-      "minecraft:potted_bamboo": {
-        "protocol_id": 760
-      },
-      "minecraft:potted_birch_sapling": {
         "protocol_id": 384
       },
-      "minecraft:potted_blue_orchid": {
-        "protocol_id": 394
+      "minecraft:potted_acacia_sapling": {
+        "protocol_id": 361
       },
-      "minecraft:potted_brown_mushroom": {
-        "protocol_id": 406
+      "minecraft:potted_allium": {
+        "protocol_id": 369
       },
-      "minecraft:potted_cactus": {
-        "protocol_id": 408
+      "minecraft:potted_azalea_bush": {
+        "protocol_id": 995
       },
-      "minecraft:potted_cherry_sapling": {
-        "protocol_id": 387
+      "minecraft:potted_azure_bluet": {
+        "protocol_id": 370
       },
-      "minecraft:potted_closed_eyeblossom": {
-        "protocol_id": 1102
+      "minecraft:potted_bamboo": {
+        "protocol_id": 728
       },
-      "minecraft:potted_cornflower": {
-        "protocol_id": 402
-      },
-      "minecraft:potted_crimson_fungus": {
-        "protocol_id": 878
-      },
-      "minecraft:potted_crimson_roots": {
-        "protocol_id": 880
-      },
-      "minecraft:potted_dandelion": {
-        "protocol_id": 392
-      },
-      "minecraft:potted_dark_oak_sapling": {
-        "protocol_id": 388
-      },
-      "minecraft:potted_dead_bush": {
-        "protocol_id": 407
-      },
-      "minecraft:potted_fern": {
-        "protocol_id": 391
-      },
-      "minecraft:potted_flowering_azalea_bush": {
-        "protocol_id": 1085
-      },
-      "minecraft:potted_jungle_sapling": {
-        "protocol_id": 385
-      },
-      "minecraft:potted_lily_of_the_valley": {
-        "protocol_id": 403
-      },
-      "minecraft:potted_mangrove_propagule": {
-        "protocol_id": 390
-      },
-      "minecraft:potted_oak_sapling": {
-        "protocol_id": 382
-      },
-      "minecraft:potted_open_eyeblossom": {
-        "protocol_id": 1101
-      },
-      "minecraft:potted_orange_tulip": {
-        "protocol_id": 398
-      },
-      "minecraft:potted_oxeye_daisy": {
-        "protocol_id": 401
-      },
-      "minecraft:potted_pale_oak_sapling": {
-        "protocol_id": 389
-      },
-      "minecraft:potted_pink_tulip": {
-        "protocol_id": 400
-      },
-      "minecraft:potted_poppy": {
-        "protocol_id": 393
-      },
-      "minecraft:potted_red_mushroom": {
-        "protocol_id": 405
-      },
-      "minecraft:potted_red_tulip": {
-        "protocol_id": 397
-      },
-      "minecraft:potted_spruce_sapling": {
-        "protocol_id": 383
-      },
-      "minecraft:potted_torchflower": {
-        "protocol_id": 381
-      },
-      "minecraft:potted_warped_fungus": {
-        "protocol_id": 879
-      },
-      "minecraft:potted_warped_roots": {
-        "protocol_id": 881
-      },
-      "minecraft:potted_white_tulip": {
-        "protocol_id": 399
-      },
-      "minecraft:potted_wither_rose": {
-        "protocol_id": 404
-      },
-      "minecraft:powder_snow": {
-        "protocol_id": 959
-      },
-      "minecraft:powder_snow_cauldron": {
+      "minecraft:potted_birch_sapling": {
         "protocol_id": 359
       },
-      "minecraft:powered_rail": {
-        "protocol_id": 126
+      "minecraft:potted_blue_orchid": {
+        "protocol_id": 368
       },
-      "minecraft:prismarine": {
-        "protocol_id": 495
+      "minecraft:potted_brown_mushroom": {
+        "protocol_id": 380
       },
-      "minecraft:prismarine_brick_slab": {
-        "protocol_id": 502
+      "minecraft:potted_cactus": {
+        "protocol_id": 382
       },
-      "minecraft:prismarine_brick_stairs": {
-        "protocol_id": 499
+      "minecraft:potted_cherry_sapling": {
+        "protocol_id": 362
       },
-      "minecraft:prismarine_bricks": {
-        "protocol_id": 496
+      "minecraft:potted_cornflower": {
+        "protocol_id": 376
       },
-      "minecraft:prismarine_slab": {
-        "protocol_id": 501
+      "minecraft:potted_crimson_fungus": {
+        "protocol_id": 844
       },
-      "minecraft:prismarine_stairs": {
-        "protocol_id": 498
+      "minecraft:potted_crimson_roots": {
+        "protocol_id": 846
       },
-      "minecraft:prismarine_wall": {
-        "protocol_id": 792
-      },
-      "minecraft:pumpkin": {
-        "protocol_id": 329
-      },
-      "minecraft:pumpkin_stem": {
-        "protocol_id": 333
-      },
-      "minecraft:purple_banner": {
-        "protocol_id": 541
-      },
-      "minecraft:purple_bed": {
-        "protocol_id": 120
-      },
-      "minecraft:purple_candle": {
-        "protocol_id": 914
-      },
-      "minecraft:purple_candle_cake": {
-        "protocol_id": 931
-      },
-      "minecraft:purple_carpet": {
-        "protocol_id": 516
-      },
-      "minecraft:purple_concrete": {
-        "protocol_id": 688
-      },
-      "minecraft:purple_concrete_powder": {
-        "protocol_id": 704
-      },
-      "minecraft:purple_glazed_terracotta": {
-        "protocol_id": 672
-      },
-      "minecraft:purple_shulker_box": {
-        "protocol_id": 656
-      },
-      "minecraft:purple_stained_glass": {
-        "protocol_id": 295
-      },
-      "minecraft:purple_stained_glass_pane": {
-        "protocol_id": 478
-      },
-      "minecraft:purple_terracotta": {
-        "protocol_id": 462
-      },
-      "minecraft:purple_wall_banner": {
-        "protocol_id": 557
-      },
-      "minecraft:purple_wool": {
-        "protocol_id": 150
-      },
-      "minecraft:purpur_block": {
-        "protocol_id": 626
-      },
-      "minecraft:purpur_pillar": {
-        "protocol_id": 627
-      },
-      "minecraft:purpur_slab": {
-        "protocol_id": 591
-      },
-      "minecraft:purpur_stairs": {
-        "protocol_id": 628
-      },
-      "minecraft:quartz_block": {
-        "protocol_id": 446
-      },
-      "minecraft:quartz_bricks": {
-        "protocol_id": 902
-      },
-      "minecraft:quartz_pillar": {
-        "protocol_id": 448
-      },
-      "minecraft:quartz_slab": {
-        "protocol_id": 588
-      },
-      "minecraft:quartz_stairs": {
-        "protocol_id": 449
-      },
-      "minecraft:rail": {
-        "protocol_id": 209
-      },
-      "minecraft:raw_copper_block": {
-        "protocol_id": 1082
-      },
-      "minecraft:raw_gold_block": {
-        "protocol_id": 1083
-      },
-      "minecraft:raw_iron_block": {
-        "protocol_id": 1081
-      },
-      "minecraft:red_banner": {
-        "protocol_id": 545
-      },
-      "minecraft:red_bed": {
-        "protocol_id": 124
-      },
-      "minecraft:red_candle": {
-        "protocol_id": 918
-      },
-      "minecraft:red_candle_cake": {
-        "protocol_id": 935
-      },
-      "minecraft:red_carpet": {
-        "protocol_id": 520
-      },
-      "minecraft:red_concrete": {
-        "protocol_id": 692
-      },
-      "minecraft:red_concrete_powder": {
-        "protocol_id": 708
-      },
-      "minecraft:red_glazed_terracotta": {
-        "protocol_id": 676
-      },
-      "minecraft:red_mushroom": {
-        "protocol_id": 172
-      },
-      "minecraft:red_mushroom_block": {
-        "protocol_id": 324
-      },
-      "minecraft:red_nether_brick_slab": {
-        "protocol_id": 788
-      },
-      "minecraft:red_nether_brick_stairs": {
-        "protocol_id": 775
-      },
-      "minecraft:red_nether_brick_wall": {
-        "protocol_id": 800
-      },
-      "minecraft:red_nether_bricks": {
-        "protocol_id": 641
-      },
-      "minecraft:red_sand": {
-        "protocol_id": 39
-      },
-      "minecraft:red_sandstone": {
-        "protocol_id": 563
-      },
-      "minecraft:red_sandstone_slab": {
-        "protocol_id": 589
-      },
-      "minecraft:red_sandstone_stairs": {
-        "protocol_id": 566
-      },
-      "minecraft:red_sandstone_wall": {
-        "protocol_id": 793
-      },
-      "minecraft:red_shulker_box": {
-        "protocol_id": 660
-      },
-      "minecraft:red_stained_glass": {
-        "protocol_id": 299
-      },
-      "minecraft:red_stained_glass_pane": {
-        "protocol_id": 482
-      },
-      "minecraft:red_terracotta": {
-        "protocol_id": 466
-      },
-      "minecraft:red_tulip": {
-        "protocol_id": 163
-      },
-      "minecraft:red_wall_banner": {
-        "protocol_id": 561
-      },
-      "minecraft:red_wool": {
-        "protocol_id": 154
-      },
-      "minecraft:redstone_block": {
-        "protocol_id": 443
-      },
-      "minecraft:redstone_lamp": {
-        "protocol_id": 364
-      },
-      "minecraft:redstone_ore": {
-        "protocol_id": 258
-      },
-      "minecraft:redstone_torch": {
-        "protocol_id": 260
-      },
-      "minecraft:redstone_wall_torch": {
-        "protocol_id": 261
-      },
-      "minecraft:redstone_wire": {
-        "protocol_id": 189
-      },
-      "minecraft:reinforced_deepslate": {
-        "protocol_id": 1090
-      },
-      "minecraft:repeater": {
-        "protocol_id": 284
-      },
-      "minecraft:repeating_command_block": {
-        "protocol_id": 636
-      },
-      "minecraft:resin_block": {
-        "protocol_id": 344
-      },
-      "minecraft:resin_brick_slab": {
-        "protocol_id": 347
-      },
-      "minecraft:resin_brick_stairs": {
-        "protocol_id": 346
-      },
-      "minecraft:resin_brick_wall": {
-        "protocol_id": 348
-      },
-      "minecraft:resin_bricks": {
-        "protocol_id": 345
-      },
-      "minecraft:resin_clump": {
-        "protocol_id": 337
-      },
-      "minecraft:respawn_anchor": {
-        "protocol_id": 877
-      },
-      "minecraft:rooted_dirt": {
-        "protocol_id": 1057
-      },
-      "minecraft:rose_bush": {
-        "protocol_id": 527
-      },
-      "minecraft:sand": {
-        "protocol_id": 37
-      },
-      "minecraft:sandstone": {
-        "protocol_id": 106
-      },
-      "minecraft:sandstone_slab": {
-        "protocol_id": 580
-      },
-      "minecraft:sandstone_stairs": {
+      "minecraft:potted_dandelion": {
         "protocol_id": 366
       },
-      "minecraft:sandstone_wall": {
-        "protocol_id": 801
+      "minecraft:potted_dark_oak_sapling": {
+        "protocol_id": 363
       },
-      "minecraft:scaffolding": {
-        "protocol_id": 804
+      "minecraft:potted_dead_bush": {
+        "protocol_id": 381
       },
-      "minecraft:sculk": {
-        "protocol_id": 962
+      "minecraft:potted_fern": {
+        "protocol_id": 365
       },
-      "minecraft:sculk_catalyst": {
-        "protocol_id": 964
+      "minecraft:potted_flowering_azalea_bush": {
+        "protocol_id": 996
       },
-      "minecraft:sculk_sensor": {
-        "protocol_id": 960
+      "minecraft:potted_jungle_sapling": {
+        "protocol_id": 360
       },
-      "minecraft:sculk_shrieker": {
-        "protocol_id": 965
+      "minecraft:potted_lily_of_the_valley": {
+        "protocol_id": 377
       },
-      "minecraft:sculk_vein": {
-        "protocol_id": 963
+      "minecraft:potted_mangrove_propagule": {
+        "protocol_id": 364
       },
-      "minecraft:sea_lantern": {
-        "protocol_id": 504
+      "minecraft:potted_oak_sapling": {
+        "protocol_id": 357
       },
-      "minecraft:sea_pickle": {
-        "protocol_id": 755
+      "minecraft:potted_orange_tulip": {
+        "protocol_id": 372
       },
-      "minecraft:seagrass": {
-        "protocol_id": 136
+      "minecraft:potted_oxeye_daisy": {
+        "protocol_id": 375
       },
-      "minecraft:short_dry_grass": {
-        "protocol_id": 134
+      "minecraft:potted_pink_tulip": {
+        "protocol_id": 374
       },
-      "minecraft:short_grass": {
-        "protocol_id": 130
+      "minecraft:potted_poppy": {
+        "protocol_id": 367
       },
-      "minecraft:shroomlight": {
-        "protocol_id": 836
+      "minecraft:potted_red_mushroom": {
+        "protocol_id": 379
       },
-      "minecraft:shulker_box": {
-        "protocol_id": 645
+      "minecraft:potted_red_tulip": {
+        "protocol_id": 371
       },
-      "minecraft:skeleton_skull": {
-        "protocol_id": 421
+      "minecraft:potted_spruce_sapling": {
+        "protocol_id": 358
       },
-      "minecraft:skeleton_wall_skull": {
-        "protocol_id": 422
+      "minecraft:potted_torchflower": {
+        "protocol_id": 356
       },
-      "minecraft:slime_block": {
-        "protocol_id": 491
+      "minecraft:potted_warped_fungus": {
+        "protocol_id": 845
       },
-      "minecraft:small_amethyst_bud": {
-        "protocol_id": 942
+      "minecraft:potted_warped_roots": {
+        "protocol_id": 847
       },
-      "minecraft:small_dripleaf": {
-        "protocol_id": 1055
+      "minecraft:potted_white_tulip": {
+        "protocol_id": 373
       },
-      "minecraft:smithing_table": {
-        "protocol_id": 813
+      "minecraft:potted_wither_rose": {
+        "protocol_id": 378
       },
-      "minecraft:smoker": {
-        "protocol_id": 807
+      "minecraft:powder_snow": {
+        "protocol_id": 912
       },
-      "minecraft:smooth_basalt": {
-        "protocol_id": 1080
+      "minecraft:powder_snow_cauldron": {
+        "protocol_id": 334
       },
-      "minecraft:smooth_quartz": {
+      "minecraft:powered_rail": {
+        "protocol_id": 119
+      },
+      "minecraft:prismarine": {
+        "protocol_id": 467
+      },
+      "minecraft:prismarine_brick_slab": {
+        "protocol_id": 474
+      },
+      "minecraft:prismarine_brick_stairs": {
+        "protocol_id": 471
+      },
+      "minecraft:prismarine_bricks": {
+        "protocol_id": 468
+      },
+      "minecraft:prismarine_slab": {
+        "protocol_id": 473
+      },
+      "minecraft:prismarine_stairs": {
+        "protocol_id": 470
+      },
+      "minecraft:prismarine_wall": {
+        "protocol_id": 760
+      },
+      "minecraft:pumpkin": {
+        "protocol_id": 255
+      },
+      "minecraft:pumpkin_stem": {
+        "protocol_id": 315
+      },
+      "minecraft:purple_banner": {
+        "protocol_id": 513
+      },
+      "minecraft:purple_bed": {
+        "protocol_id": 113
+      },
+      "minecraft:purple_candle": {
+        "protocol_id": 880
+      },
+      "minecraft:purple_candle_cake": {
+        "protocol_id": 897
+      },
+      "minecraft:purple_carpet": {
+        "protocol_id": 488
+      },
+      "minecraft:purple_concrete": {
+        "protocol_id": 656
+      },
+      "minecraft:purple_concrete_powder": {
+        "protocol_id": 672
+      },
+      "minecraft:purple_glazed_terracotta": {
+        "protocol_id": 640
+      },
+      "minecraft:purple_shulker_box": {
+        "protocol_id": 624
+      },
+      "minecraft:purple_stained_glass": {
+        "protocol_id": 279
+      },
+      "minecraft:purple_stained_glass_pane": {
+        "protocol_id": 451
+      },
+      "minecraft:purple_terracotta": {
+        "protocol_id": 435
+      },
+      "minecraft:purple_wall_banner": {
+        "protocol_id": 529
+      },
+      "minecraft:purple_wool": {
+        "protocol_id": 140
+      },
+      "minecraft:purpur_block": {
         "protocol_id": 594
       },
-      "minecraft:smooth_quartz_slab": {
-        "protocol_id": 785
-      },
-      "minecraft:smooth_quartz_stairs": {
-        "protocol_id": 772
-      },
-      "minecraft:smooth_red_sandstone": {
+      "minecraft:purpur_pillar": {
         "protocol_id": 595
       },
-      "minecraft:smooth_red_sandstone_slab": {
-        "protocol_id": 779
+      "minecraft:purpur_slab": {
+        "protocol_id": 562
       },
-      "minecraft:smooth_red_sandstone_stairs": {
-        "protocol_id": 765
-      },
-      "minecraft:smooth_sandstone": {
-        "protocol_id": 593
-      },
-      "minecraft:smooth_sandstone_slab": {
-        "protocol_id": 784
-      },
-      "minecraft:smooth_sandstone_stairs": {
-        "protocol_id": 771
-      },
-      "minecraft:smooth_stone": {
-        "protocol_id": 592
-      },
-      "minecraft:smooth_stone_slab": {
-        "protocol_id": 579
-      },
-      "minecraft:sniffer_egg": {
-        "protocol_id": 714
-      },
-      "minecraft:snow": {
-        "protocol_id": 263
-      },
-      "minecraft:snow_block": {
-        "protocol_id": 265
-      },
-      "minecraft:soul_campfire": {
-        "protocol_id": 819
-      },
-      "minecraft:soul_fire": {
-        "protocol_id": 184
-      },
-      "minecraft:soul_lantern": {
-        "protocol_id": 817
-      },
-      "minecraft:soul_sand": {
-        "protocol_id": 273
-      },
-      "minecraft:soul_soil": {
-        "protocol_id": 274
-      },
-      "minecraft:soul_torch": {
-        "protocol_id": 277
-      },
-      "minecraft:soul_wall_torch": {
-        "protocol_id": 278
-      },
-      "minecraft:spawner": {
-        "protocol_id": 185
-      },
-      "minecraft:sponge": {
-        "protocol_id": 99
-      },
-      "minecraft:spore_blossom": {
-        "protocol_id": 1045
-      },
-      "minecraft:spruce_button": {
-        "protocol_id": 412
-      },
-      "minecraft:spruce_door": {
-        "protocol_id": 614
-      },
-      "minecraft:spruce_fence": {
-        "protocol_id": 605
-      },
-      "minecraft:spruce_fence_gate": {
+      "minecraft:purpur_stairs": {
         "protocol_id": 596
       },
+      "minecraft:quartz_block": {
+        "protocol_id": 419
+      },
+      "minecraft:quartz_bricks": {
+        "protocol_id": 868
+      },
+      "minecraft:quartz_pillar": {
+        "protocol_id": 421
+      },
+      "minecraft:quartz_slab": {
+        "protocol_id": 559
+      },
+      "minecraft:quartz_stairs": {
+        "protocol_id": 422
+      },
+      "minecraft:rail": {
+        "protocol_id": 197
+      },
+      "minecraft:raw_copper_block": {
+        "protocol_id": 993
+      },
+      "minecraft:raw_gold_block": {
+        "protocol_id": 994
+      },
+      "minecraft:raw_iron_block": {
+        "protocol_id": 992
+      },
+      "minecraft:red_banner": {
+        "protocol_id": 517
+      },
+      "minecraft:red_bed": {
+        "protocol_id": 117
+      },
+      "minecraft:red_candle": {
+        "protocol_id": 884
+      },
+      "minecraft:red_candle_cake": {
+        "protocol_id": 901
+      },
+      "minecraft:red_carpet": {
+        "protocol_id": 492
+      },
+      "minecraft:red_concrete": {
+        "protocol_id": 660
+      },
+      "minecraft:red_concrete_powder": {
+        "protocol_id": 676
+      },
+      "minecraft:red_glazed_terracotta": {
+        "protocol_id": 644
+      },
+      "minecraft:red_mushroom": {
+        "protocol_id": 162
+      },
+      "minecraft:red_mushroom_block": {
+        "protocol_id": 307
+      },
+      "minecraft:red_nether_brick_slab": {
+        "protocol_id": 756
+      },
+      "minecraft:red_nether_brick_stairs": {
+        "protocol_id": 743
+      },
+      "minecraft:red_nether_brick_wall": {
+        "protocol_id": 768
+      },
+      "minecraft:red_nether_bricks": {
+        "protocol_id": 609
+      },
+      "minecraft:red_sand": {
+        "protocol_id": 36
+      },
+      "minecraft:red_sandstone": {
+        "protocol_id": 535
+      },
+      "minecraft:red_sandstone_slab": {
+        "protocol_id": 560
+      },
+      "minecraft:red_sandstone_stairs": {
+        "protocol_id": 538
+      },
+      "minecraft:red_sandstone_wall": {
+        "protocol_id": 761
+      },
+      "minecraft:red_shulker_box": {
+        "protocol_id": 628
+      },
+      "minecraft:red_stained_glass": {
+        "protocol_id": 283
+      },
+      "minecraft:red_stained_glass_pane": {
+        "protocol_id": 455
+      },
+      "minecraft:red_terracotta": {
+        "protocol_id": 439
+      },
+      "minecraft:red_tulip": {
+        "protocol_id": 153
+      },
+      "minecraft:red_wall_banner": {
+        "protocol_id": 533
+      },
+      "minecraft:red_wool": {
+        "protocol_id": 144
+      },
+      "minecraft:redstone_block": {
+        "protocol_id": 416
+      },
+      "minecraft:redstone_lamp": {
+        "protocol_id": 339
+      },
+      "minecraft:redstone_ore": {
+        "protocol_id": 242
+      },
+      "minecraft:redstone_torch": {
+        "protocol_id": 244
+      },
+      "minecraft:redstone_wall_torch": {
+        "protocol_id": 245
+      },
+      "minecraft:redstone_wire": {
+        "protocol_id": 178
+      },
+      "minecraft:reinforced_deepslate": {
+        "protocol_id": 1001
+      },
+      "minecraft:repeater": {
+        "protocol_id": 268
+      },
+      "minecraft:repeating_command_block": {
+        "protocol_id": 604
+      },
+      "minecraft:respawn_anchor": {
+        "protocol_id": 843
+      },
+      "minecraft:rooted_dirt": {
+        "protocol_id": 968
+      },
+      "minecraft:rose_bush": {
+        "protocol_id": 499
+      },
+      "minecraft:sand": {
+        "protocol_id": 34
+      },
+      "minecraft:sandstone": {
+        "protocol_id": 99
+      },
+      "minecraft:sandstone_slab": {
+        "protocol_id": 551
+      },
+      "minecraft:sandstone_stairs": {
+        "protocol_id": 341
+      },
+      "minecraft:sandstone_wall": {
+        "protocol_id": 769
+      },
+      "minecraft:scaffolding": {
+        "protocol_id": 772
+      },
+      "minecraft:sculk": {
+        "protocol_id": 915
+      },
+      "minecraft:sculk_catalyst": {
+        "protocol_id": 917
+      },
+      "minecraft:sculk_sensor": {
+        "protocol_id": 913
+      },
+      "minecraft:sculk_shrieker": {
+        "protocol_id": 918
+      },
+      "minecraft:sculk_vein": {
+        "protocol_id": 916
+      },
+      "minecraft:sea_lantern": {
+        "protocol_id": 476
+      },
+      "minecraft:sea_pickle": {
+        "protocol_id": 723
+      },
+      "minecraft:seagrass": {
+        "protocol_id": 126
+      },
+      "minecraft:shroomlight": {
+        "protocol_id": 804
+      },
+      "minecraft:shulker_box": {
+        "protocol_id": 613
+      },
+      "minecraft:skeleton_skull": {
+        "protocol_id": 394
+      },
+      "minecraft:skeleton_wall_skull": {
+        "protocol_id": 395
+      },
+      "minecraft:slime_block": {
+        "protocol_id": 463
+      },
+      "minecraft:small_amethyst_bud": {
+        "protocol_id": 908
+      },
+      "minecraft:small_dripleaf": {
+        "protocol_id": 966
+      },
+      "minecraft:smithing_table": {
+        "protocol_id": 781
+      },
+      "minecraft:smoker": {
+        "protocol_id": 775
+      },
+      "minecraft:smooth_basalt": {
+        "protocol_id": 991
+      },
+      "minecraft:smooth_quartz": {
+        "protocol_id": 565
+      },
+      "minecraft:smooth_quartz_slab": {
+        "protocol_id": 753
+      },
+      "minecraft:smooth_quartz_stairs": {
+        "protocol_id": 740
+      },
+      "minecraft:smooth_red_sandstone": {
+        "protocol_id": 566
+      },
+      "minecraft:smooth_red_sandstone_slab": {
+        "protocol_id": 747
+      },
+      "minecraft:smooth_red_sandstone_stairs": {
+        "protocol_id": 733
+      },
+      "minecraft:smooth_sandstone": {
+        "protocol_id": 564
+      },
+      "minecraft:smooth_sandstone_slab": {
+        "protocol_id": 752
+      },
+      "minecraft:smooth_sandstone_stairs": {
+        "protocol_id": 739
+      },
+      "minecraft:smooth_stone": {
+        "protocol_id": 563
+      },
+      "minecraft:smooth_stone_slab": {
+        "protocol_id": 550
+      },
+      "minecraft:sniffer_egg": {
+        "protocol_id": 682
+      },
+      "minecraft:snow": {
+        "protocol_id": 247
+      },
+      "minecraft:snow_block": {
+        "protocol_id": 249
+      },
+      "minecraft:soul_campfire": {
+        "protocol_id": 787
+      },
+      "minecraft:soul_fire": {
+        "protocol_id": 174
+      },
+      "minecraft:soul_lantern": {
+        "protocol_id": 785
+      },
+      "minecraft:soul_sand": {
+        "protocol_id": 257
+      },
+      "minecraft:soul_soil": {
+        "protocol_id": 258
+      },
+      "minecraft:soul_torch": {
+        "protocol_id": 261
+      },
+      "minecraft:soul_wall_torch": {
+        "protocol_id": 262
+      },
+      "minecraft:spawner": {
+        "protocol_id": 175
+      },
+      "minecraft:sponge": {
+        "protocol_id": 92
+      },
+      "minecraft:spore_blossom": {
+        "protocol_id": 958
+      },
+      "minecraft:spruce_button": {
+        "protocol_id": 386
+      },
+      "minecraft:spruce_door": {
+        "protocol_id": 583
+      },
+      "minecraft:spruce_fence": {
+        "protocol_id": 575
+      },
+      "minecraft:spruce_fence_gate": {
+        "protocol_id": 567
+      },
       "minecraft:spruce_hanging_sign": {
-        "protocol_id": 222
+        "protocol_id": 209
       },
       "minecraft:spruce_leaves": {
-        "protocol_id": 89
+        "protocol_id": 83
       },
       "minecraft:spruce_log": {
-        "protocol_id": 50
+        "protocol_id": 47
       },
       "minecraft:spruce_planks": {
         "protocol_id": 14
       },
       "minecraft:spruce_pressure_plate": {
-        "protocol_id": 249
-      },
-      "minecraft:spruce_sapling": {
-        "protocol_id": 26
-      },
-      "minecraft:spruce_sign": {
-        "protocol_id": 198
-      },
-      "minecraft:spruce_slab": {
-        "protocol_id": 568
-      },
-      "minecraft:spruce_stairs": {
-        "protocol_id": 373
-      },
-      "minecraft:spruce_trapdoor": {
-        "protocol_id": 302
-      },
-      "minecraft:spruce_wall_hanging_sign": {
         "protocol_id": 234
       },
+      "minecraft:spruce_sapling": {
+        "protocol_id": 24
+      },
+      "minecraft:spruce_sign": {
+        "protocol_id": 187
+      },
+      "minecraft:spruce_slab": {
+        "protocol_id": 540
+      },
+      "minecraft:spruce_stairs": {
+        "protocol_id": 348
+      },
+      "minecraft:spruce_trapdoor": {
+        "protocol_id": 286
+      },
+      "minecraft:spruce_wall_hanging_sign": {
+        "protocol_id": 220
+      },
       "minecraft:spruce_wall_sign": {
-        "protocol_id": 212
+        "protocol_id": 200
       },
       "minecraft:spruce_wood": {
-        "protocol_id": 72
+        "protocol_id": 67
       },
       "minecraft:sticky_piston": {
-        "protocol_id": 128
+        "protocol_id": 121
       },
       "minecraft:stone": {
         "protocol_id": 1
       },
       "minecraft:stone_brick_slab": {
-        "protocol_id": 585
+        "protocol_id": 556
       },
       "minecraft:stone_brick_stairs": {
-        "protocol_id": 340
+        "protocol_id": 321
       },
       "minecraft:stone_brick_wall": {
-        "protocol_id": 796
+        "protocol_id": 764
       },
       "minecraft:stone_bricks": {
-        "protocol_id": 311
+        "protocol_id": 294
       },
       "minecraft:stone_button": {
-        "protocol_id": 262
-      },
-      "minecraft:stone_pressure_plate": {
         "protocol_id": 246
       },
+      "minecraft:stone_pressure_plate": {
+        "protocol_id": 231
+      },
       "minecraft:stone_slab": {
-        "protocol_id": 578
+        "protocol_id": 549
       },
       "minecraft:stone_stairs": {
-        "protocol_id": 770
+        "protocol_id": 738
       },
       "minecraft:stonecutter": {
-        "protocol_id": 814
+        "protocol_id": 782
       },
       "minecraft:stripped_acacia_log": {
-        "protocol_id": 64
+        "protocol_id": 60
       },
       "minecraft:stripped_acacia_wood": {
-        "protocol_id": 83
+        "protocol_id": 78
       },
       "minecraft:stripped_bamboo_block": {
-        "protocol_id": 70
-      },
-      "minecraft:stripped_birch_log": {
-        "protocol_id": 62
-      },
-      "minecraft:stripped_birch_wood": {
-        "protocol_id": 81
-      },
-      "minecraft:stripped_cherry_log": {
         "protocol_id": 65
       },
-      "minecraft:stripped_cherry_wood": {
-        "protocol_id": 84
+      "minecraft:stripped_birch_log": {
+        "protocol_id": 58
       },
-      "minecraft:stripped_crimson_hyphae": {
-        "protocol_id": 833
+      "minecraft:stripped_birch_wood": {
+        "protocol_id": 76
       },
-      "minecraft:stripped_crimson_stem": {
-        "protocol_id": 831
-      },
-      "minecraft:stripped_dark_oak_log": {
-        "protocol_id": 66
-      },
-      "minecraft:stripped_dark_oak_wood": {
-        "protocol_id": 85
-      },
-      "minecraft:stripped_jungle_log": {
-        "protocol_id": 63
-      },
-      "minecraft:stripped_jungle_wood": {
-        "protocol_id": 82
-      },
-      "minecraft:stripped_mangrove_log": {
-        "protocol_id": 69
-      },
-      "minecraft:stripped_mangrove_wood": {
-        "protocol_id": 87
-      },
-      "minecraft:stripped_oak_log": {
-        "protocol_id": 68
-      },
-      "minecraft:stripped_oak_wood": {
-        "protocol_id": 79
-      },
-      "minecraft:stripped_pale_oak_log": {
-        "protocol_id": 67
-      },
-      "minecraft:stripped_pale_oak_wood": {
-        "protocol_id": 86
-      },
-      "minecraft:stripped_spruce_log": {
+      "minecraft:stripped_cherry_log": {
         "protocol_id": 61
       },
-      "minecraft:stripped_spruce_wood": {
+      "minecraft:stripped_cherry_wood": {
+        "protocol_id": 79
+      },
+      "minecraft:stripped_crimson_hyphae": {
+        "protocol_id": 801
+      },
+      "minecraft:stripped_crimson_stem": {
+        "protocol_id": 799
+      },
+      "minecraft:stripped_dark_oak_log": {
+        "protocol_id": 62
+      },
+      "minecraft:stripped_dark_oak_wood": {
         "protocol_id": 80
       },
+      "minecraft:stripped_jungle_log": {
+        "protocol_id": 59
+      },
+      "minecraft:stripped_jungle_wood": {
+        "protocol_id": 77
+      },
+      "minecraft:stripped_mangrove_log": {
+        "protocol_id": 64
+      },
+      "minecraft:stripped_mangrove_wood": {
+        "protocol_id": 81
+      },
+      "minecraft:stripped_oak_log": {
+        "protocol_id": 63
+      },
+      "minecraft:stripped_oak_wood": {
+        "protocol_id": 74
+      },
+      "minecraft:stripped_spruce_log": {
+        "protocol_id": 57
+      },
+      "minecraft:stripped_spruce_wood": {
+        "protocol_id": 75
+      },
       "minecraft:stripped_warped_hyphae": {
-        "protocol_id": 824
+        "protocol_id": 792
       },
       "minecraft:stripped_warped_stem": {
-        "protocol_id": 822
+        "protocol_id": 790
       },
       "minecraft:structure_block": {
-        "protocol_id": 864
+        "protocol_id": 832
       },
       "minecraft:structure_void": {
-        "protocol_id": 643
+        "protocol_id": 611
       },
       "minecraft:sugar_cane": {
-        "protocol_id": 269
+        "protocol_id": 252
       },
       "minecraft:sunflower": {
-        "protocol_id": 525
+        "protocol_id": 497
       },
       "minecraft:suspicious_gravel": {
-        "protocol_id": 41
-      },
-      "minecraft:suspicious_sand": {
         "protocol_id": 38
       },
-      "minecraft:sweet_berry_bush": {
-        "protocol_id": 820
-      },
-      "minecraft:tall_dry_grass": {
-        "protocol_id": 135
-      },
-      "minecraft:tall_grass": {
-        "protocol_id": 529
-      },
-      "minecraft:tall_seagrass": {
-        "protocol_id": 137
-      },
-      "minecraft:target": {
-        "protocol_id": 869
-      },
-      "minecraft:terracotta": {
-        "protocol_id": 522
-      },
-      "minecraft:test_block": {
-        "protocol_id": 866
-      },
-      "minecraft:test_instance_block": {
-        "protocol_id": 867
-      },
-      "minecraft:tinted_glass": {
-        "protocol_id": 958
-      },
-      "minecraft:tnt": {
-        "protocol_id": 176
-      },
-      "minecraft:torch": {
-        "protocol_id": 181
-      },
-      "minecraft:torchflower": {
-        "protocol_id": 158
-      },
-      "minecraft:torchflower_crop": {
-        "protocol_id": 630
-      },
-      "minecraft:trapped_chest": {
-        "protocol_id": 438
-      },
-      "minecraft:trial_spawner": {
-        "protocol_id": 1093
-      },
-      "minecraft:tripwire": {
-        "protocol_id": 371
-      },
-      "minecraft:tripwire_hook": {
-        "protocol_id": 370
-      },
-      "minecraft:tube_coral": {
-        "protocol_id": 730
-      },
-      "minecraft:tube_coral_block": {
-        "protocol_id": 720
-      },
-      "minecraft:tube_coral_fan": {
-        "protocol_id": 740
-      },
-      "minecraft:tube_coral_wall_fan": {
-        "protocol_id": 750
-      },
-      "minecraft:tuff": {
-        "protocol_id": 943
-      },
-      "minecraft:tuff_brick_slab": {
-        "protocol_id": 953
-      },
-      "minecraft:tuff_brick_stairs": {
-        "protocol_id": 954
-      },
-      "minecraft:tuff_brick_wall": {
-        "protocol_id": 955
-      },
-      "minecraft:tuff_bricks": {
-        "protocol_id": 952
-      },
-      "minecraft:tuff_slab": {
-        "protocol_id": 944
-      },
-      "minecraft:tuff_stairs": {
-        "protocol_id": 945
-      },
-      "minecraft:tuff_wall": {
-        "protocol_id": 946
-      },
-      "minecraft:turtle_egg": {
-        "protocol_id": 713
-      },
-      "minecraft:twisting_vines": {
-        "protocol_id": 839
-      },
-      "minecraft:twisting_vines_plant": {
-        "protocol_id": 840
-      },
-      "minecraft:vault": {
-        "protocol_id": 1094
-      },
-      "minecraft:verdant_froglight": {
-        "protocol_id": 1087
-      },
-      "minecraft:vine": {
-        "protocol_id": 335
-      },
-      "minecraft:void_air": {
-        "protocol_id": 761
-      },
-      "minecraft:wall_torch": {
-        "protocol_id": 182
-      },
-      "minecraft:warped_button": {
-        "protocol_id": 857
-      },
-      "minecraft:warped_door": {
-        "protocol_id": 859
-      },
-      "minecraft:warped_fence": {
-        "protocol_id": 849
-      },
-      "minecraft:warped_fence_gate": {
-        "protocol_id": 853
-      },
-      "minecraft:warped_fungus": {
-        "protocol_id": 826
-      },
-      "minecraft:warped_hanging_sign": {
-        "protocol_id": 230
-      },
-      "minecraft:warped_hyphae": {
-        "protocol_id": 823
-      },
-      "minecraft:warped_nylium": {
-        "protocol_id": 825
-      },
-      "minecraft:warped_planks": {
-        "protocol_id": 843
-      },
-      "minecraft:warped_pressure_plate": {
-        "protocol_id": 847
-      },
-      "minecraft:warped_roots": {
-        "protocol_id": 828
-      },
-      "minecraft:warped_sign": {
-        "protocol_id": 861
-      },
-      "minecraft:warped_slab": {
-        "protocol_id": 845
-      },
-      "minecraft:warped_stairs": {
-        "protocol_id": 855
-      },
-      "minecraft:warped_stem": {
-        "protocol_id": 821
-      },
-      "minecraft:warped_trapdoor": {
-        "protocol_id": 851
-      },
-      "minecraft:warped_wall_hanging_sign": {
-        "protocol_id": 243
-      },
-      "minecraft:warped_wall_sign": {
-        "protocol_id": 863
-      },
-      "minecraft:warped_wart_block": {
-        "protocol_id": 827
-      },
-      "minecraft:water": {
+      "minecraft:suspicious_sand": {
         "protocol_id": 35
       },
-      "minecraft:water_cauldron": {
-        "protocol_id": 357
+      "minecraft:sweet_berry_bush": {
+        "protocol_id": 788
       },
-      "minecraft:waxed_chiseled_copper": {
-        "protocol_id": 983
+      "minecraft:tall_grass": {
+        "protocol_id": 501
       },
-      "minecraft:waxed_copper_block": {
-        "protocol_id": 992
+      "minecraft:tall_seagrass": {
+        "protocol_id": 127
       },
-      "minecraft:waxed_copper_bulb": {
-        "protocol_id": 1036
+      "minecraft:target": {
+        "protocol_id": 835
       },
-      "minecraft:waxed_copper_door": {
-        "protocol_id": 1012
+      "minecraft:terracotta": {
+        "protocol_id": 494
       },
-      "minecraft:waxed_copper_grate": {
-        "protocol_id": 1028
+      "minecraft:tinted_glass": {
+        "protocol_id": 911
       },
-      "minecraft:waxed_copper_trapdoor": {
-        "protocol_id": 1020
+      "minecraft:tnt": {
+        "protocol_id": 166
       },
-      "minecraft:waxed_cut_copper": {
-        "protocol_id": 999
+      "minecraft:torch": {
+        "protocol_id": 171
       },
-      "minecraft:waxed_cut_copper_slab": {
-        "protocol_id": 1007
+      "minecraft:torchflower": {
+        "protocol_id": 148
       },
-      "minecraft:waxed_cut_copper_stairs": {
-        "protocol_id": 1003
+      "minecraft:torchflower_crop": {
+        "protocol_id": 598
       },
-      "minecraft:waxed_exposed_chiseled_copper": {
-        "protocol_id": 982
+      "minecraft:trapped_chest": {
+        "protocol_id": 411
       },
-      "minecraft:waxed_exposed_copper": {
-        "protocol_id": 994
+      "minecraft:tripwire": {
+        "protocol_id": 346
       },
-      "minecraft:waxed_exposed_copper_bulb": {
-        "protocol_id": 1037
+      "minecraft:tripwire_hook": {
+        "protocol_id": 345
       },
-      "minecraft:waxed_exposed_copper_door": {
-        "protocol_id": 1013
-      },
-      "minecraft:waxed_exposed_copper_grate": {
-        "protocol_id": 1029
-      },
-      "minecraft:waxed_exposed_copper_trapdoor": {
-        "protocol_id": 1021
-      },
-      "minecraft:waxed_exposed_cut_copper": {
-        "protocol_id": 998
-      },
-      "minecraft:waxed_exposed_cut_copper_slab": {
-        "protocol_id": 1006
-      },
-      "minecraft:waxed_exposed_cut_copper_stairs": {
-        "protocol_id": 1002
-      },
-      "minecraft:waxed_oxidized_chiseled_copper": {
-        "protocol_id": 980
-      },
-      "minecraft:waxed_oxidized_copper": {
-        "protocol_id": 995
-      },
-      "minecraft:waxed_oxidized_copper_bulb": {
-        "protocol_id": 1039
-      },
-      "minecraft:waxed_oxidized_copper_door": {
-        "protocol_id": 1014
-      },
-      "minecraft:waxed_oxidized_copper_grate": {
-        "protocol_id": 1031
-      },
-      "minecraft:waxed_oxidized_copper_trapdoor": {
-        "protocol_id": 1022
-      },
-      "minecraft:waxed_oxidized_cut_copper": {
-        "protocol_id": 996
-      },
-      "minecraft:waxed_oxidized_cut_copper_slab": {
-        "protocol_id": 1004
-      },
-      "minecraft:waxed_oxidized_cut_copper_stairs": {
-        "protocol_id": 1000
-      },
-      "minecraft:waxed_weathered_chiseled_copper": {
-        "protocol_id": 981
-      },
-      "minecraft:waxed_weathered_copper": {
-        "protocol_id": 993
-      },
-      "minecraft:waxed_weathered_copper_bulb": {
-        "protocol_id": 1038
-      },
-      "minecraft:waxed_weathered_copper_door": {
-        "protocol_id": 1015
-      },
-      "minecraft:waxed_weathered_copper_grate": {
-        "protocol_id": 1030
-      },
-      "minecraft:waxed_weathered_copper_trapdoor": {
-        "protocol_id": 1023
-      },
-      "minecraft:waxed_weathered_cut_copper": {
-        "protocol_id": 997
-      },
-      "minecraft:waxed_weathered_cut_copper_slab": {
-        "protocol_id": 1005
-      },
-      "minecraft:waxed_weathered_cut_copper_stairs": {
-        "protocol_id": 1001
-      },
-      "minecraft:weathered_chiseled_copper": {
-        "protocol_id": 977
-      },
-      "minecraft:weathered_copper": {
-        "protocol_id": 968
-      },
-      "minecraft:weathered_copper_bulb": {
-        "protocol_id": 1034
-      },
-      "minecraft:weathered_copper_door": {
-        "protocol_id": 1011
-      },
-      "minecraft:weathered_copper_grate": {
-        "protocol_id": 1026
-      },
-      "minecraft:weathered_copper_trapdoor": {
-        "protocol_id": 1019
-      },
-      "minecraft:weathered_cut_copper": {
-        "protocol_id": 973
-      },
-      "minecraft:weathered_cut_copper_slab": {
-        "protocol_id": 989
-      },
-      "minecraft:weathered_cut_copper_stairs": {
-        "protocol_id": 985
-      },
-      "minecraft:weeping_vines": {
-        "protocol_id": 837
-      },
-      "minecraft:weeping_vines_plant": {
-        "protocol_id": 838
-      },
-      "minecraft:wet_sponge": {
-        "protocol_id": 100
-      },
-      "minecraft:wheat": {
-        "protocol_id": 194
-      },
-      "minecraft:white_banner": {
-        "protocol_id": 531
-      },
-      "minecraft:white_bed": {
-        "protocol_id": 110
-      },
-      "minecraft:white_candle": {
-        "protocol_id": 904
-      },
-      "minecraft:white_candle_cake": {
-        "protocol_id": 921
-      },
-      "minecraft:white_carpet": {
-        "protocol_id": 506
-      },
-      "minecraft:white_concrete": {
-        "protocol_id": 678
-      },
-      "minecraft:white_concrete_powder": {
-        "protocol_id": 694
-      },
-      "minecraft:white_glazed_terracotta": {
-        "protocol_id": 662
-      },
-      "minecraft:white_shulker_box": {
-        "protocol_id": 646
-      },
-      "minecraft:white_stained_glass": {
-        "protocol_id": 285
-      },
-      "minecraft:white_stained_glass_pane": {
-        "protocol_id": 468
-      },
-      "minecraft:white_terracotta": {
-        "protocol_id": 452
-      },
-      "minecraft:white_tulip": {
-        "protocol_id": 165
-      },
-      "minecraft:white_wall_banner": {
-        "protocol_id": 547
-      },
-      "minecraft:white_wool": {
-        "protocol_id": 140
-      },
-      "minecraft:wildflowers": {
-        "protocol_id": 1050
-      },
-      "minecraft:wither_rose": {
-        "protocol_id": 169
-      },
-      "minecraft:wither_skeleton_skull": {
-        "protocol_id": 423
-      },
-      "minecraft:wither_skeleton_wall_skull": {
-        "protocol_id": 424
-      },
-      "minecraft:yellow_banner": {
-        "protocol_id": 535
-      },
-      "minecraft:yellow_bed": {
-        "protocol_id": 114
-      },
-      "minecraft:yellow_candle": {
-        "protocol_id": 908
-      },
-      "minecraft:yellow_candle_cake": {
-        "protocol_id": 925
-      },
-      "minecraft:yellow_carpet": {
-        "protocol_id": 510
-      },
-      "minecraft:yellow_concrete": {
-        "protocol_id": 682
-      },
-      "minecraft:yellow_concrete_powder": {
+      "minecraft:tube_coral": {
         "protocol_id": 698
       },
-      "minecraft:yellow_glazed_terracotta": {
-        "protocol_id": 666
+      "minecraft:tube_coral_block": {
+        "protocol_id": 688
       },
-      "minecraft:yellow_shulker_box": {
-        "protocol_id": 650
+      "minecraft:tube_coral_fan": {
+        "protocol_id": 708
       },
-      "minecraft:yellow_stained_glass": {
-        "protocol_id": 289
+      "minecraft:tube_coral_wall_fan": {
+        "protocol_id": 718
       },
-      "minecraft:yellow_stained_glass_pane": {
-        "protocol_id": 472
+      "minecraft:tuff": {
+        "protocol_id": 909
       },
-      "minecraft:yellow_terracotta": {
-        "protocol_id": 456
+      "minecraft:turtle_egg": {
+        "protocol_id": 681
       },
-      "minecraft:yellow_wall_banner": {
-        "protocol_id": 551
+      "minecraft:twisting_vines": {
+        "protocol_id": 807
       },
-      "minecraft:yellow_wool": {
-        "protocol_id": 144
+      "minecraft:twisting_vines_plant": {
+        "protocol_id": 808
       },
-      "minecraft:zombie_head": {
+      "minecraft:verdant_froglight": {
+        "protocol_id": 998
+      },
+      "minecraft:vine": {
+        "protocol_id": 317
+      },
+      "minecraft:void_air": {
+        "protocol_id": 729
+      },
+      "minecraft:wall_torch": {
+        "protocol_id": 172
+      },
+      "minecraft:warped_button": {
+        "protocol_id": 825
+      },
+      "minecraft:warped_door": {
+        "protocol_id": 827
+      },
+      "minecraft:warped_fence": {
+        "protocol_id": 817
+      },
+      "minecraft:warped_fence_gate": {
+        "protocol_id": 821
+      },
+      "minecraft:warped_fungus": {
+        "protocol_id": 794
+      },
+      "minecraft:warped_hanging_sign": {
+        "protocol_id": 216
+      },
+      "minecraft:warped_hyphae": {
+        "protocol_id": 791
+      },
+      "minecraft:warped_nylium": {
+        "protocol_id": 793
+      },
+      "minecraft:warped_planks": {
+        "protocol_id": 811
+      },
+      "minecraft:warped_pressure_plate": {
+        "protocol_id": 815
+      },
+      "minecraft:warped_roots": {
+        "protocol_id": 796
+      },
+      "minecraft:warped_sign": {
+        "protocol_id": 829
+      },
+      "minecraft:warped_slab": {
+        "protocol_id": 813
+      },
+      "minecraft:warped_stairs": {
+        "protocol_id": 823
+      },
+      "minecraft:warped_stem": {
+        "protocol_id": 789
+      },
+      "minecraft:warped_trapdoor": {
+        "protocol_id": 819
+      },
+      "minecraft:warped_wall_hanging_sign": {
+        "protocol_id": 228
+      },
+      "minecraft:warped_wall_sign": {
+        "protocol_id": 831
+      },
+      "minecraft:warped_wart_block": {
+        "protocol_id": 795
+      },
+      "minecraft:water": {
+        "protocol_id": 32
+      },
+      "minecraft:water_cauldron": {
+        "protocol_id": 332
+      },
+      "minecraft:waxed_copper_block": {
+        "protocol_id": 937
+      },
+      "minecraft:waxed_cut_copper": {
+        "protocol_id": 944
+      },
+      "minecraft:waxed_cut_copper_slab": {
+        "protocol_id": 952
+      },
+      "minecraft:waxed_cut_copper_stairs": {
+        "protocol_id": 948
+      },
+      "minecraft:waxed_exposed_copper": {
+        "protocol_id": 939
+      },
+      "minecraft:waxed_exposed_cut_copper": {
+        "protocol_id": 943
+      },
+      "minecraft:waxed_exposed_cut_copper_slab": {
+        "protocol_id": 951
+      },
+      "minecraft:waxed_exposed_cut_copper_stairs": {
+        "protocol_id": 947
+      },
+      "minecraft:waxed_oxidized_copper": {
+        "protocol_id": 940
+      },
+      "minecraft:waxed_oxidized_cut_copper": {
+        "protocol_id": 941
+      },
+      "minecraft:waxed_oxidized_cut_copper_slab": {
+        "protocol_id": 949
+      },
+      "minecraft:waxed_oxidized_cut_copper_stairs": {
+        "protocol_id": 945
+      },
+      "minecraft:waxed_weathered_copper": {
+        "protocol_id": 938
+      },
+      "minecraft:waxed_weathered_cut_copper": {
+        "protocol_id": 942
+      },
+      "minecraft:waxed_weathered_cut_copper_slab": {
+        "protocol_id": 950
+      },
+      "minecraft:waxed_weathered_cut_copper_stairs": {
+        "protocol_id": 946
+      },
+      "minecraft:weathered_copper": {
+        "protocol_id": 920
+      },
+      "minecraft:weathered_cut_copper": {
+        "protocol_id": 926
+      },
+      "minecraft:weathered_cut_copper_slab": {
+        "protocol_id": 934
+      },
+      "minecraft:weathered_cut_copper_stairs": {
+        "protocol_id": 930
+      },
+      "minecraft:weeping_vines": {
+        "protocol_id": 805
+      },
+      "minecraft:weeping_vines_plant": {
+        "protocol_id": 806
+      },
+      "minecraft:wet_sponge": {
+        "protocol_id": 93
+      },
+      "minecraft:wheat": {
+        "protocol_id": 183
+      },
+      "minecraft:white_banner": {
+        "protocol_id": 503
+      },
+      "minecraft:white_bed": {
+        "protocol_id": 103
+      },
+      "minecraft:white_candle": {
+        "protocol_id": 870
+      },
+      "minecraft:white_candle_cake": {
+        "protocol_id": 887
+      },
+      "minecraft:white_carpet": {
+        "protocol_id": 478
+      },
+      "minecraft:white_concrete": {
+        "protocol_id": 646
+      },
+      "minecraft:white_concrete_powder": {
+        "protocol_id": 662
+      },
+      "minecraft:white_glazed_terracotta": {
+        "protocol_id": 630
+      },
+      "minecraft:white_shulker_box": {
+        "protocol_id": 614
+      },
+      "minecraft:white_stained_glass": {
+        "protocol_id": 269
+      },
+      "minecraft:white_stained_glass_pane": {
+        "protocol_id": 441
+      },
+      "minecraft:white_terracotta": {
         "protocol_id": 425
       },
+      "minecraft:white_tulip": {
+        "protocol_id": 155
+      },
+      "minecraft:white_wall_banner": {
+        "protocol_id": 519
+      },
+      "minecraft:white_wool": {
+        "protocol_id": 130
+      },
+      "minecraft:wither_rose": {
+        "protocol_id": 159
+      },
+      "minecraft:wither_skeleton_skull": {
+        "protocol_id": 396
+      },
+      "minecraft:wither_skeleton_wall_skull": {
+        "protocol_id": 397
+      },
+      "minecraft:yellow_banner": {
+        "protocol_id": 507
+      },
+      "minecraft:yellow_bed": {
+        "protocol_id": 107
+      },
+      "minecraft:yellow_candle": {
+        "protocol_id": 874
+      },
+      "minecraft:yellow_candle_cake": {
+        "protocol_id": 891
+      },
+      "minecraft:yellow_carpet": {
+        "protocol_id": 482
+      },
+      "minecraft:yellow_concrete": {
+        "protocol_id": 650
+      },
+      "minecraft:yellow_concrete_powder": {
+        "protocol_id": 666
+      },
+      "minecraft:yellow_glazed_terracotta": {
+        "protocol_id": 634
+      },
+      "minecraft:yellow_shulker_box": {
+        "protocol_id": 618
+      },
+      "minecraft:yellow_stained_glass": {
+        "protocol_id": 273
+      },
+      "minecraft:yellow_stained_glass_pane": {
+        "protocol_id": 445
+      },
+      "minecraft:yellow_terracotta": {
+        "protocol_id": 429
+      },
+      "minecraft:yellow_wall_banner": {
+        "protocol_id": 523
+      },
+      "minecraft:yellow_wool": {
+        "protocol_id": 134
+      },
+      "minecraft:zombie_head": {
+        "protocol_id": 398
+      },
       "minecraft:zombie_wall_head": {
-        "protocol_id": 426
+        "protocol_id": 399
       }
     },
     "protocol_id": 4
@@ -3504,64 +3272,58 @@
   "minecraft:block_entity_type": {
     "entries": {
       "minecraft:banner": {
-        "protocol_id": 20
+        "protocol_id": 19
       },
       "minecraft:barrel": {
-        "protocol_id": 27
+        "protocol_id": 26
       },
       "minecraft:beacon": {
-        "protocol_id": 15
+        "protocol_id": 14
       },
       "minecraft:bed": {
-        "protocol_id": 25
+        "protocol_id": 24
       },
       "minecraft:beehive": {
-        "protocol_id": 34
+        "protocol_id": 33
       },
       "minecraft:bell": {
-        "protocol_id": 31
+        "protocol_id": 30
       },
       "minecraft:blast_furnace": {
-        "protocol_id": 29
+        "protocol_id": 28
       },
       "minecraft:brewing_stand": {
-        "protocol_id": 12
+        "protocol_id": 11
       },
       "minecraft:brushable_block": {
-        "protocol_id": 40
+        "protocol_id": 39
       },
       "minecraft:calibrated_sculk_sensor": {
-        "protocol_id": 36
+        "protocol_id": 35
       },
       "minecraft:campfire": {
-        "protocol_id": 33
+        "protocol_id": 32
       },
       "minecraft:chest": {
         "protocol_id": 1
       },
       "minecraft:chiseled_bookshelf": {
-        "protocol_id": 39
+        "protocol_id": 38
       },
       "minecraft:command_block": {
-        "protocol_id": 23
+        "protocol_id": 22
       },
       "minecraft:comparator": {
-        "protocol_id": 19
+        "protocol_id": 18
       },
       "minecraft:conduit": {
-        "protocol_id": 26
-      },
-      "minecraft:crafter": {
-        "protocol_id": 42
-      },
-      "minecraft:creaking_heart": {
-        "protocol_id": 10
+        "protocol_id": 25
       },
       "minecraft:daylight_detector": {
-        "protocol_id": 17
+        "protocol_id": 16
       },
       "minecraft:decorated_pot": {
-        "protocol_id": 41
+        "protocol_id": 40
       },
       "minecraft:dispenser": {
         "protocol_id": 5
@@ -3570,13 +3332,13 @@
         "protocol_id": 6
       },
       "minecraft:enchanting_table": {
-        "protocol_id": 13
+        "protocol_id": 12
       },
       "minecraft:end_gateway": {
-        "protocol_id": 22
+        "protocol_id": 21
       },
       "minecraft:end_portal": {
-        "protocol_id": 14
+        "protocol_id": 13
       },
       "minecraft:ender_chest": {
         "protocol_id": 3
@@ -3588,64 +3350,52 @@
         "protocol_id": 8
       },
       "minecraft:hopper": {
-        "protocol_id": 18
+        "protocol_id": 17
       },
       "minecraft:jigsaw": {
-        "protocol_id": 32
+        "protocol_id": 31
       },
       "minecraft:jukebox": {
         "protocol_id": 4
       },
       "minecraft:lectern": {
-        "protocol_id": 30
+        "protocol_id": 29
       },
       "minecraft:mob_spawner": {
         "protocol_id": 9
       },
       "minecraft:piston": {
-        "protocol_id": 11
+        "protocol_id": 10
       },
       "minecraft:sculk_catalyst": {
-        "protocol_id": 37
+        "protocol_id": 36
       },
       "minecraft:sculk_sensor": {
-        "protocol_id": 35
+        "protocol_id": 34
       },
       "minecraft:sculk_shrieker": {
-        "protocol_id": 38
+        "protocol_id": 37
       },
       "minecraft:shulker_box": {
-        "protocol_id": 24
+        "protocol_id": 23
       },
       "minecraft:sign": {
         "protocol_id": 7
       },
       "minecraft:skull": {
-        "protocol_id": 16
+        "protocol_id": 15
       },
       "minecraft:smoker": {
-        "protocol_id": 28
+        "protocol_id": 27
       },
       "minecraft:structure_block": {
-        "protocol_id": 21
-      },
-      "minecraft:test_block": {
-        "protocol_id": 45
-      },
-      "minecraft:test_instance_block": {
-        "protocol_id": 46
+        "protocol_id": 20
       },
       "minecraft:trapped_chest": {
         "protocol_id": 2
-      },
-      "minecraft:trial_spawner": {
-        "protocol_id": 43
-      },
-      "minecraft:vault": {
-        "protocol_id": 44
       }
     },
-    "protocol_id": 9
+    "protocol_id": 10
   },
   "minecraft:block_predicate_type": {
     "entries": {
@@ -3682,784 +3432,49 @@
       "minecraft:true": {
         "protocol_id": 11
       },
-      "minecraft:unobstructed": {
-        "protocol_id": 12
-      },
       "minecraft:would_survive": {
         "protocol_id": 6
       }
     },
-    "protocol_id": 38
+    "protocol_id": 40
   },
-  "minecraft:block_type": {
+  "minecraft:cat_variant": {
     "entries": {
-      "minecraft:air": {
-        "protocol_id": 1
-      },
-      "minecraft:amethyst": {
-        "protocol_id": 2
-      },
-      "minecraft:amethyst_cluster": {
-        "protocol_id": 3
-      },
-      "minecraft:anvil": {
-        "protocol_id": 4
-      },
-      "minecraft:attached_stem": {
-        "protocol_id": 5
-      },
-      "minecraft:azalea": {
-        "protocol_id": 6
-      },
-      "minecraft:bamboo_sapling": {
-        "protocol_id": 7
-      },
-      "minecraft:bamboo_stalk": {
-        "protocol_id": 8
-      },
-      "minecraft:banner": {
-        "protocol_id": 9
-      },
-      "minecraft:barrel": {
+      "minecraft:all_black": {
         "protocol_id": 10
       },
-      "minecraft:barrier": {
-        "protocol_id": 11
+      "minecraft:black": {
+        "protocol_id": 1
       },
-      "minecraft:base_coral_fan": {
-        "protocol_id": 12
+      "minecraft:british_shorthair": {
+        "protocol_id": 4
       },
-      "minecraft:base_coral_plant": {
-        "protocol_id": 13
+      "minecraft:calico": {
+        "protocol_id": 5
       },
-      "minecraft:base_coral_wall_fan": {
-        "protocol_id": 14
+      "minecraft:jellie": {
+        "protocol_id": 9
       },
-      "minecraft:beacon": {
-        "protocol_id": 15
+      "minecraft:persian": {
+        "protocol_id": 6
       },
-      "minecraft:bed": {
-        "protocol_id": 16
+      "minecraft:ragdoll": {
+        "protocol_id": 7
       },
-      "minecraft:beehive": {
-        "protocol_id": 17
+      "minecraft:red": {
+        "protocol_id": 2
       },
-      "minecraft:beetroot": {
-        "protocol_id": 18
+      "minecraft:siamese": {
+        "protocol_id": 3
       },
-      "minecraft:bell": {
-        "protocol_id": 19
-      },
-      "minecraft:big_dripleaf": {
-        "protocol_id": 20
-      },
-      "minecraft:big_dripleaf_stem": {
-        "protocol_id": 21
-      },
-      "minecraft:blast_furnace": {
-        "protocol_id": 22
-      },
-      "minecraft:block": {
+      "minecraft:tabby": {
         "protocol_id": 0
       },
-      "minecraft:bonemealable_feature_placer": {
-        "protocol_id": 83
-      },
-      "minecraft:brewing_stand": {
-        "protocol_id": 23
-      },
-      "minecraft:brushable": {
-        "protocol_id": 24
-      },
-      "minecraft:bubble_column": {
-        "protocol_id": 25
-      },
-      "minecraft:budding_amethyst": {
-        "protocol_id": 26
-      },
-      "minecraft:bush": {
-        "protocol_id": 27
-      },
-      "minecraft:button": {
-        "protocol_id": 28
-      },
-      "minecraft:cactus": {
-        "protocol_id": 29
-      },
-      "minecraft:cactus_flower": {
-        "protocol_id": 30
-      },
-      "minecraft:cake": {
-        "protocol_id": 31
-      },
-      "minecraft:calibrated_sculk_sensor": {
-        "protocol_id": 32
-      },
-      "minecraft:campfire": {
-        "protocol_id": 33
-      },
-      "minecraft:candle": {
-        "protocol_id": 35
-      },
-      "minecraft:candle_cake": {
-        "protocol_id": 34
-      },
-      "minecraft:carpet": {
-        "protocol_id": 36
-      },
-      "minecraft:carrot": {
-        "protocol_id": 37
-      },
-      "minecraft:cartography_table": {
-        "protocol_id": 38
-      },
-      "minecraft:cauldron": {
-        "protocol_id": 39
-      },
-      "minecraft:cave_vines": {
-        "protocol_id": 40
-      },
-      "minecraft:cave_vines_plant": {
-        "protocol_id": 41
-      },
-      "minecraft:ceiling_hanging_sign": {
-        "protocol_id": 42
-      },
-      "minecraft:chain": {
-        "protocol_id": 43
-      },
-      "minecraft:chest": {
-        "protocol_id": 44
-      },
-      "minecraft:chiseled_book_shelf": {
-        "protocol_id": 45
-      },
-      "minecraft:chorus_flower": {
-        "protocol_id": 46
-      },
-      "minecraft:chorus_plant": {
-        "protocol_id": 47
-      },
-      "minecraft:cocoa": {
-        "protocol_id": 48
-      },
-      "minecraft:colored_falling": {
-        "protocol_id": 49
-      },
-      "minecraft:command": {
-        "protocol_id": 50
-      },
-      "minecraft:comparator": {
-        "protocol_id": 51
-      },
-      "minecraft:composter": {
-        "protocol_id": 52
-      },
-      "minecraft:concrete_powder": {
-        "protocol_id": 53
-      },
-      "minecraft:conduit": {
-        "protocol_id": 54
-      },
-      "minecraft:copper_bulb_block": {
-        "protocol_id": 55
-      },
-      "minecraft:coral": {
-        "protocol_id": 56
-      },
-      "minecraft:coral_fan": {
-        "protocol_id": 57
-      },
-      "minecraft:coral_plant": {
-        "protocol_id": 58
-      },
-      "minecraft:coral_wall_fan": {
-        "protocol_id": 59
-      },
-      "minecraft:crafter": {
-        "protocol_id": 60
-      },
-      "minecraft:crafting_table": {
-        "protocol_id": 61
-      },
-      "minecraft:creaking_heart": {
-        "protocol_id": 193
-      },
-      "minecraft:crop": {
-        "protocol_id": 62
-      },
-      "minecraft:crying_obsidian": {
-        "protocol_id": 63
-      },
-      "minecraft:daylight_detector": {
-        "protocol_id": 64
-      },
-      "minecraft:decorated_pot": {
-        "protocol_id": 66
-      },
-      "minecraft:detector_rail": {
-        "protocol_id": 67
-      },
-      "minecraft:dirt_path": {
-        "protocol_id": 68
-      },
-      "minecraft:dispenser": {
-        "protocol_id": 69
-      },
-      "minecraft:door": {
-        "protocol_id": 70
-      },
-      "minecraft:double_plant": {
-        "protocol_id": 71
-      },
-      "minecraft:dragon_egg": {
-        "protocol_id": 72
-      },
-      "minecraft:drop_experience": {
-        "protocol_id": 73
-      },
-      "minecraft:dropper": {
-        "protocol_id": 74
-      },
-      "minecraft:dry_vegetation": {
-        "protocol_id": 65
-      },
-      "minecraft:enchantment_table": {
-        "protocol_id": 75
-      },
-      "minecraft:end_gateway": {
-        "protocol_id": 77
-      },
-      "minecraft:end_portal": {
-        "protocol_id": 78
-      },
-      "minecraft:end_portal_frame": {
-        "protocol_id": 79
-      },
-      "minecraft:end_rod": {
-        "protocol_id": 80
-      },
-      "minecraft:ender_chest": {
-        "protocol_id": 76
-      },
-      "minecraft:eyeblossom": {
-        "protocol_id": 81
-      },
-      "minecraft:farm": {
-        "protocol_id": 82
-      },
-      "minecraft:fence": {
-        "protocol_id": 84
-      },
-      "minecraft:fence_gate": {
-        "protocol_id": 85
-      },
-      "minecraft:fire": {
-        "protocol_id": 86
-      },
-      "minecraft:firefly_bush": {
-        "protocol_id": 87
-      },
-      "minecraft:fletching_table": {
-        "protocol_id": 88
-      },
-      "minecraft:flower": {
-        "protocol_id": 89
-      },
-      "minecraft:flower_bed": {
-        "protocol_id": 145
-      },
-      "minecraft:flower_pot": {
-        "protocol_id": 90
-      },
-      "minecraft:frogspawn": {
-        "protocol_id": 91
-      },
-      "minecraft:frosted_ice": {
-        "protocol_id": 92
-      },
-      "minecraft:fungus": {
-        "protocol_id": 93
-      },
-      "minecraft:furnace": {
-        "protocol_id": 94
-      },
-      "minecraft:glazed_terracotta": {
-        "protocol_id": 95
-      },
-      "minecraft:glow_lichen": {
-        "protocol_id": 96
-      },
-      "minecraft:grass": {
-        "protocol_id": 97
-      },
-      "minecraft:grindstone": {
-        "protocol_id": 98
-      },
-      "minecraft:half_transparent": {
-        "protocol_id": 99
-      },
-      "minecraft:hanging_moss": {
-        "protocol_id": 100
-      },
-      "minecraft:hanging_roots": {
-        "protocol_id": 101
-      },
-      "minecraft:hay": {
-        "protocol_id": 102
-      },
-      "minecraft:heavy_core": {
-        "protocol_id": 103
-      },
-      "minecraft:honey": {
-        "protocol_id": 104
-      },
-      "minecraft:hopper": {
-        "protocol_id": 105
-      },
-      "minecraft:huge_mushroom": {
-        "protocol_id": 106
-      },
-      "minecraft:ice": {
-        "protocol_id": 107
-      },
-      "minecraft:infested": {
-        "protocol_id": 108
-      },
-      "minecraft:infested_rotated_pillar": {
-        "protocol_id": 109
-      },
-      "minecraft:iron_bars": {
-        "protocol_id": 110
-      },
-      "minecraft:jack_o_lantern": {
-        "protocol_id": 111
-      },
-      "minecraft:jigsaw": {
-        "protocol_id": 112
-      },
-      "minecraft:jukebox": {
-        "protocol_id": 113
-      },
-      "minecraft:kelp": {
-        "protocol_id": 114
-      },
-      "minecraft:kelp_plant": {
-        "protocol_id": 115
-      },
-      "minecraft:ladder": {
-        "protocol_id": 116
-      },
-      "minecraft:lantern": {
-        "protocol_id": 117
-      },
-      "minecraft:lava_cauldron": {
-        "protocol_id": 118
-      },
-      "minecraft:layered_cauldron": {
-        "protocol_id": 119
-      },
-      "minecraft:leaf_litter": {
-        "protocol_id": 120
-      },
-      "minecraft:lectern": {
-        "protocol_id": 121
-      },
-      "minecraft:lever": {
-        "protocol_id": 122
-      },
-      "minecraft:light": {
-        "protocol_id": 123
-      },
-      "minecraft:lightning_rod": {
-        "protocol_id": 124
-      },
-      "minecraft:liquid": {
-        "protocol_id": 125
-      },
-      "minecraft:loom": {
-        "protocol_id": 126
-      },
-      "minecraft:magma": {
-        "protocol_id": 127
-      },
-      "minecraft:mangrove_leaves": {
-        "protocol_id": 128
-      },
-      "minecraft:mangrove_propagule": {
-        "protocol_id": 129
-      },
-      "minecraft:mangrove_roots": {
-        "protocol_id": 130
-      },
-      "minecraft:mossy_carpet": {
-        "protocol_id": 131
-      },
-      "minecraft:moving_piston": {
-        "protocol_id": 132
-      },
-      "minecraft:mud": {
-        "protocol_id": 133
-      },
-      "minecraft:multiface": {
-        "protocol_id": 134
-      },
-      "minecraft:mushroom": {
-        "protocol_id": 135
-      },
-      "minecraft:mycelium": {
-        "protocol_id": 136
-      },
-      "minecraft:nether_portal": {
-        "protocol_id": 137
-      },
-      "minecraft:nether_sprouts": {
-        "protocol_id": 139
-      },
-      "minecraft:nether_wart": {
-        "protocol_id": 140
-      },
-      "minecraft:netherrack": {
-        "protocol_id": 138
-      },
-      "minecraft:note": {
-        "protocol_id": 141
-      },
-      "minecraft:nylium": {
-        "protocol_id": 142
-      },
-      "minecraft:observer": {
-        "protocol_id": 143
-      },
-      "minecraft:piglinwallskull": {
-        "protocol_id": 144
-      },
-      "minecraft:piston_base": {
-        "protocol_id": 146
-      },
-      "minecraft:piston_head": {
-        "protocol_id": 147
-      },
-      "minecraft:pitcher_crop": {
-        "protocol_id": 148
-      },
-      "minecraft:player_head": {
-        "protocol_id": 149
-      },
-      "minecraft:player_wall_head": {
-        "protocol_id": 150
-      },
-      "minecraft:pointed_dripstone": {
-        "protocol_id": 151
-      },
-      "minecraft:potato": {
-        "protocol_id": 152
-      },
-      "minecraft:powder_snow": {
-        "protocol_id": 153
-      },
-      "minecraft:powered": {
-        "protocol_id": 154
-      },
-      "minecraft:powered_rail": {
-        "protocol_id": 155
-      },
-      "minecraft:pressure_plate": {
-        "protocol_id": 156
-      },
-      "minecraft:pumpkin": {
-        "protocol_id": 157
-      },
-      "minecraft:rail": {
-        "protocol_id": 158
-      },
-      "minecraft:redstone_lamp": {
-        "protocol_id": 159
-      },
-      "minecraft:redstone_ore": {
-        "protocol_id": 160
-      },
-      "minecraft:redstone_torch": {
-        "protocol_id": 161
-      },
-      "minecraft:redstone_wall_torch": {
-        "protocol_id": 162
-      },
-      "minecraft:redstone_wire": {
-        "protocol_id": 163
-      },
-      "minecraft:repeater": {
-        "protocol_id": 164
-      },
-      "minecraft:respawn_anchor": {
-        "protocol_id": 165
-      },
-      "minecraft:rooted_dirt": {
-        "protocol_id": 166
-      },
-      "minecraft:roots": {
-        "protocol_id": 167
-      },
-      "minecraft:rotated_pillar": {
-        "protocol_id": 168
-      },
-      "minecraft:sand": {
-        "protocol_id": 170
-      },
-      "minecraft:sapling": {
-        "protocol_id": 169
-      },
-      "minecraft:scaffolding": {
-        "protocol_id": 171
-      },
-      "minecraft:sculk": {
-        "protocol_id": 173
-      },
-      "minecraft:sculk_catalyst": {
-        "protocol_id": 172
-      },
-      "minecraft:sculk_sensor": {
-        "protocol_id": 174
-      },
-      "minecraft:sculk_shrieker": {
-        "protocol_id": 175
-      },
-      "minecraft:sculk_vein": {
-        "protocol_id": 176
-      },
-      "minecraft:sea_pickle": {
-        "protocol_id": 178
-      },
-      "minecraft:seagrass": {
-        "protocol_id": 177
-      },
-      "minecraft:short_dry_grass": {
-        "protocol_id": 179
-      },
-      "minecraft:shulker_box": {
-        "protocol_id": 180
-      },
-      "minecraft:skull": {
-        "protocol_id": 181
-      },
-      "minecraft:slab": {
-        "protocol_id": 182
-      },
-      "minecraft:slime": {
-        "protocol_id": 183
-      },
-      "minecraft:small_dripleaf": {
-        "protocol_id": 184
-      },
-      "minecraft:smithing_table": {
-        "protocol_id": 185
-      },
-      "minecraft:smoker": {
-        "protocol_id": 186
-      },
-      "minecraft:sniffer_egg": {
-        "protocol_id": 187
-      },
-      "minecraft:snow_layer": {
-        "protocol_id": 188
-      },
-      "minecraft:snowy_dirt": {
-        "protocol_id": 189
-      },
-      "minecraft:soul_fire": {
-        "protocol_id": 190
-      },
-      "minecraft:soul_sand": {
-        "protocol_id": 191
-      },
-      "minecraft:spawner": {
-        "protocol_id": 192
-      },
-      "minecraft:sponge": {
-        "protocol_id": 194
-      },
-      "minecraft:spore_blossom": {
-        "protocol_id": 195
-      },
-      "minecraft:stained_glass": {
-        "protocol_id": 197
-      },
-      "minecraft:stained_glass_pane": {
-        "protocol_id": 196
-      },
-      "minecraft:stair": {
-        "protocol_id": 198
-      },
-      "minecraft:standing_sign": {
-        "protocol_id": 199
-      },
-      "minecraft:stem": {
-        "protocol_id": 200
-      },
-      "minecraft:stonecutter": {
-        "protocol_id": 201
-      },
-      "minecraft:structure": {
-        "protocol_id": 202
-      },
-      "minecraft:structure_void": {
-        "protocol_id": 203
-      },
-      "minecraft:sugar_cane": {
-        "protocol_id": 204
-      },
-      "minecraft:sweet_berry_bush": {
-        "protocol_id": 205
-      },
-      "minecraft:tall_dry_grass": {
-        "protocol_id": 206
-      },
-      "minecraft:tall_flower": {
-        "protocol_id": 207
-      },
-      "minecraft:tall_grass": {
-        "protocol_id": 208
-      },
-      "minecraft:tall_seagrass": {
-        "protocol_id": 209
-      },
-      "minecraft:target": {
-        "protocol_id": 210
-      },
-      "minecraft:terracotta": {
-        "protocol_id": 211
-      },
-      "minecraft:test": {
-        "protocol_id": 212
-      },
-      "minecraft:test_instance": {
-        "protocol_id": 213
-      },
-      "minecraft:tinted_glass": {
-        "protocol_id": 214
-      },
-      "minecraft:tinted_particle_leaves": {
-        "protocol_id": 215
-      },
-      "minecraft:tnt": {
-        "protocol_id": 216
-      },
-      "minecraft:torch": {
-        "protocol_id": 218
-      },
-      "minecraft:torchflower_crop": {
-        "protocol_id": 217
-      },
-      "minecraft:transparent": {
-        "protocol_id": 219
-      },
-      "minecraft:trapdoor": {
-        "protocol_id": 220
-      },
-      "minecraft:trapped_chest": {
-        "protocol_id": 221
-      },
-      "minecraft:trial_spawner": {
-        "protocol_id": 222
-      },
-      "minecraft:trip_wire_hook": {
-        "protocol_id": 223
-      },
-      "minecraft:tripwire": {
-        "protocol_id": 224
-      },
-      "minecraft:turtle_egg": {
-        "protocol_id": 225
-      },
-      "minecraft:twisting_vines": {
-        "protocol_id": 227
-      },
-      "minecraft:twisting_vines_plant": {
-        "protocol_id": 226
-      },
-      "minecraft:untinted_particle_leaves": {
-        "protocol_id": 228
-      },
-      "minecraft:vault": {
-        "protocol_id": 229
-      },
-      "minecraft:vine": {
-        "protocol_id": 230
-      },
-      "minecraft:wall": {
-        "protocol_id": 236
-      },
-      "minecraft:wall_banner": {
-        "protocol_id": 231
-      },
-      "minecraft:wall_hanging_sign": {
-        "protocol_id": 232
-      },
-      "minecraft:wall_sign": {
-        "protocol_id": 233
-      },
-      "minecraft:wall_skull": {
-        "protocol_id": 234
-      },
-      "minecraft:wall_torch": {
-        "protocol_id": 235
-      },
-      "minecraft:waterlily": {
-        "protocol_id": 237
-      },
-      "minecraft:waterlogged_transparent": {
-        "protocol_id": 238
-      },
-      "minecraft:weathering_copper_bulb": {
-        "protocol_id": 239
-      },
-      "minecraft:weathering_copper_door": {
-        "protocol_id": 240
-      },
-      "minecraft:weathering_copper_full": {
-        "protocol_id": 241
-      },
-      "minecraft:weathering_copper_grate": {
-        "protocol_id": 242
-      },
-      "minecraft:weathering_copper_slab": {
-        "protocol_id": 243
-      },
-      "minecraft:weathering_copper_stair": {
-        "protocol_id": 244
-      },
-      "minecraft:weathering_copper_trap_door": {
-        "protocol_id": 245
-      },
-      "minecraft:web": {
-        "protocol_id": 246
-      },
-      "minecraft:weeping_vines": {
-        "protocol_id": 248
-      },
-      "minecraft:weeping_vines_plant": {
-        "protocol_id": 247
-      },
-      "minecraft:weighted_pressure_plate": {
-        "protocol_id": 249
-      },
-      "minecraft:wet_sponge": {
-        "protocol_id": 250
-      },
-      "minecraft:wither_rose": {
-        "protocol_id": 251
-      },
-      "minecraft:wither_skull": {
-        "protocol_id": 252
-      },
-      "minecraft:wither_wall_skull": {
-        "protocol_id": 253
-      },
-      "minecraft:wool_carpet": {
-        "protocol_id": 254
+      "minecraft:white": {
+        "protocol_id": 8
       }
     },
-    "protocol_id": 56
+    "protocol_id": 60
   },
   "minecraft:chunk_status": {
     "default": "minecraft:empty",
@@ -4501,7 +3516,7 @@
         "protocol_id": 5
       }
     },
-    "protocol_id": 11
+    "protocol_id": 13
   },
   "minecraft:command_argument_type": {
     "entries": {
@@ -4524,7 +3539,7 @@
         "protocol_id": 5
       },
       "minecraft:angle": {
-        "protocol_id": 27
+        "protocol_id": 26
       },
       "minecraft:block_pos": {
         "protocol_id": 8
@@ -4545,124 +3560,106 @@
         "protocol_id": 17
       },
       "minecraft:dimension": {
-        "protocol_id": 40
+        "protocol_id": 38
       },
       "minecraft:entity": {
         "protocol_id": 6
       },
       "minecraft:entity_anchor": {
-        "protocol_id": 37
+        "protocol_id": 35
       },
       "minecraft:float_range": {
-        "protocol_id": 39
+        "protocol_id": 37
       },
       "minecraft:function": {
-        "protocol_id": 36
+        "protocol_id": 34
       },
       "minecraft:game_profile": {
         "protocol_id": 7
       },
       "minecraft:gamemode": {
-        "protocol_id": 41
+        "protocol_id": 39
       },
       "minecraft:heightmap": {
-        "protocol_id": 50
+        "protocol_id": 47
       },
       "minecraft:int_range": {
-        "protocol_id": 38
+        "protocol_id": 36
       },
       "minecraft:item_predicate": {
         "protocol_id": 15
       },
       "minecraft:item_slot": {
-        "protocol_id": 33
-      },
-      "minecraft:item_slots": {
-        "protocol_id": 34
+        "protocol_id": 32
       },
       "minecraft:item_stack": {
         "protocol_id": 14
       },
-      "minecraft:loot_modifier": {
-        "protocol_id": 53
-      },
-      "minecraft:loot_predicate": {
-        "protocol_id": 52
-      },
-      "minecraft:loot_table": {
-        "protocol_id": 51
-      },
       "minecraft:message": {
-        "protocol_id": 19
-      },
-      "minecraft:nbt_compound_tag": {
-        "protocol_id": 20
-      },
-      "minecraft:nbt_path": {
-        "protocol_id": 22
-      },
-      "minecraft:nbt_tag": {
-        "protocol_id": 21
-      },
-      "minecraft:objective": {
-        "protocol_id": 23
-      },
-      "minecraft:objective_criteria": {
-        "protocol_id": 24
-      },
-      "minecraft:operation": {
-        "protocol_id": 25
-      },
-      "minecraft:particle": {
-        "protocol_id": 26
-      },
-      "minecraft:resource": {
-        "protocol_id": 45
-      },
-      "minecraft:resource_key": {
-        "protocol_id": 46
-      },
-      "minecraft:resource_location": {
-        "protocol_id": 35
-      },
-      "minecraft:resource_or_tag": {
-        "protocol_id": 43
-      },
-      "minecraft:resource_or_tag_key": {
-        "protocol_id": 44
-      },
-      "minecraft:resource_selector": {
-        "protocol_id": 47
-      },
-      "minecraft:rotation": {
-        "protocol_id": 28
-      },
-      "minecraft:score_holder": {
-        "protocol_id": 30
-      },
-      "minecraft:scoreboard_slot": {
-        "protocol_id": 29
-      },
-      "minecraft:style": {
         "protocol_id": 18
       },
-      "minecraft:swizzle": {
-        "protocol_id": 31
+      "minecraft:nbt_compound_tag": {
+        "protocol_id": 19
       },
-      "minecraft:team": {
-        "protocol_id": 32
+      "minecraft:nbt_path": {
+        "protocol_id": 21
       },
-      "minecraft:template_mirror": {
-        "protocol_id": 48
+      "minecraft:nbt_tag": {
+        "protocol_id": 20
       },
-      "minecraft:template_rotation": {
-        "protocol_id": 49
+      "minecraft:objective": {
+        "protocol_id": 22
       },
-      "minecraft:time": {
+      "minecraft:objective_criteria": {
+        "protocol_id": 23
+      },
+      "minecraft:operation": {
+        "protocol_id": 24
+      },
+      "minecraft:particle": {
+        "protocol_id": 25
+      },
+      "minecraft:resource": {
+        "protocol_id": 43
+      },
+      "minecraft:resource_key": {
+        "protocol_id": 44
+      },
+      "minecraft:resource_location": {
+        "protocol_id": 33
+      },
+      "minecraft:resource_or_tag": {
+        "protocol_id": 41
+      },
+      "minecraft:resource_or_tag_key": {
         "protocol_id": 42
       },
+      "minecraft:rotation": {
+        "protocol_id": 27
+      },
+      "minecraft:score_holder": {
+        "protocol_id": 29
+      },
+      "minecraft:scoreboard_slot": {
+        "protocol_id": 28
+      },
+      "minecraft:swizzle": {
+        "protocol_id": 30
+      },
+      "minecraft:team": {
+        "protocol_id": 31
+      },
+      "minecraft:template_mirror": {
+        "protocol_id": 45
+      },
+      "minecraft:template_rotation": {
+        "protocol_id": 46
+      },
+      "minecraft:time": {
+        "protocol_id": 40
+      },
       "minecraft:uuid": {
-        "protocol_id": 54
+        "protocol_id": 48
       },
       "minecraft:vec2": {
         "protocol_id": 11
@@ -4671,27 +3668,7 @@
         "protocol_id": 10
       }
     },
-    "protocol_id": 20
-  },
-  "minecraft:consume_effect_type": {
-    "entries": {
-      "minecraft:apply_effects": {
-        "protocol_id": 0
-      },
-      "minecraft:clear_all_effects": {
-        "protocol_id": 2
-      },
-      "minecraft:play_sound": {
-        "protocol_id": 4
-      },
-      "minecraft:remove_effects": {
-        "protocol_id": 1
-      },
-      "minecraft:teleport_randomly": {
-        "protocol_id": 3
-      }
-    },
-    "protocol_id": 74
+    "protocol_id": 22
   },
   "minecraft:creative_mode_tab": {
     "entries": {
@@ -4738,7 +3715,7 @@
         "protocol_id": 7
       }
     },
-    "protocol_id": 61
+    "protocol_id": 65
   },
   "minecraft:custom_stat": {
     "entries": {
@@ -4968,1143 +3945,578 @@
         "protocol_id": 13
       }
     },
-    "protocol_id": 10
+    "protocol_id": 12
   },
-  "minecraft:data_component_predicate_type": {
+  "minecraft:decorated_pot_patterns": {
     "entries": {
-      "minecraft:attribute_modifiers": {
-        "protocol_id": 11
-      },
-      "minecraft:bundle_contents": {
-        "protocol_id": 6
-      },
-      "minecraft:container": {
-        "protocol_id": 5
-      },
-      "minecraft:custom_data": {
-        "protocol_id": 4
-      },
-      "minecraft:damage": {
-        "protocol_id": 0
-      },
-      "minecraft:enchantments": {
+      "minecraft:angler_pottery_pattern": {
         "protocol_id": 1
       },
-      "minecraft:firework_explosion": {
-        "protocol_id": 7
-      },
-      "minecraft:fireworks": {
-        "protocol_id": 8
-      },
-      "minecraft:jukebox_playable": {
-        "protocol_id": 13
-      },
-      "minecraft:potion_contents": {
-        "protocol_id": 3
-      },
-      "minecraft:stored_enchantments": {
+      "minecraft:archer_pottery_pattern": {
         "protocol_id": 2
       },
-      "minecraft:trim": {
-        "protocol_id": 12
+      "minecraft:arms_up_pottery_pattern": {
+        "protocol_id": 3
       },
-      "minecraft:writable_book_content": {
-        "protocol_id": 9
+      "minecraft:blade_pottery_pattern": {
+        "protocol_id": 4
       },
-      "minecraft:written_book_content": {
-        "protocol_id": 10
-      }
-    },
-    "protocol_id": 66
-  },
-  "minecraft:data_component_type": {
-    "entries": {
-      "minecraft:attribute_modifiers": {
-        "protocol_id": 13
+      "minecraft:brewer_pottery_pattern": {
+        "protocol_id": 5
       },
-      "minecraft:axolotl/variant": {
-        "protocol_id": 91
+      "minecraft:burn_pottery_pattern": {
+        "protocol_id": 6
       },
-      "minecraft:banner_patterns": {
-        "protocol_id": 63
+      "minecraft:danger_pottery_pattern": {
+        "protocol_id": 7
       },
-      "minecraft:base_color": {
-        "protocol_id": 64
-      },
-      "minecraft:bees": {
-        "protocol_id": 68
-      },
-      "minecraft:block_entity_data": {
-        "protocol_id": 51
-      },
-      "minecraft:block_state": {
-        "protocol_id": 67
-      },
-      "minecraft:blocks_attacks": {
-        "protocol_id": 33
-      },
-      "minecraft:break_sound": {
-        "protocol_id": 71
-      },
-      "minecraft:bucket_entity_data": {
-        "protocol_id": 50
-      },
-      "minecraft:bundle_contents": {
-        "protocol_id": 41
-      },
-      "minecraft:can_break": {
-        "protocol_id": 12
-      },
-      "minecraft:can_place_on": {
-        "protocol_id": 11
-      },
-      "minecraft:cat/collar": {
-        "protocol_id": 93
-      },
-      "minecraft:cat/variant": {
-        "protocol_id": 92
-      },
-      "minecraft:charged_projectiles": {
-        "protocol_id": 40
-      },
-      "minecraft:chicken/variant": {
-        "protocol_id": 86
-      },
-      "minecraft:consumable": {
+      "minecraft:decorated_pot_base": {
         "protocol_id": 21
       },
-      "minecraft:container": {
-        "protocol_id": 66
-      },
-      "minecraft:container_loot": {
-        "protocol_id": 70
-      },
-      "minecraft:cow/variant": {
-        "protocol_id": 85
-      },
-      "minecraft:creative_slot_lock": {
-        "protocol_id": 17
-      },
-      "minecraft:custom_data": {
+      "minecraft:decorated_pot_side": {
         "protocol_id": 0
       },
-      "minecraft:custom_model_data": {
-        "protocol_id": 14
-      },
-      "minecraft:custom_name": {
-        "protocol_id": 5
-      },
-      "minecraft:damage": {
-        "protocol_id": 3
-      },
-      "minecraft:damage_resistant": {
-        "protocol_id": 24
-      },
-      "minecraft:death_protection": {
-        "protocol_id": 32
-      },
-      "minecraft:debug_stick_state": {
-        "protocol_id": 48
-      },
-      "minecraft:dyed_color": {
-        "protocol_id": 35
-      },
-      "minecraft:enchantable": {
-        "protocol_id": 27
-      },
-      "minecraft:enchantment_glint_override": {
-        "protocol_id": 18
-      },
-      "minecraft:enchantments": {
-        "protocol_id": 10
-      },
-      "minecraft:entity_data": {
-        "protocol_id": 49
-      },
-      "minecraft:equippable": {
-        "protocol_id": 28
-      },
-      "minecraft:firework_explosion": {
-        "protocol_id": 59
-      },
-      "minecraft:fireworks": {
-        "protocol_id": 60
-      },
-      "minecraft:food": {
-        "protocol_id": 20
-      },
-      "minecraft:fox/variant": {
-        "protocol_id": 76
-      },
-      "minecraft:frog/variant": {
-        "protocol_id": 87
-      },
-      "minecraft:glider": {
-        "protocol_id": 30
-      },
-      "minecraft:horse/variant": {
-        "protocol_id": 88
-      },
-      "minecraft:instrument": {
-        "protocol_id": 52
-      },
-      "minecraft:intangible_projectile": {
-        "protocol_id": 19
-      },
-      "minecraft:item_model": {
-        "protocol_id": 7
-      },
-      "minecraft:item_name": {
-        "protocol_id": 6
-      },
-      "minecraft:jukebox_playable": {
-        "protocol_id": 55
-      },
-      "minecraft:llama/variant": {
-        "protocol_id": 90
-      },
-      "minecraft:lock": {
-        "protocol_id": 69
-      },
-      "minecraft:lodestone_tracker": {
-        "protocol_id": 58
-      },
-      "minecraft:lore": {
+      "minecraft:explorer_pottery_pattern": {
         "protocol_id": 8
       },
-      "minecraft:map_color": {
-        "protocol_id": 36
-      },
-      "minecraft:map_decorations": {
-        "protocol_id": 38
-      },
-      "minecraft:map_id": {
-        "protocol_id": 37
-      },
-      "minecraft:map_post_processing": {
-        "protocol_id": 39
-      },
-      "minecraft:max_damage": {
-        "protocol_id": 2
-      },
-      "minecraft:max_stack_size": {
-        "protocol_id": 1
-      },
-      "minecraft:mooshroom/variant": {
-        "protocol_id": 82
-      },
-      "minecraft:note_block_sound": {
-        "protocol_id": 62
-      },
-      "minecraft:ominous_bottle_amplifier": {
-        "protocol_id": 54
-      },
-      "minecraft:painting/variant": {
-        "protocol_id": 89
-      },
-      "minecraft:parrot/variant": {
-        "protocol_id": 78
-      },
-      "minecraft:pig/variant": {
-        "protocol_id": 84
-      },
-      "minecraft:pot_decorations": {
-        "protocol_id": 65
-      },
-      "minecraft:potion_contents": {
-        "protocol_id": 42
-      },
-      "minecraft:potion_duration_scale": {
-        "protocol_id": 43
-      },
-      "minecraft:profile": {
-        "protocol_id": 61
-      },
-      "minecraft:provides_banner_patterns": {
-        "protocol_id": 56
-      },
-      "minecraft:provides_trim_material": {
-        "protocol_id": 53
-      },
-      "minecraft:rabbit/variant": {
-        "protocol_id": 83
-      },
-      "minecraft:rarity": {
+      "minecraft:friend_pottery_pattern": {
         "protocol_id": 9
       },
-      "minecraft:recipes": {
-        "protocol_id": 57
+      "minecraft:heart_pottery_pattern": {
+        "protocol_id": 10
       },
-      "minecraft:repair_cost": {
-        "protocol_id": 16
+      "minecraft:heartbreak_pottery_pattern": {
+        "protocol_id": 11
       },
-      "minecraft:repairable": {
-        "protocol_id": 29
+      "minecraft:howl_pottery_pattern": {
+        "protocol_id": 12
       },
-      "minecraft:salmon/size": {
-        "protocol_id": 77
+      "minecraft:miner_pottery_pattern": {
+        "protocol_id": 13
       },
-      "minecraft:sheep/color": {
-        "protocol_id": 94
+      "minecraft:mourner_pottery_pattern": {
+        "protocol_id": 14
       },
-      "minecraft:shulker/color": {
-        "protocol_id": 95
-      },
-      "minecraft:stored_enchantments": {
-        "protocol_id": 34
-      },
-      "minecraft:suspicious_stew_effects": {
-        "protocol_id": 44
-      },
-      "minecraft:tool": {
-        "protocol_id": 25
-      },
-      "minecraft:tooltip_display": {
+      "minecraft:plenty_pottery_pattern": {
         "protocol_id": 15
       },
-      "minecraft:tooltip_style": {
-        "protocol_id": 31
+      "minecraft:prize_pottery_pattern": {
+        "protocol_id": 16
       },
-      "minecraft:trim": {
-        "protocol_id": 47
+      "minecraft:sheaf_pottery_pattern": {
+        "protocol_id": 17
       },
-      "minecraft:tropical_fish/base_color": {
-        "protocol_id": 80
+      "minecraft:shelter_pottery_pattern": {
+        "protocol_id": 18
       },
-      "minecraft:tropical_fish/pattern": {
-        "protocol_id": 79
+      "minecraft:skull_pottery_pattern": {
+        "protocol_id": 19
       },
-      "minecraft:tropical_fish/pattern_color": {
-        "protocol_id": 81
-      },
-      "minecraft:unbreakable": {
-        "protocol_id": 4
-      },
-      "minecraft:use_cooldown": {
-        "protocol_id": 23
-      },
-      "minecraft:use_remainder": {
-        "protocol_id": 22
-      },
-      "minecraft:villager/variant": {
-        "protocol_id": 72
-      },
-      "minecraft:weapon": {
-        "protocol_id": 26
-      },
-      "minecraft:wolf/collar": {
-        "protocol_id": 75
-      },
-      "minecraft:wolf/sound_variant": {
-        "protocol_id": 74
-      },
-      "minecraft:wolf/variant": {
-        "protocol_id": 73
-      },
-      "minecraft:writable_book_content": {
-        "protocol_id": 45
-      },
-      "minecraft:written_book_content": {
-        "protocol_id": 46
+      "minecraft:snort_pottery_pattern": {
+        "protocol_id": 20
       }
     },
     "protocol_id": 64
   },
-  "minecraft:decorated_pot_pattern": {
+  "minecraft:enchantment": {
     "entries": {
-      "minecraft:angler": {
-        "protocol_id": 0
-      },
-      "minecraft:archer": {
-        "protocol_id": 1
-      },
-      "minecraft:arms_up": {
-        "protocol_id": 2
-      },
-      "minecraft:blade": {
-        "protocol_id": 3
-      },
-      "minecraft:blank": {
-        "protocol_id": 23
-      },
-      "minecraft:brewer": {
-        "protocol_id": 4
-      },
-      "minecraft:burn": {
-        "protocol_id": 5
-      },
-      "minecraft:danger": {
+      "minecraft:aqua_affinity": {
         "protocol_id": 6
       },
-      "minecraft:explorer": {
-        "protocol_id": 7
-      },
-      "minecraft:flow": {
-        "protocol_id": 8
-      },
-      "minecraft:friend": {
-        "protocol_id": 9
-      },
-      "minecraft:guster": {
-        "protocol_id": 10
-      },
-      "minecraft:heart": {
-        "protocol_id": 11
-      },
-      "minecraft:heartbreak": {
-        "protocol_id": 12
-      },
-      "minecraft:howl": {
-        "protocol_id": 13
-      },
-      "minecraft:miner": {
-        "protocol_id": 14
-      },
-      "minecraft:mourner": {
+      "minecraft:bane_of_arthropods": {
         "protocol_id": 15
       },
-      "minecraft:plenty": {
-        "protocol_id": 16
-      },
-      "minecraft:prize": {
-        "protocol_id": 17
-      },
-      "minecraft:scrape": {
-        "protocol_id": 18
-      },
-      "minecraft:sheaf": {
-        "protocol_id": 19
-      },
-      "minecraft:shelter": {
-        "protocol_id": 20
-      },
-      "minecraft:skull": {
-        "protocol_id": 21
-      },
-      "minecraft:snort": {
-        "protocol_id": 22
-      }
-    },
-    "protocol_id": 60
-  },
-  "minecraft:enchantment_effect_component_type": {
-    "entries": {
-      "minecraft:ammo_use": {
-        "protocol_id": 13
-      },
-      "minecraft:armor_effectiveness": {
-        "protocol_id": 5
-      },
-      "minecraft:attributes": {
-        "protocol_id": 9
-      },
-      "minecraft:block_experience": {
-        "protocol_id": 21
-      },
-      "minecraft:crossbow_charge_time": {
-        "protocol_id": 24
-      },
-      "minecraft:crossbow_charging_sounds": {
-        "protocol_id": 25
-      },
-      "minecraft:damage": {
-        "protocol_id": 2
-      },
-      "minecraft:damage_immunity": {
-        "protocol_id": 1
-      },
-      "minecraft:damage_protection": {
-        "protocol_id": 0
-      },
-      "minecraft:equipment_drops": {
+      "minecraft:binding_curse": {
         "protocol_id": 10
       },
-      "minecraft:fishing_luck_bonus": {
-        "protocol_id": 20
-      },
-      "minecraft:fishing_time_reduction": {
-        "protocol_id": 19
-      },
-      "minecraft:hit_block": {
-        "protocol_id": 7
-      },
-      "minecraft:item_damage": {
-        "protocol_id": 8
-      },
-      "minecraft:knockback": {
-        "protocol_id": 4
-      },
-      "minecraft:location_changed": {
-        "protocol_id": 11
-      },
-      "minecraft:mob_experience": {
-        "protocol_id": 22
-      },
-      "minecraft:post_attack": {
-        "protocol_id": 6
-      },
-      "minecraft:prevent_armor_change": {
-        "protocol_id": 28
-      },
-      "minecraft:prevent_equipment_drop": {
-        "protocol_id": 27
-      },
-      "minecraft:projectile_count": {
-        "protocol_id": 17
-      },
-      "minecraft:projectile_piercing": {
-        "protocol_id": 14
-      },
-      "minecraft:projectile_spawned": {
-        "protocol_id": 15
-      },
-      "minecraft:projectile_spread": {
-        "protocol_id": 16
-      },
-      "minecraft:repair_with_xp": {
-        "protocol_id": 23
-      },
-      "minecraft:smash_damage_per_fallen_block": {
+      "minecraft:blast_protection": {
         "protocol_id": 3
       },
-      "minecraft:tick": {
-        "protocol_id": 12
+      "minecraft:channeling": {
+        "protocol_id": 33
       },
-      "minecraft:trident_return_acceleration": {
-        "protocol_id": 18
+      "minecraft:depth_strider": {
+        "protocol_id": 8
       },
-      "minecraft:trident_sound": {
+      "minecraft:efficiency": {
+        "protocol_id": 20
+      },
+      "minecraft:feather_falling": {
+        "protocol_id": 2
+      },
+      "minecraft:fire_aspect": {
+        "protocol_id": 17
+      },
+      "minecraft:fire_protection": {
+        "protocol_id": 1
+      },
+      "minecraft:flame": {
         "protocol_id": 26
       },
-      "minecraft:trident_spin_attack_strength": {
+      "minecraft:fortune": {
+        "protocol_id": 23
+      },
+      "minecraft:frost_walker": {
+        "protocol_id": 9
+      },
+      "minecraft:impaling": {
+        "protocol_id": 31
+      },
+      "minecraft:infinity": {
+        "protocol_id": 27
+      },
+      "minecraft:knockback": {
+        "protocol_id": 16
+      },
+      "minecraft:looting": {
+        "protocol_id": 18
+      },
+      "minecraft:loyalty": {
+        "protocol_id": 30
+      },
+      "minecraft:luck_of_the_sea": {
+        "protocol_id": 28
+      },
+      "minecraft:lure": {
         "protocol_id": 29
-      }
-    },
-    "protocol_id": 68
-  },
-  "minecraft:enchantment_entity_effect_type": {
-    "entries": {
-      "minecraft:all_of": {
-        "protocol_id": 0
       },
-      "minecraft:apply_mob_effect": {
-        "protocol_id": 1
+      "minecraft:mending": {
+        "protocol_id": 37
       },
-      "minecraft:change_item_damage": {
-        "protocol_id": 2
+      "minecraft:multishot": {
+        "protocol_id": 34
       },
-      "minecraft:damage_entity": {
-        "protocol_id": 3
+      "minecraft:piercing": {
+        "protocol_id": 36
       },
-      "minecraft:explode": {
+      "minecraft:power": {
+        "protocol_id": 24
+      },
+      "minecraft:projectile_protection": {
         "protocol_id": 4
       },
-      "minecraft:ignite": {
+      "minecraft:protection": {
+        "protocol_id": 0
+      },
+      "minecraft:punch": {
+        "protocol_id": 25
+      },
+      "minecraft:quick_charge": {
+        "protocol_id": 35
+      },
+      "minecraft:respiration": {
         "protocol_id": 5
       },
-      "minecraft:play_sound": {
-        "protocol_id": 6
+      "minecraft:riptide": {
+        "protocol_id": 32
       },
-      "minecraft:replace_block": {
-        "protocol_id": 7
-      },
-      "minecraft:replace_disk": {
-        "protocol_id": 8
-      },
-      "minecraft:run_function": {
-        "protocol_id": 9
-      },
-      "minecraft:set_block_properties": {
-        "protocol_id": 10
-      },
-      "minecraft:spawn_particles": {
-        "protocol_id": 11
-      },
-      "minecraft:summon_entity": {
-        "protocol_id": 12
-      }
-    },
-    "protocol_id": 70
-  },
-  "minecraft:enchantment_level_based_value_type": {
-    "entries": {
-      "minecraft:clamped": {
-        "protocol_id": 0
-      },
-      "minecraft:fraction": {
-        "protocol_id": 1
-      },
-      "minecraft:levels_squared": {
-        "protocol_id": 2
-      },
-      "minecraft:linear": {
-        "protocol_id": 3
-      },
-      "minecraft:lookup": {
-        "protocol_id": 4
-      }
-    },
-    "protocol_id": 69
-  },
-  "minecraft:enchantment_location_based_effect_type": {
-    "entries": {
-      "minecraft:all_of": {
-        "protocol_id": 0
-      },
-      "minecraft:apply_mob_effect": {
-        "protocol_id": 1
-      },
-      "minecraft:attribute": {
-        "protocol_id": 2
-      },
-      "minecraft:change_item_damage": {
-        "protocol_id": 3
-      },
-      "minecraft:damage_entity": {
-        "protocol_id": 4
-      },
-      "minecraft:explode": {
-        "protocol_id": 5
-      },
-      "minecraft:ignite": {
-        "protocol_id": 6
-      },
-      "minecraft:play_sound": {
-        "protocol_id": 7
-      },
-      "minecraft:replace_block": {
-        "protocol_id": 8
-      },
-      "minecraft:replace_disk": {
-        "protocol_id": 9
-      },
-      "minecraft:run_function": {
-        "protocol_id": 10
-      },
-      "minecraft:set_block_properties": {
-        "protocol_id": 11
-      },
-      "minecraft:spawn_particles": {
-        "protocol_id": 12
-      },
-      "minecraft:summon_entity": {
+      "minecraft:sharpness": {
         "protocol_id": 13
+      },
+      "minecraft:silk_touch": {
+        "protocol_id": 21
+      },
+      "minecraft:smite": {
+        "protocol_id": 14
+      },
+      "minecraft:soul_speed": {
+        "protocol_id": 11
+      },
+      "minecraft:sweeping": {
+        "protocol_id": 19
+      },
+      "minecraft:swift_sneak": {
+        "protocol_id": 12
+      },
+      "minecraft:thorns": {
+        "protocol_id": 7
+      },
+      "minecraft:unbreaking": {
+        "protocol_id": 22
+      },
+      "minecraft:vanishing_curse": {
+        "protocol_id": 38
       }
     },
-    "protocol_id": 71
-  },
-  "minecraft:enchantment_provider_type": {
-    "entries": {
-      "minecraft:by_cost": {
-        "protocol_id": 0
-      },
-      "minecraft:by_cost_with_difficulty": {
-        "protocol_id": 1
-      },
-      "minecraft:single": {
-        "protocol_id": 2
-      }
-    },
-    "protocol_id": 73
-  },
-  "minecraft:enchantment_value_effect_type": {
-    "entries": {
-      "minecraft:add": {
-        "protocol_id": 0
-      },
-      "minecraft:all_of": {
-        "protocol_id": 1
-      },
-      "minecraft:multiply": {
-        "protocol_id": 2
-      },
-      "minecraft:remove_binomial": {
-        "protocol_id": 3
-      },
-      "minecraft:set": {
-        "protocol_id": 4
-      }
-    },
-    "protocol_id": 72
-  },
-  "minecraft:entity_sub_predicate_type": {
-    "entries": {
-      "minecraft:fishing_hook": {
-        "protocol_id": 1
-      },
-      "minecraft:lightning": {
-        "protocol_id": 0
-      },
-      "minecraft:player": {
-        "protocol_id": 2
-      },
-      "minecraft:raider": {
-        "protocol_id": 4
-      },
-      "minecraft:sheep": {
-        "protocol_id": 5
-      },
-      "minecraft:slime": {
-        "protocol_id": 3
-      }
-    },
-    "protocol_id": 65
+    "protocol_id": 5
   },
   "minecraft:entity_type": {
     "default": "minecraft:pig",
     "entries": {
-      "minecraft:acacia_boat": {
+      "minecraft:allay": {
         "protocol_id": 0
       },
-      "minecraft:acacia_chest_boat": {
+      "minecraft:area_effect_cloud": {
         "protocol_id": 1
       },
-      "minecraft:allay": {
+      "minecraft:armor_stand": {
         "protocol_id": 2
       },
-      "minecraft:area_effect_cloud": {
+      "minecraft:arrow": {
         "protocol_id": 3
       },
-      "minecraft:armadillo": {
+      "minecraft:axolotl": {
         "protocol_id": 4
       },
-      "minecraft:armor_stand": {
+      "minecraft:bat": {
         "protocol_id": 5
       },
-      "minecraft:arrow": {
+      "minecraft:bee": {
         "protocol_id": 6
       },
-      "minecraft:axolotl": {
+      "minecraft:blaze": {
         "protocol_id": 7
       },
-      "minecraft:bamboo_chest_raft": {
+      "minecraft:block_display": {
         "protocol_id": 8
       },
-      "minecraft:bamboo_raft": {
+      "minecraft:boat": {
         "protocol_id": 9
       },
-      "minecraft:bat": {
+      "minecraft:camel": {
         "protocol_id": 10
       },
-      "minecraft:bee": {
+      "minecraft:cat": {
         "protocol_id": 11
       },
-      "minecraft:birch_boat": {
+      "minecraft:cave_spider": {
         "protocol_id": 12
       },
-      "minecraft:birch_chest_boat": {
+      "minecraft:chest_boat": {
         "protocol_id": 13
       },
-      "minecraft:blaze": {
+      "minecraft:chest_minecart": {
         "protocol_id": 14
       },
-      "minecraft:block_display": {
+      "minecraft:chicken": {
         "protocol_id": 15
       },
-      "minecraft:bogged": {
+      "minecraft:cod": {
         "protocol_id": 16
       },
-      "minecraft:breeze": {
+      "minecraft:command_block_minecart": {
         "protocol_id": 17
       },
-      "minecraft:breeze_wind_charge": {
+      "minecraft:cow": {
         "protocol_id": 18
       },
-      "minecraft:camel": {
+      "minecraft:creeper": {
         "protocol_id": 19
       },
-      "minecraft:cat": {
+      "minecraft:dolphin": {
         "protocol_id": 20
       },
-      "minecraft:cave_spider": {
+      "minecraft:donkey": {
         "protocol_id": 21
       },
-      "minecraft:cherry_boat": {
+      "minecraft:dragon_fireball": {
         "protocol_id": 22
       },
-      "minecraft:cherry_chest_boat": {
+      "minecraft:drowned": {
         "protocol_id": 23
       },
-      "minecraft:chest_minecart": {
+      "minecraft:egg": {
         "protocol_id": 24
       },
-      "minecraft:chicken": {
+      "minecraft:elder_guardian": {
         "protocol_id": 25
       },
-      "minecraft:cod": {
+      "minecraft:end_crystal": {
         "protocol_id": 26
       },
-      "minecraft:command_block_minecart": {
+      "minecraft:ender_dragon": {
         "protocol_id": 27
       },
-      "minecraft:cow": {
+      "minecraft:ender_pearl": {
         "protocol_id": 28
       },
-      "minecraft:creaking": {
+      "minecraft:enderman": {
         "protocol_id": 29
       },
-      "minecraft:creeper": {
+      "minecraft:endermite": {
         "protocol_id": 30
       },
-      "minecraft:dark_oak_boat": {
+      "minecraft:evoker": {
         "protocol_id": 31
       },
-      "minecraft:dark_oak_chest_boat": {
+      "minecraft:evoker_fangs": {
         "protocol_id": 32
       },
-      "minecraft:dolphin": {
+      "minecraft:experience_bottle": {
         "protocol_id": 33
       },
-      "minecraft:donkey": {
+      "minecraft:experience_orb": {
         "protocol_id": 34
       },
-      "minecraft:dragon_fireball": {
+      "minecraft:eye_of_ender": {
         "protocol_id": 35
       },
-      "minecraft:drowned": {
+      "minecraft:falling_block": {
         "protocol_id": 36
       },
-      "minecraft:egg": {
-        "protocol_id": 37
-      },
-      "minecraft:elder_guardian": {
-        "protocol_id": 38
-      },
-      "minecraft:end_crystal": {
-        "protocol_id": 43
-      },
-      "minecraft:ender_dragon": {
-        "protocol_id": 41
-      },
-      "minecraft:ender_pearl": {
-        "protocol_id": 42
-      },
-      "minecraft:enderman": {
-        "protocol_id": 39
-      },
-      "minecraft:endermite": {
-        "protocol_id": 40
-      },
-      "minecraft:evoker": {
-        "protocol_id": 44
-      },
-      "minecraft:evoker_fangs": {
-        "protocol_id": 45
-      },
-      "minecraft:experience_bottle": {
-        "protocol_id": 46
-      },
-      "minecraft:experience_orb": {
-        "protocol_id": 47
-      },
-      "minecraft:eye_of_ender": {
-        "protocol_id": 48
-      },
-      "minecraft:falling_block": {
-        "protocol_id": 49
-      },
       "minecraft:fireball": {
-        "protocol_id": 50
-      },
-      "minecraft:firework_rocket": {
-        "protocol_id": 51
-      },
-      "minecraft:fishing_bobber": {
-        "protocol_id": 149
-      },
-      "minecraft:fox": {
-        "protocol_id": 52
-      },
-      "minecraft:frog": {
-        "protocol_id": 53
-      },
-      "minecraft:furnace_minecart": {
-        "protocol_id": 54
-      },
-      "minecraft:ghast": {
-        "protocol_id": 55
-      },
-      "minecraft:giant": {
-        "protocol_id": 56
-      },
-      "minecraft:glow_item_frame": {
         "protocol_id": 57
       },
-      "minecraft:glow_squid": {
-        "protocol_id": 58
+      "minecraft:firework_rocket": {
+        "protocol_id": 37
       },
-      "minecraft:goat": {
-        "protocol_id": 59
-      },
-      "minecraft:guardian": {
-        "protocol_id": 60
-      },
-      "minecraft:hoglin": {
-        "protocol_id": 61
-      },
-      "minecraft:hopper_minecart": {
-        "protocol_id": 62
-      },
-      "minecraft:horse": {
-        "protocol_id": 63
-      },
-      "minecraft:husk": {
-        "protocol_id": 64
-      },
-      "minecraft:illusioner": {
-        "protocol_id": 65
-      },
-      "minecraft:interaction": {
-        "protocol_id": 66
-      },
-      "minecraft:iron_golem": {
-        "protocol_id": 67
-      },
-      "minecraft:item": {
-        "protocol_id": 68
-      },
-      "minecraft:item_display": {
-        "protocol_id": 69
-      },
-      "minecraft:item_frame": {
-        "protocol_id": 70
-      },
-      "minecraft:jungle_boat": {
-        "protocol_id": 71
-      },
-      "minecraft:jungle_chest_boat": {
-        "protocol_id": 72
-      },
-      "minecraft:leash_knot": {
-        "protocol_id": 73
-      },
-      "minecraft:lightning_bolt": {
-        "protocol_id": 74
-      },
-      "minecraft:lingering_potion": {
-        "protocol_id": 100
-      },
-      "minecraft:llama": {
-        "protocol_id": 75
-      },
-      "minecraft:llama_spit": {
-        "protocol_id": 76
-      },
-      "minecraft:magma_cube": {
-        "protocol_id": 77
-      },
-      "minecraft:mangrove_boat": {
-        "protocol_id": 78
-      },
-      "minecraft:mangrove_chest_boat": {
-        "protocol_id": 79
-      },
-      "minecraft:marker": {
-        "protocol_id": 80
-      },
-      "minecraft:minecart": {
-        "protocol_id": 81
-      },
-      "minecraft:mooshroom": {
-        "protocol_id": 82
-      },
-      "minecraft:mule": {
-        "protocol_id": 83
-      },
-      "minecraft:oak_boat": {
-        "protocol_id": 84
-      },
-      "minecraft:oak_chest_boat": {
-        "protocol_id": 85
-      },
-      "minecraft:ocelot": {
-        "protocol_id": 86
-      },
-      "minecraft:ominous_item_spawner": {
-        "protocol_id": 87
-      },
-      "minecraft:painting": {
-        "protocol_id": 88
-      },
-      "minecraft:pale_oak_boat": {
-        "protocol_id": 89
-      },
-      "minecraft:pale_oak_chest_boat": {
-        "protocol_id": 90
-      },
-      "minecraft:panda": {
-        "protocol_id": 91
-      },
-      "minecraft:parrot": {
-        "protocol_id": 92
-      },
-      "minecraft:phantom": {
-        "protocol_id": 93
-      },
-      "minecraft:pig": {
-        "protocol_id": 94
-      },
-      "minecraft:piglin": {
-        "protocol_id": 95
-      },
-      "minecraft:piglin_brute": {
-        "protocol_id": 96
-      },
-      "minecraft:pillager": {
-        "protocol_id": 97
-      },
-      "minecraft:player": {
-        "protocol_id": 148
-      },
-      "minecraft:polar_bear": {
-        "protocol_id": 98
-      },
-      "minecraft:pufferfish": {
-        "protocol_id": 101
-      },
-      "minecraft:rabbit": {
-        "protocol_id": 102
-      },
-      "minecraft:ravager": {
-        "protocol_id": 103
-      },
-      "minecraft:salmon": {
-        "protocol_id": 104
-      },
-      "minecraft:sheep": {
-        "protocol_id": 105
-      },
-      "minecraft:shulker": {
-        "protocol_id": 106
-      },
-      "minecraft:shulker_bullet": {
-        "protocol_id": 107
-      },
-      "minecraft:silverfish": {
-        "protocol_id": 108
-      },
-      "minecraft:skeleton": {
-        "protocol_id": 109
-      },
-      "minecraft:skeleton_horse": {
-        "protocol_id": 110
-      },
-      "minecraft:slime": {
-        "protocol_id": 111
-      },
-      "minecraft:small_fireball": {
-        "protocol_id": 112
-      },
-      "minecraft:sniffer": {
-        "protocol_id": 113
-      },
-      "minecraft:snow_golem": {
-        "protocol_id": 115
-      },
-      "minecraft:snowball": {
-        "protocol_id": 114
-      },
-      "minecraft:spawner_minecart": {
-        "protocol_id": 116
-      },
-      "minecraft:spectral_arrow": {
-        "protocol_id": 117
-      },
-      "minecraft:spider": {
-        "protocol_id": 118
-      },
-      "minecraft:splash_potion": {
-        "protocol_id": 99
-      },
-      "minecraft:spruce_boat": {
-        "protocol_id": 119
-      },
-      "minecraft:spruce_chest_boat": {
-        "protocol_id": 120
-      },
-      "minecraft:squid": {
-        "protocol_id": 121
-      },
-      "minecraft:stray": {
-        "protocol_id": 122
-      },
-      "minecraft:strider": {
+      "minecraft:fishing_bobber": {
         "protocol_id": 123
       },
+      "minecraft:fox": {
+        "protocol_id": 38
+      },
+      "minecraft:frog": {
+        "protocol_id": 39
+      },
+      "minecraft:furnace_minecart": {
+        "protocol_id": 40
+      },
+      "minecraft:ghast": {
+        "protocol_id": 41
+      },
+      "minecraft:giant": {
+        "protocol_id": 42
+      },
+      "minecraft:glow_item_frame": {
+        "protocol_id": 43
+      },
+      "minecraft:glow_squid": {
+        "protocol_id": 44
+      },
+      "minecraft:goat": {
+        "protocol_id": 45
+      },
+      "minecraft:guardian": {
+        "protocol_id": 46
+      },
+      "minecraft:hoglin": {
+        "protocol_id": 47
+      },
+      "minecraft:hopper_minecart": {
+        "protocol_id": 48
+      },
+      "minecraft:horse": {
+        "protocol_id": 49
+      },
+      "minecraft:husk": {
+        "protocol_id": 50
+      },
+      "minecraft:illusioner": {
+        "protocol_id": 51
+      },
+      "minecraft:interaction": {
+        "protocol_id": 52
+      },
+      "minecraft:iron_golem": {
+        "protocol_id": 53
+      },
+      "minecraft:item": {
+        "protocol_id": 54
+      },
+      "minecraft:item_display": {
+        "protocol_id": 55
+      },
+      "minecraft:item_frame": {
+        "protocol_id": 56
+      },
+      "minecraft:leash_knot": {
+        "protocol_id": 58
+      },
+      "minecraft:lightning_bolt": {
+        "protocol_id": 59
+      },
+      "minecraft:llama": {
+        "protocol_id": 60
+      },
+      "minecraft:llama_spit": {
+        "protocol_id": 61
+      },
+      "minecraft:magma_cube": {
+        "protocol_id": 62
+      },
+      "minecraft:marker": {
+        "protocol_id": 63
+      },
+      "minecraft:minecart": {
+        "protocol_id": 64
+      },
+      "minecraft:mooshroom": {
+        "protocol_id": 65
+      },
+      "minecraft:mule": {
+        "protocol_id": 66
+      },
+      "minecraft:ocelot": {
+        "protocol_id": 67
+      },
+      "minecraft:painting": {
+        "protocol_id": 68
+      },
+      "minecraft:panda": {
+        "protocol_id": 69
+      },
+      "minecraft:parrot": {
+        "protocol_id": 70
+      },
+      "minecraft:phantom": {
+        "protocol_id": 71
+      },
+      "minecraft:pig": {
+        "protocol_id": 72
+      },
+      "minecraft:piglin": {
+        "protocol_id": 73
+      },
+      "minecraft:piglin_brute": {
+        "protocol_id": 74
+      },
+      "minecraft:pillager": {
+        "protocol_id": 75
+      },
+      "minecraft:player": {
+        "protocol_id": 122
+      },
+      "minecraft:polar_bear": {
+        "protocol_id": 76
+      },
+      "minecraft:potion": {
+        "protocol_id": 77
+      },
+      "minecraft:pufferfish": {
+        "protocol_id": 78
+      },
+      "minecraft:rabbit": {
+        "protocol_id": 79
+      },
+      "minecraft:ravager": {
+        "protocol_id": 80
+      },
+      "minecraft:salmon": {
+        "protocol_id": 81
+      },
+      "minecraft:sheep": {
+        "protocol_id": 82
+      },
+      "minecraft:shulker": {
+        "protocol_id": 83
+      },
+      "minecraft:shulker_bullet": {
+        "protocol_id": 84
+      },
+      "minecraft:silverfish": {
+        "protocol_id": 85
+      },
+      "minecraft:skeleton": {
+        "protocol_id": 86
+      },
+      "minecraft:skeleton_horse": {
+        "protocol_id": 87
+      },
+      "minecraft:slime": {
+        "protocol_id": 88
+      },
+      "minecraft:small_fireball": {
+        "protocol_id": 89
+      },
+      "minecraft:sniffer": {
+        "protocol_id": 90
+      },
+      "minecraft:snow_golem": {
+        "protocol_id": 91
+      },
+      "minecraft:snowball": {
+        "protocol_id": 92
+      },
+      "minecraft:spawner_minecart": {
+        "protocol_id": 93
+      },
+      "minecraft:spectral_arrow": {
+        "protocol_id": 94
+      },
+      "minecraft:spider": {
+        "protocol_id": 95
+      },
+      "minecraft:squid": {
+        "protocol_id": 96
+      },
+      "minecraft:stray": {
+        "protocol_id": 97
+      },
+      "minecraft:strider": {
+        "protocol_id": 98
+      },
       "minecraft:tadpole": {
-        "protocol_id": 124
+        "protocol_id": 99
       },
       "minecraft:text_display": {
-        "protocol_id": 125
+        "protocol_id": 100
       },
       "minecraft:tnt": {
-        "protocol_id": 126
+        "protocol_id": 101
       },
       "minecraft:tnt_minecart": {
-        "protocol_id": 127
+        "protocol_id": 102
       },
       "minecraft:trader_llama": {
-        "protocol_id": 128
+        "protocol_id": 103
       },
       "minecraft:trident": {
-        "protocol_id": 129
+        "protocol_id": 104
       },
       "minecraft:tropical_fish": {
-        "protocol_id": 130
+        "protocol_id": 105
       },
       "minecraft:turtle": {
-        "protocol_id": 131
+        "protocol_id": 106
       },
       "minecraft:vex": {
-        "protocol_id": 132
+        "protocol_id": 107
       },
       "minecraft:villager": {
-        "protocol_id": 133
+        "protocol_id": 108
       },
       "minecraft:vindicator": {
-        "protocol_id": 134
+        "protocol_id": 109
       },
       "minecraft:wandering_trader": {
-        "protocol_id": 135
+        "protocol_id": 110
       },
       "minecraft:warden": {
-        "protocol_id": 136
-      },
-      "minecraft:wind_charge": {
-        "protocol_id": 137
+        "protocol_id": 111
       },
       "minecraft:witch": {
-        "protocol_id": 138
+        "protocol_id": 112
       },
       "minecraft:wither": {
-        "protocol_id": 139
+        "protocol_id": 113
       },
       "minecraft:wither_skeleton": {
-        "protocol_id": 140
+        "protocol_id": 114
       },
       "minecraft:wither_skull": {
-        "protocol_id": 141
+        "protocol_id": 115
       },
       "minecraft:wolf": {
-        "protocol_id": 142
+        "protocol_id": 116
       },
       "minecraft:zoglin": {
-        "protocol_id": 143
+        "protocol_id": 117
       },
       "minecraft:zombie": {
-        "protocol_id": 144
+        "protocol_id": 118
       },
       "minecraft:zombie_horse": {
-        "protocol_id": 145
+        "protocol_id": 119
       },
       "minecraft:zombie_villager": {
-        "protocol_id": 146
+        "protocol_id": 120
       },
       "minecraft:zombified_piglin": {
-        "protocol_id": 147
+        "protocol_id": 121
       }
     },
-    "protocol_id": 5
+    "protocol_id": 6
   },
   "minecraft:float_provider_type": {
     "entries": {
@@ -6121,7 +4533,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 35
+    "protocol_id": 37
   },
   "minecraft:fluid": {
     "default": "minecraft:empty",
@@ -6143,6 +4555,20 @@
       }
     },
     "protocol_id": 2
+  },
+  "minecraft:frog_variant": {
+    "entries": {
+      "minecraft:cold": {
+        "protocol_id": 2
+      },
+      "minecraft:temperate": {
+        "protocol_id": 0
+      },
+      "minecraft:warm": {
+        "protocol_id": 1
+      }
+    },
+    "protocol_id": 61
   },
   "minecraft:game_event": {
     "default": "minecraft:step",
@@ -6189,9 +4615,6 @@
       "minecraft:elytra_glide": {
         "protocol_id": 13
       },
-      "minecraft:entity_action": {
-        "protocol_id": 20
-      },
       "minecraft:entity_damage": {
         "protocol_id": 14
       },
@@ -6210,53 +4633,59 @@
       "minecraft:entity_place": {
         "protocol_id": 19
       },
-      "minecraft:equip": {
+      "minecraft:entity_roar": {
+        "protocol_id": 20
+      },
+      "minecraft:entity_shake": {
         "protocol_id": 21
       },
-      "minecraft:explode": {
+      "minecraft:equip": {
         "protocol_id": 22
       },
-      "minecraft:flap": {
+      "minecraft:explode": {
         "protocol_id": 23
       },
-      "minecraft:fluid_pickup": {
+      "minecraft:flap": {
         "protocol_id": 24
       },
-      "minecraft:fluid_place": {
+      "minecraft:fluid_pickup": {
         "protocol_id": 25
       },
-      "minecraft:hit_ground": {
+      "minecraft:fluid_place": {
         "protocol_id": 26
       },
-      "minecraft:instrument_play": {
+      "minecraft:hit_ground": {
         "protocol_id": 27
       },
-      "minecraft:item_interact_finish": {
+      "minecraft:instrument_play": {
         "protocol_id": 28
       },
-      "minecraft:item_interact_start": {
+      "minecraft:item_interact_finish": {
         "protocol_id": 29
       },
-      "minecraft:jukebox_play": {
+      "minecraft:item_interact_start": {
         "protocol_id": 30
       },
-      "minecraft:jukebox_stop_play": {
+      "minecraft:jukebox_play": {
         "protocol_id": 31
       },
-      "minecraft:lightning_strike": {
+      "minecraft:jukebox_stop_play": {
         "protocol_id": 32
       },
-      "minecraft:note_block_play": {
+      "minecraft:lightning_strike": {
         "protocol_id": 33
       },
-      "minecraft:prime_fuse": {
+      "minecraft:note_block_play": {
         "protocol_id": 34
       },
-      "minecraft:projectile_land": {
+      "minecraft:prime_fuse": {
         "protocol_id": 35
       },
-      "minecraft:projectile_shoot": {
+      "minecraft:projectile_land": {
         "protocol_id": 36
+      },
+      "minecraft:projectile_shoot": {
+        "protocol_id": 37
       },
       "minecraft:resonate_1": {
         "protocol_id": 45
@@ -6304,27 +4733,24 @@
         "protocol_id": 53
       },
       "minecraft:sculk_sensor_tendrils_clicking": {
-        "protocol_id": 37
-      },
-      "minecraft:shear": {
         "protocol_id": 38
       },
-      "minecraft:shriek": {
+      "minecraft:shear": {
         "protocol_id": 39
       },
-      "minecraft:splash": {
+      "minecraft:shriek": {
         "protocol_id": 40
       },
-      "minecraft:step": {
+      "minecraft:splash": {
         "protocol_id": 41
       },
-      "minecraft:swim": {
+      "minecraft:step": {
         "protocol_id": 42
       },
-      "minecraft:teleport": {
+      "minecraft:swim": {
         "protocol_id": 43
       },
-      "minecraft:unequip": {
+      "minecraft:teleport": {
         "protocol_id": 44
       }
     },
@@ -6351,7 +4777,36 @@
         "protocol_id": 5
       }
     },
-    "protocol_id": 37
+    "protocol_id": 39
+  },
+  "minecraft:instrument": {
+    "entries": {
+      "minecraft:admire_goat_horn": {
+        "protocol_id": 4
+      },
+      "minecraft:call_goat_horn": {
+        "protocol_id": 5
+      },
+      "minecraft:dream_goat_horn": {
+        "protocol_id": 7
+      },
+      "minecraft:feel_goat_horn": {
+        "protocol_id": 3
+      },
+      "minecraft:ponder_goat_horn": {
+        "protocol_id": 0
+      },
+      "minecraft:seek_goat_horn": {
+        "protocol_id": 2
+      },
+      "minecraft:sing_goat_horn": {
+        "protocol_id": 1
+      },
+      "minecraft:yearn_goat_horn": {
+        "protocol_id": 6
+      }
+    },
+    "protocol_id": 63
   },
   "minecraft:int_provider_type": {
     "entries": {
@@ -6374,4201 +4829,3778 @@
         "protocol_id": 4
       }
     },
-    "protocol_id": 36
+    "protocol_id": 38
   },
   "minecraft:item": {
     "default": "minecraft:air",
     "entries": {
       "minecraft:acacia_boat": {
-        "protocol_id": 818
+        "protocol_id": 744
       },
       "minecraft:acacia_button": {
-        "protocol_id": 718
+        "protocol_id": 666
       },
       "minecraft:acacia_chest_boat": {
-        "protocol_id": 819
+        "protocol_id": 745
       },
       "minecraft:acacia_door": {
-        "protocol_id": 747
+        "protocol_id": 693
       },
       "minecraft:acacia_fence": {
-        "protocol_id": 336
+        "protocol_id": 293
       },
       "minecraft:acacia_fence_gate": {
-        "protocol_id": 788
+        "protocol_id": 716
       },
       "minecraft:acacia_hanging_sign": {
-        "protocol_id": 942
+        "protocol_id": 861
       },
       "minecraft:acacia_leaves": {
-        "protocol_id": 186
+        "protocol_id": 158
       },
       "minecraft:acacia_log": {
-        "protocol_id": 138
+        "protocol_id": 114
       },
       "minecraft:acacia_planks": {
-        "protocol_id": 40
+        "protocol_id": 27
       },
       "minecraft:acacia_pressure_plate": {
-        "protocol_id": 734
+        "protocol_id": 681
       },
       "minecraft:acacia_sapling": {
-        "protocol_id": 53
+        "protocol_id": 39
       },
       "minecraft:acacia_sign": {
-        "protocol_id": 930
+        "protocol_id": 850
       },
       "minecraft:acacia_slab": {
-        "protocol_id": 274
+        "protocol_id": 234
       },
       "minecraft:acacia_stairs": {
-        "protocol_id": 416
+        "protocol_id": 365
       },
       "minecraft:acacia_trapdoor": {
-        "protocol_id": 768
+        "protocol_id": 705
       },
       "minecraft:acacia_wood": {
-        "protocol_id": 175
+        "protocol_id": 148
       },
       "minecraft:activator_rail": {
-        "protocol_id": 799
+        "protocol_id": 726
       },
       "minecraft:air": {
         "protocol_id": 0
       },
       "minecraft:allay_spawn_egg": {
-        "protocol_id": 1069
+        "protocol_id": 967
       },
       "minecraft:allium": {
-        "protocol_id": 234
+        "protocol_id": 199
       },
       "minecraft:amethyst_block": {
-        "protocol_id": 88
+        "protocol_id": 72
       },
       "minecraft:amethyst_cluster": {
-        "protocol_id": 1325
+        "protocol_id": 1210
       },
       "minecraft:amethyst_shard": {
-        "protocol_id": 849
+        "protocol_id": 768
       },
       "minecraft:ancient_debris": {
-        "protocol_id": 82
+        "protocol_id": 67
       },
       "minecraft:andesite": {
         "protocol_id": 6
       },
       "minecraft:andesite_slab": {
-        "protocol_id": 678
-      },
-      "minecraft:andesite_stairs": {
-        "protocol_id": 661
-      },
-      "minecraft:andesite_wall": {
-        "protocol_id": 437
-      },
-      "minecraft:angler_pottery_sherd": {
-        "protocol_id": 1352
-      },
-      "minecraft:anvil": {
-        "protocol_id": 449
-      },
-      "minecraft:apple": {
-        "protocol_id": 840
-      },
-      "minecraft:archer_pottery_sherd": {
-        "protocol_id": 1353
-      },
-      "minecraft:armadillo_scute": {
-        "protocol_id": 836
-      },
-      "minecraft:armadillo_spawn_egg": {
-        "protocol_id": 1068
-      },
-      "minecraft:armor_stand": {
-        "protocol_id": 1186
-      },
-      "minecraft:arms_up_pottery_sherd": {
-        "protocol_id": 1354
-      },
-      "minecraft:arrow": {
-        "protocol_id": 842
-      },
-      "minecraft:axolotl_bucket": {
-        "protocol_id": 961
-      },
-      "minecraft:axolotl_spawn_egg": {
-        "protocol_id": 1070
-      },
-      "minecraft:azalea": {
-        "protocol_id": 205
-      },
-      "minecraft:azalea_leaves": {
-        "protocol_id": 191
-      },
-      "minecraft:azure_bluet": {
-        "protocol_id": 235
-      },
-      "minecraft:baked_potato": {
-        "protocol_id": 1161
-      },
-      "minecraft:bamboo": {
-        "protocol_id": 269
-      },
-      "minecraft:bamboo_block": {
-        "protocol_id": 147
-      },
-      "minecraft:bamboo_button": {
-        "protocol_id": 723
-      },
-      "minecraft:bamboo_chest_raft": {
-        "protocol_id": 829
-      },
-      "minecraft:bamboo_door": {
-        "protocol_id": 752
-      },
-      "minecraft:bamboo_fence": {
-        "protocol_id": 341
-      },
-      "minecraft:bamboo_fence_gate": {
-        "protocol_id": 793
-      },
-      "minecraft:bamboo_hanging_sign": {
-        "protocol_id": 947
-      },
-      "minecraft:bamboo_mosaic": {
-        "protocol_id": 48
-      },
-      "minecraft:bamboo_mosaic_slab": {
-        "protocol_id": 280
-      },
-      "minecraft:bamboo_mosaic_stairs": {
-        "protocol_id": 422
-      },
-      "minecraft:bamboo_planks": {
-        "protocol_id": 45
-      },
-      "minecraft:bamboo_pressure_plate": {
-        "protocol_id": 739
-      },
-      "minecraft:bamboo_raft": {
-        "protocol_id": 828
-      },
-      "minecraft:bamboo_sign": {
-        "protocol_id": 935
-      },
-      "minecraft:bamboo_slab": {
-        "protocol_id": 279
-      },
-      "minecraft:bamboo_stairs": {
-        "protocol_id": 421
-      },
-      "minecraft:bamboo_trapdoor": {
-        "protocol_id": 773
-      },
-      "minecraft:barrel": {
-        "protocol_id": 1269
-      },
-      "minecraft:barrier": {
-        "protocol_id": 473
-      },
-      "minecraft:basalt": {
-        "protocol_id": 350
-      },
-      "minecraft:bat_spawn_egg": {
-        "protocol_id": 1071
-      },
-      "minecraft:beacon": {
-        "protocol_id": 426
-      },
-      "minecraft:bedrock": {
-        "protocol_id": 58
-      },
-      "minecraft:bee_nest": {
-        "protocol_id": 1286
-      },
-      "minecraft:bee_spawn_egg": {
-        "protocol_id": 1072
-      },
-      "minecraft:beef": {
-        "protocol_id": 1048
-      },
-      "minecraft:beehive": {
-        "protocol_id": 1287
-      },
-      "minecraft:beetroot": {
-        "protocol_id": 1217
-      },
-      "minecraft:beetroot_seeds": {
-        "protocol_id": 1218
-      },
-      "minecraft:beetroot_soup": {
-        "protocol_id": 1219
-      },
-      "minecraft:bell": {
-        "protocol_id": 1277
-      },
-      "minecraft:big_dripleaf": {
-        "protocol_id": 267
-      },
-      "minecraft:birch_boat": {
-        "protocol_id": 814
-      },
-      "minecraft:birch_button": {
-        "protocol_id": 716
-      },
-      "minecraft:birch_chest_boat": {
-        "protocol_id": 815
-      },
-      "minecraft:birch_door": {
-        "protocol_id": 745
-      },
-      "minecraft:birch_fence": {
-        "protocol_id": 334
-      },
-      "minecraft:birch_fence_gate": {
-        "protocol_id": 786
-      },
-      "minecraft:birch_hanging_sign": {
-        "protocol_id": 940
-      },
-      "minecraft:birch_leaves": {
-        "protocol_id": 184
-      },
-      "minecraft:birch_log": {
-        "protocol_id": 136
-      },
-      "minecraft:birch_planks": {
-        "protocol_id": 38
-      },
-      "minecraft:birch_pressure_plate": {
-        "protocol_id": 732
-      },
-      "minecraft:birch_sapling": {
-        "protocol_id": 51
-      },
-      "minecraft:birch_sign": {
-        "protocol_id": 928
-      },
-      "minecraft:birch_slab": {
-        "protocol_id": 272
-      },
-      "minecraft:birch_stairs": {
-        "protocol_id": 414
-      },
-      "minecraft:birch_trapdoor": {
-        "protocol_id": 766
-      },
-      "minecraft:birch_wood": {
-        "protocol_id": 173
-      },
-      "minecraft:black_banner": {
-        "protocol_id": 1211
-      },
-      "minecraft:black_bed": {
-        "protocol_id": 1039
-      },
-      "minecraft:black_bundle": {
-        "protocol_id": 990
-      },
-      "minecraft:black_candle": {
-        "protocol_id": 1321
-      },
-      "minecraft:black_carpet": {
-        "protocol_id": 491
-      },
-      "minecraft:black_concrete": {
-        "protocol_id": 600
-      },
-      "minecraft:black_concrete_powder": {
-        "protocol_id": 616
-      },
-      "minecraft:black_dye": {
-        "protocol_id": 1019
-      },
-      "minecraft:black_glazed_terracotta": {
-        "protocol_id": 584
-      },
-      "minecraft:black_shulker_box": {
-        "protocol_id": 568
-      },
-      "minecraft:black_stained_glass": {
-        "protocol_id": 516
-      },
-      "minecraft:black_stained_glass_pane": {
-        "protocol_id": 532
-      },
-      "minecraft:black_terracotta": {
-        "protocol_id": 472
-      },
-      "minecraft:black_wool": {
-        "protocol_id": 228
-      },
-      "minecraft:blackstone": {
-        "protocol_id": 1292
-      },
-      "minecraft:blackstone_slab": {
-        "protocol_id": 1293
-      },
-      "minecraft:blackstone_stairs": {
-        "protocol_id": 1294
-      },
-      "minecraft:blackstone_wall": {
-        "protocol_id": 442
-      },
-      "minecraft:blade_pottery_sherd": {
-        "protocol_id": 1355
-      },
-      "minecraft:blast_furnace": {
-        "protocol_id": 1271
-      },
-      "minecraft:blaze_powder": {
-        "protocol_id": 1062
-      },
-      "minecraft:blaze_rod": {
-        "protocol_id": 1054
-      },
-      "minecraft:blaze_spawn_egg": {
-        "protocol_id": 1073
-      },
-      "minecraft:blue_banner": {
-        "protocol_id": 1207
-      },
-      "minecraft:blue_bed": {
-        "protocol_id": 1035
-      },
-      "minecraft:blue_bundle": {
-        "protocol_id": 986
-      },
-      "minecraft:blue_candle": {
-        "protocol_id": 1317
-      },
-      "minecraft:blue_carpet": {
-        "protocol_id": 487
-      },
-      "minecraft:blue_concrete": {
-        "protocol_id": 596
-      },
-      "minecraft:blue_concrete_powder": {
-        "protocol_id": 612
-      },
-      "minecraft:blue_dye": {
-        "protocol_id": 1015
-      },
-      "minecraft:blue_egg": {
-        "protocol_id": 970
-      },
-      "minecraft:blue_glazed_terracotta": {
-        "protocol_id": 580
-      },
-      "minecraft:blue_ice": {
-        "protocol_id": 649
-      },
-      "minecraft:blue_orchid": {
-        "protocol_id": 233
-      },
-      "minecraft:blue_shulker_box": {
-        "protocol_id": 564
-      },
-      "minecraft:blue_stained_glass": {
-        "protocol_id": 512
-      },
-      "minecraft:blue_stained_glass_pane": {
-        "protocol_id": 528
-      },
-      "minecraft:blue_terracotta": {
-        "protocol_id": 468
-      },
-      "minecraft:blue_wool": {
-        "protocol_id": 224
-      },
-      "minecraft:bogged_spawn_egg": {
-        "protocol_id": 1074
-      },
-      "minecraft:bolt_armor_trim_smithing_template": {
-        "protocol_id": 1351
-      },
-      "minecraft:bone": {
-        "protocol_id": 1021
-      },
-      "minecraft:bone_block": {
-        "protocol_id": 550
-      },
-      "minecraft:bone_meal": {
-        "protocol_id": 1020
-      },
-      "minecraft:book": {
-        "protocol_id": 967
-      },
-      "minecraft:bookshelf": {
-        "protocol_id": 305
-      },
-      "minecraft:bordure_indented_banner_pattern": {
-        "protocol_id": 1266
-      },
-      "minecraft:bow": {
-        "protocol_id": 841
-      },
-      "minecraft:bowl": {
-        "protocol_id": 839
-      },
-      "minecraft:brain_coral": {
-        "protocol_id": 630
-      },
-      "minecraft:brain_coral_block": {
-        "protocol_id": 625
-      },
-      "minecraft:brain_coral_fan": {
-        "protocol_id": 640
-      },
-      "minecraft:bread": {
-        "protocol_id": 895
-      },
-      "minecraft:breeze_rod": {
-        "protocol_id": 1154
-      },
-      "minecraft:breeze_spawn_egg": {
-        "protocol_id": 1075
-      },
-      "minecraft:brewer_pottery_sherd": {
-        "protocol_id": 1356
-      },
-      "minecraft:brewing_stand": {
-        "protocol_id": 1064
-      },
-      "minecraft:brick": {
-        "protocol_id": 963
-      },
-      "minecraft:brick_slab": {
-        "protocol_id": 289
-      },
-      "minecraft:brick_stairs": {
-        "protocol_id": 390
-      },
-      "minecraft:brick_wall": {
-        "protocol_id": 429
-      },
-      "minecraft:bricks": {
-        "protocol_id": 304
-      },
-      "minecraft:brown_banner": {
-        "protocol_id": 1208
-      },
-      "minecraft:brown_bed": {
-        "protocol_id": 1036
-      },
-      "minecraft:brown_bundle": {
-        "protocol_id": 987
-      },
-      "minecraft:brown_candle": {
-        "protocol_id": 1318
-      },
-      "minecraft:brown_carpet": {
-        "protocol_id": 488
-      },
-      "minecraft:brown_concrete": {
-        "protocol_id": 597
-      },
-      "minecraft:brown_concrete_powder": {
-        "protocol_id": 613
-      },
-      "minecraft:brown_dye": {
-        "protocol_id": 1016
-      },
-      "minecraft:brown_egg": {
-        "protocol_id": 971
-      },
-      "minecraft:brown_glazed_terracotta": {
-        "protocol_id": 581
-      },
-      "minecraft:brown_mushroom": {
-        "protocol_id": 247
-      },
-      "minecraft:brown_mushroom_block": {
-        "protocol_id": 374
-      },
-      "minecraft:brown_shulker_box": {
-        "protocol_id": 565
-      },
-      "minecraft:brown_stained_glass": {
-        "protocol_id": 513
-      },
-      "minecraft:brown_stained_glass_pane": {
-        "protocol_id": 529
-      },
-      "minecraft:brown_terracotta": {
-        "protocol_id": 469
-      },
-      "minecraft:brown_wool": {
-        "protocol_id": 225
-      },
-      "minecraft:brush": {
-        "protocol_id": 1332
-      },
-      "minecraft:bubble_coral": {
-        "protocol_id": 631
-      },
-      "minecraft:bubble_coral_block": {
         "protocol_id": 626
       },
+      "minecraft:andesite_stairs": {
+        "protocol_id": 609
+      },
+      "minecraft:andesite_wall": {
+        "protocol_id": 385
+      },
+      "minecraft:angler_pottery_sherd": {
+        "protocol_id": 1235
+      },
+      "minecraft:anvil": {
+        "protocol_id": 397
+      },
+      "minecraft:apple": {
+        "protocol_id": 759
+      },
+      "minecraft:archer_pottery_sherd": {
+        "protocol_id": 1236
+      },
+      "minecraft:armor_stand": {
+        "protocol_id": 1077
+      },
+      "minecraft:arms_up_pottery_sherd": {
+        "protocol_id": 1237
+      },
+      "minecraft:arrow": {
+        "protocol_id": 761
+      },
+      "minecraft:axolotl_bucket": {
+        "protocol_id": 879
+      },
+      "minecraft:axolotl_spawn_egg": {
+        "protocol_id": 968
+      },
+      "minecraft:azalea": {
+        "protocol_id": 175
+      },
+      "minecraft:azalea_leaves": {
+        "protocol_id": 162
+      },
+      "minecraft:azure_bluet": {
+        "protocol_id": 200
+      },
+      "minecraft:baked_potato": {
+        "protocol_id": 1053
+      },
+      "minecraft:bamboo": {
+        "protocol_id": 229
+      },
+      "minecraft:bamboo_block": {
+        "protocol_id": 122
+      },
+      "minecraft:bamboo_button": {
+        "protocol_id": 670
+      },
+      "minecraft:bamboo_chest_raft": {
+        "protocol_id": 753
+      },
+      "minecraft:bamboo_door": {
+        "protocol_id": 697
+      },
+      "minecraft:bamboo_fence": {
+        "protocol_id": 297
+      },
+      "minecraft:bamboo_fence_gate": {
+        "protocol_id": 720
+      },
+      "minecraft:bamboo_hanging_sign": {
+        "protocol_id": 865
+      },
+      "minecraft:bamboo_mosaic": {
+        "protocol_id": 34
+      },
+      "minecraft:bamboo_mosaic_slab": {
+        "protocol_id": 239
+      },
+      "minecraft:bamboo_mosaic_stairs": {
+        "protocol_id": 370
+      },
+      "minecraft:bamboo_planks": {
+        "protocol_id": 31
+      },
+      "minecraft:bamboo_pressure_plate": {
+        "protocol_id": 685
+      },
+      "minecraft:bamboo_raft": {
+        "protocol_id": 752
+      },
+      "minecraft:bamboo_sign": {
+        "protocol_id": 854
+      },
+      "minecraft:bamboo_slab": {
+        "protocol_id": 238
+      },
+      "minecraft:bamboo_stairs": {
+        "protocol_id": 369
+      },
+      "minecraft:bamboo_trapdoor": {
+        "protocol_id": 709
+      },
+      "minecraft:barrel": {
+        "protocol_id": 1154
+      },
+      "minecraft:barrier": {
+        "protocol_id": 421
+      },
+      "minecraft:basalt": {
+        "protocol_id": 306
+      },
+      "minecraft:bat_spawn_egg": {
+        "protocol_id": 969
+      },
+      "minecraft:beacon": {
+        "protocol_id": 374
+      },
+      "minecraft:bedrock": {
+        "protocol_id": 43
+      },
+      "minecraft:bee_nest": {
+        "protocol_id": 1171
+      },
+      "minecraft:bee_spawn_egg": {
+        "protocol_id": 970
+      },
+      "minecraft:beef": {
+        "protocol_id": 947
+      },
+      "minecraft:beehive": {
+        "protocol_id": 1172
+      },
+      "minecraft:beetroot": {
+        "protocol_id": 1108
+      },
+      "minecraft:beetroot_seeds": {
+        "protocol_id": 1109
+      },
+      "minecraft:beetroot_soup": {
+        "protocol_id": 1110
+      },
+      "minecraft:bell": {
+        "protocol_id": 1162
+      },
+      "minecraft:big_dripleaf": {
+        "protocol_id": 227
+      },
+      "minecraft:birch_boat": {
+        "protocol_id": 740
+      },
+      "minecraft:birch_button": {
+        "protocol_id": 664
+      },
+      "minecraft:birch_chest_boat": {
+        "protocol_id": 741
+      },
+      "minecraft:birch_door": {
+        "protocol_id": 691
+      },
+      "minecraft:birch_fence": {
+        "protocol_id": 291
+      },
+      "minecraft:birch_fence_gate": {
+        "protocol_id": 714
+      },
+      "minecraft:birch_hanging_sign": {
+        "protocol_id": 859
+      },
+      "minecraft:birch_leaves": {
+        "protocol_id": 156
+      },
+      "minecraft:birch_log": {
+        "protocol_id": 112
+      },
+      "minecraft:birch_planks": {
+        "protocol_id": 25
+      },
+      "minecraft:birch_pressure_plate": {
+        "protocol_id": 679
+      },
+      "minecraft:birch_sapling": {
+        "protocol_id": 37
+      },
+      "minecraft:birch_sign": {
+        "protocol_id": 848
+      },
+      "minecraft:birch_slab": {
+        "protocol_id": 232
+      },
+      "minecraft:birch_stairs": {
+        "protocol_id": 363
+      },
+      "minecraft:birch_trapdoor": {
+        "protocol_id": 703
+      },
+      "minecraft:birch_wood": {
+        "protocol_id": 146
+      },
+      "minecraft:black_banner": {
+        "protocol_id": 1102
+      },
+      "minecraft:black_bed": {
+        "protocol_id": 939
+      },
+      "minecraft:black_candle": {
+        "protocol_id": 1206
+      },
+      "minecraft:black_carpet": {
+        "protocol_id": 439
+      },
+      "minecraft:black_concrete": {
+        "protocol_id": 548
+      },
+      "minecraft:black_concrete_powder": {
+        "protocol_id": 564
+      },
+      "minecraft:black_dye": {
+        "protocol_id": 919
+      },
+      "minecraft:black_glazed_terracotta": {
+        "protocol_id": 532
+      },
+      "minecraft:black_shulker_box": {
+        "protocol_id": 516
+      },
+      "minecraft:black_stained_glass": {
+        "protocol_id": 464
+      },
+      "minecraft:black_stained_glass_pane": {
+        "protocol_id": 480
+      },
+      "minecraft:black_terracotta": {
+        "protocol_id": 420
+      },
+      "minecraft:black_wool": {
+        "protocol_id": 195
+      },
+      "minecraft:blackstone": {
+        "protocol_id": 1177
+      },
+      "minecraft:blackstone_slab": {
+        "protocol_id": 1178
+      },
+      "minecraft:blackstone_stairs": {
+        "protocol_id": 1179
+      },
+      "minecraft:blackstone_wall": {
+        "protocol_id": 390
+      },
+      "minecraft:blade_pottery_sherd": {
+        "protocol_id": 1238
+      },
+      "minecraft:blast_furnace": {
+        "protocol_id": 1156
+      },
+      "minecraft:blaze_powder": {
+        "protocol_id": 961
+      },
+      "minecraft:blaze_rod": {
+        "protocol_id": 953
+      },
+      "minecraft:blaze_spawn_egg": {
+        "protocol_id": 971
+      },
+      "minecraft:blue_banner": {
+        "protocol_id": 1098
+      },
+      "minecraft:blue_bed": {
+        "protocol_id": 935
+      },
+      "minecraft:blue_candle": {
+        "protocol_id": 1202
+      },
+      "minecraft:blue_carpet": {
+        "protocol_id": 435
+      },
+      "minecraft:blue_concrete": {
+        "protocol_id": 544
+      },
+      "minecraft:blue_concrete_powder": {
+        "protocol_id": 560
+      },
+      "minecraft:blue_dye": {
+        "protocol_id": 915
+      },
+      "minecraft:blue_glazed_terracotta": {
+        "protocol_id": 528
+      },
+      "minecraft:blue_ice": {
+        "protocol_id": 597
+      },
+      "minecraft:blue_orchid": {
+        "protocol_id": 198
+      },
+      "minecraft:blue_shulker_box": {
+        "protocol_id": 512
+      },
+      "minecraft:blue_stained_glass": {
+        "protocol_id": 460
+      },
+      "minecraft:blue_stained_glass_pane": {
+        "protocol_id": 476
+      },
+      "minecraft:blue_terracotta": {
+        "protocol_id": 416
+      },
+      "minecraft:blue_wool": {
+        "protocol_id": 191
+      },
+      "minecraft:bone": {
+        "protocol_id": 921
+      },
+      "minecraft:bone_block": {
+        "protocol_id": 498
+      },
+      "minecraft:bone_meal": {
+        "protocol_id": 920
+      },
+      "minecraft:book": {
+        "protocol_id": 885
+      },
+      "minecraft:bookshelf": {
+        "protocol_id": 264
+      },
+      "minecraft:bow": {
+        "protocol_id": 760
+      },
+      "minecraft:bowl": {
+        "protocol_id": 808
+      },
+      "minecraft:brain_coral": {
+        "protocol_id": 578
+      },
+      "minecraft:brain_coral_block": {
+        "protocol_id": 573
+      },
+      "minecraft:brain_coral_fan": {
+        "protocol_id": 588
+      },
+      "minecraft:bread": {
+        "protocol_id": 815
+      },
+      "minecraft:brewer_pottery_sherd": {
+        "protocol_id": 1239
+      },
+      "minecraft:brewing_stand": {
+        "protocol_id": 963
+      },
+      "minecraft:brick": {
+        "protocol_id": 881
+      },
+      "minecraft:brick_slab": {
+        "protocol_id": 248
+      },
+      "minecraft:brick_stairs": {
+        "protocol_id": 339
+      },
+      "minecraft:brick_wall": {
+        "protocol_id": 377
+      },
+      "minecraft:bricks": {
+        "protocol_id": 263
+      },
+      "minecraft:brown_banner": {
+        "protocol_id": 1099
+      },
+      "minecraft:brown_bed": {
+        "protocol_id": 936
+      },
+      "minecraft:brown_candle": {
+        "protocol_id": 1203
+      },
+      "minecraft:brown_carpet": {
+        "protocol_id": 436
+      },
+      "minecraft:brown_concrete": {
+        "protocol_id": 545
+      },
+      "minecraft:brown_concrete_powder": {
+        "protocol_id": 561
+      },
+      "minecraft:brown_dye": {
+        "protocol_id": 916
+      },
+      "minecraft:brown_glazed_terracotta": {
+        "protocol_id": 529
+      },
+      "minecraft:brown_mushroom": {
+        "protocol_id": 212
+      },
+      "minecraft:brown_mushroom_block": {
+        "protocol_id": 330
+      },
+      "minecraft:brown_shulker_box": {
+        "protocol_id": 513
+      },
+      "minecraft:brown_stained_glass": {
+        "protocol_id": 461
+      },
+      "minecraft:brown_stained_glass_pane": {
+        "protocol_id": 477
+      },
+      "minecraft:brown_terracotta": {
+        "protocol_id": 417
+      },
+      "minecraft:brown_wool": {
+        "protocol_id": 192
+      },
+      "minecraft:brush": {
+        "protocol_id": 1217
+      },
+      "minecraft:bubble_coral": {
+        "protocol_id": 579
+      },
+      "minecraft:bubble_coral_block": {
+        "protocol_id": 574
+      },
       "minecraft:bubble_coral_fan": {
-        "protocol_id": 641
+        "protocol_id": 589
       },
       "minecraft:bucket": {
-        "protocol_id": 950
+        "protocol_id": 868
       },
       "minecraft:budding_amethyst": {
-        "protocol_id": 89
+        "protocol_id": 73
       },
       "minecraft:bundle": {
-        "protocol_id": 974
+        "protocol_id": 890
       },
       "minecraft:burn_pottery_sherd": {
-        "protocol_id": 1357
-      },
-      "minecraft:bush": {
-        "protocol_id": 204
+        "protocol_id": 1240
       },
       "minecraft:cactus": {
-        "protocol_id": 328
-      },
-      "minecraft:cactus_flower": {
-        "protocol_id": 329
+        "protocol_id": 286
       },
       "minecraft:cake": {
-        "protocol_id": 1023
+        "protocol_id": 923
       },
       "minecraft:calcite": {
         "protocol_id": 11
       },
       "minecraft:calibrated_sculk_sensor": {
-        "protocol_id": 706
+        "protocol_id": 654
       },
       "minecraft:camel_spawn_egg": {
-        "protocol_id": 1077
+        "protocol_id": 973
       },
       "minecraft:campfire": {
-        "protocol_id": 1282
+        "protocol_id": 1167
       },
       "minecraft:candle": {
-        "protocol_id": 1305
+        "protocol_id": 1190
       },
       "minecraft:carrot": {
-        "protocol_id": 1159
+        "protocol_id": 1051
       },
       "minecraft:carrot_on_a_stick": {
-        "protocol_id": 806
+        "protocol_id": 733
       },
       "minecraft:cartography_table": {
-        "protocol_id": 1272
+        "protocol_id": 1157
       },
       "minecraft:carved_pumpkin": {
-        "protocol_id": 345
+        "protocol_id": 301
       },
       "minecraft:cat_spawn_egg": {
-        "protocol_id": 1076
+        "protocol_id": 972
       },
       "minecraft:cauldron": {
-        "protocol_id": 1065
-      },
-      "minecraft:cave_spider_spawn_egg": {
-        "protocol_id": 1078
-      },
-      "minecraft:chain": {
-        "protocol_id": 378
-      },
-      "minecraft:chain_command_block": {
-        "protocol_id": 545
-      },
-      "minecraft:chainmail_boots": {
-        "protocol_id": 903
-      },
-      "minecraft:chainmail_chestplate": {
-        "protocol_id": 901
-      },
-      "minecraft:chainmail_helmet": {
-        "protocol_id": 900
-      },
-      "minecraft:chainmail_leggings": {
-        "protocol_id": 902
-      },
-      "minecraft:charcoal": {
-        "protocol_id": 844
-      },
-      "minecraft:cherry_boat": {
-        "protocol_id": 820
-      },
-      "minecraft:cherry_button": {
-        "protocol_id": 719
-      },
-      "minecraft:cherry_chest_boat": {
-        "protocol_id": 821
-      },
-      "minecraft:cherry_door": {
-        "protocol_id": 748
-      },
-      "minecraft:cherry_fence": {
-        "protocol_id": 337
-      },
-      "minecraft:cherry_fence_gate": {
-        "protocol_id": 789
-      },
-      "minecraft:cherry_hanging_sign": {
-        "protocol_id": 943
-      },
-      "minecraft:cherry_leaves": {
-        "protocol_id": 187
-      },
-      "minecraft:cherry_log": {
-        "protocol_id": 139
-      },
-      "minecraft:cherry_planks": {
-        "protocol_id": 41
-      },
-      "minecraft:cherry_pressure_plate": {
-        "protocol_id": 735
-      },
-      "minecraft:cherry_sapling": {
-        "protocol_id": 54
-      },
-      "minecraft:cherry_sign": {
-        "protocol_id": 931
-      },
-      "minecraft:cherry_slab": {
-        "protocol_id": 275
-      },
-      "minecraft:cherry_stairs": {
-        "protocol_id": 417
-      },
-      "minecraft:cherry_trapdoor": {
-        "protocol_id": 769
-      },
-      "minecraft:cherry_wood": {
-        "protocol_id": 176
-      },
-      "minecraft:chest": {
-        "protocol_id": 319
-      },
-      "minecraft:chest_minecart": {
-        "protocol_id": 802
-      },
-      "minecraft:chicken": {
-        "protocol_id": 1050
-      },
-      "minecraft:chicken_spawn_egg": {
-        "protocol_id": 1079
-      },
-      "minecraft:chipped_anvil": {
-        "protocol_id": 450
-      },
-      "minecraft:chiseled_bookshelf": {
-        "protocol_id": 306
-      },
-      "minecraft:chiseled_copper": {
-        "protocol_id": 98
-      },
-      "minecraft:chiseled_deepslate": {
-        "protocol_id": 372
-      },
-      "minecraft:chiseled_nether_bricks": {
-        "protocol_id": 397
-      },
-      "minecraft:chiseled_polished_blackstone": {
-        "protocol_id": 1299
-      },
-      "minecraft:chiseled_quartz_block": {
-        "protocol_id": 452
-      },
-      "minecraft:chiseled_red_sandstone": {
-        "protocol_id": 541
-      },
-      "minecraft:chiseled_resin_bricks": {
-        "protocol_id": 389
-      },
-      "minecraft:chiseled_sandstone": {
-        "protocol_id": 199
-      },
-      "minecraft:chiseled_stone_bricks": {
-        "protocol_id": 365
-      },
-      "minecraft:chiseled_tuff": {
-        "protocol_id": 16
-      },
-      "minecraft:chiseled_tuff_bricks": {
-        "protocol_id": 25
-      },
-      "minecraft:chorus_flower": {
-        "protocol_id": 313
-      },
-      "minecraft:chorus_fruit": {
-        "protocol_id": 1213
-      },
-      "minecraft:chorus_plant": {
-        "protocol_id": 312
-      },
-      "minecraft:clay": {
-        "protocol_id": 330
-      },
-      "minecraft:clay_ball": {
         "protocol_id": 964
       },
-      "minecraft:clock": {
-        "protocol_id": 992
+      "minecraft:cave_spider_spawn_egg": {
+        "protocol_id": 974
       },
-      "minecraft:closed_eyeblossom": {
-        "protocol_id": 231
+      "minecraft:chain": {
+        "protocol_id": 334
+      },
+      "minecraft:chain_command_block": {
+        "protocol_id": 493
+      },
+      "minecraft:chainmail_boots": {
+        "protocol_id": 823
+      },
+      "minecraft:chainmail_chestplate": {
+        "protocol_id": 821
+      },
+      "minecraft:chainmail_helmet": {
+        "protocol_id": 820
+      },
+      "minecraft:chainmail_leggings": {
+        "protocol_id": 822
+      },
+      "minecraft:charcoal": {
+        "protocol_id": 763
+      },
+      "minecraft:cherry_boat": {
+        "protocol_id": 746
+      },
+      "minecraft:cherry_button": {
+        "protocol_id": 667
+      },
+      "minecraft:cherry_chest_boat": {
+        "protocol_id": 747
+      },
+      "minecraft:cherry_door": {
+        "protocol_id": 694
+      },
+      "minecraft:cherry_fence": {
+        "protocol_id": 294
+      },
+      "minecraft:cherry_fence_gate": {
+        "protocol_id": 717
+      },
+      "minecraft:cherry_hanging_sign": {
+        "protocol_id": 862
+      },
+      "minecraft:cherry_leaves": {
+        "protocol_id": 159
+      },
+      "minecraft:cherry_log": {
+        "protocol_id": 115
+      },
+      "minecraft:cherry_planks": {
+        "protocol_id": 28
+      },
+      "minecraft:cherry_pressure_plate": {
+        "protocol_id": 682
+      },
+      "minecraft:cherry_sapling": {
+        "protocol_id": 40
+      },
+      "minecraft:cherry_sign": {
+        "protocol_id": 851
+      },
+      "minecraft:cherry_slab": {
+        "protocol_id": 235
+      },
+      "minecraft:cherry_stairs": {
+        "protocol_id": 366
+      },
+      "minecraft:cherry_trapdoor": {
+        "protocol_id": 706
+      },
+      "minecraft:cherry_wood": {
+        "protocol_id": 149
+      },
+      "minecraft:chest": {
+        "protocol_id": 277
+      },
+      "minecraft:chest_minecart": {
+        "protocol_id": 729
+      },
+      "minecraft:chicken": {
+        "protocol_id": 949
+      },
+      "minecraft:chicken_spawn_egg": {
+        "protocol_id": 975
+      },
+      "minecraft:chipped_anvil": {
+        "protocol_id": 398
+      },
+      "minecraft:chiseled_bookshelf": {
+        "protocol_id": 265
+      },
+      "minecraft:chiseled_deepslate": {
+        "protocol_id": 328
+      },
+      "minecraft:chiseled_nether_bricks": {
+        "protocol_id": 346
+      },
+      "minecraft:chiseled_polished_blackstone": {
+        "protocol_id": 1184
+      },
+      "minecraft:chiseled_quartz_block": {
+        "protocol_id": 400
+      },
+      "minecraft:chiseled_red_sandstone": {
+        "protocol_id": 489
+      },
+      "minecraft:chiseled_sandstone": {
+        "protocol_id": 170
+      },
+      "minecraft:chiseled_stone_bricks": {
+        "protocol_id": 321
+      },
+      "minecraft:chorus_flower": {
+        "protocol_id": 272
+      },
+      "minecraft:chorus_fruit": {
+        "protocol_id": 1104
+      },
+      "minecraft:chorus_plant": {
+        "protocol_id": 271
+      },
+      "minecraft:clay": {
+        "protocol_id": 287
+      },
+      "minecraft:clay_ball": {
+        "protocol_id": 882
+      },
+      "minecraft:clock": {
+        "protocol_id": 892
       },
       "minecraft:coal": {
-        "protocol_id": 843
+        "protocol_id": 762
       },
       "minecraft:coal_block": {
-        "protocol_id": 83
+        "protocol_id": 68
       },
       "minecraft:coal_ore": {
-        "protocol_id": 64
+        "protocol_id": 49
       },
       "minecraft:coarse_dirt": {
-        "protocol_id": 29
+        "protocol_id": 16
       },
       "minecraft:coast_armor_trim_smithing_template": {
-        "protocol_id": 1336
+        "protocol_id": 1221
       },
       "minecraft:cobbled_deepslate": {
         "protocol_id": 9
       },
       "minecraft:cobbled_deepslate_slab": {
-        "protocol_id": 682
+        "protocol_id": 630
       },
       "minecraft:cobbled_deepslate_stairs": {
-        "protocol_id": 665
+        "protocol_id": 613
       },
       "minecraft:cobbled_deepslate_wall": {
-        "protocol_id": 445
+        "protocol_id": 393
       },
       "minecraft:cobblestone": {
-        "protocol_id": 35
+        "protocol_id": 22
       },
       "minecraft:cobblestone_slab": {
-        "protocol_id": 288
+        "protocol_id": 247
       },
       "minecraft:cobblestone_stairs": {
-        "protocol_id": 324
+        "protocol_id": 282
       },
       "minecraft:cobblestone_wall": {
-        "protocol_id": 427
+        "protocol_id": 375
       },
       "minecraft:cobweb": {
-        "protocol_id": 201
+        "protocol_id": 172
       },
       "minecraft:cocoa_beans": {
-        "protocol_id": 1003
+        "protocol_id": 903
       },
       "minecraft:cod": {
-        "protocol_id": 995
+        "protocol_id": 895
       },
       "minecraft:cod_bucket": {
-        "protocol_id": 959
+        "protocol_id": 877
       },
       "minecraft:cod_spawn_egg": {
-        "protocol_id": 1080
+        "protocol_id": 976
       },
       "minecraft:command_block": {
-        "protocol_id": 425
+        "protocol_id": 373
       },
       "minecraft:command_block_minecart": {
-        "protocol_id": 1193
+        "protocol_id": 1084
       },
       "minecraft:comparator": {
-        "protocol_id": 691
+        "protocol_id": 639
       },
       "minecraft:compass": {
-        "protocol_id": 972
+        "protocol_id": 888
       },
       "minecraft:composter": {
-        "protocol_id": 1268
+        "protocol_id": 1153
       },
       "minecraft:conduit": {
-        "protocol_id": 650
+        "protocol_id": 598
       },
       "minecraft:cooked_beef": {
-        "protocol_id": 1049
-      },
-      "minecraft:cooked_chicken": {
-        "protocol_id": 1051
-      },
-      "minecraft:cooked_cod": {
-        "protocol_id": 999
-      },
-      "minecraft:cooked_mutton": {
-        "protocol_id": 1195
-      },
-      "minecraft:cooked_porkchop": {
-        "protocol_id": 922
-      },
-      "minecraft:cooked_rabbit": {
-        "protocol_id": 1182
-      },
-      "minecraft:cooked_salmon": {
-        "protocol_id": 1000
-      },
-      "minecraft:cookie": {
-        "protocol_id": 1040
-      },
-      "minecraft:copper_block": {
-        "protocol_id": 91
-      },
-      "minecraft:copper_bulb": {
-        "protocol_id": 1383
-      },
-      "minecraft:copper_door": {
-        "protocol_id": 755
-      },
-      "minecraft:copper_grate": {
-        "protocol_id": 1375
-      },
-      "minecraft:copper_ingot": {
-        "protocol_id": 853
-      },
-      "minecraft:copper_ore": {
-        "protocol_id": 68
-      },
-      "minecraft:copper_trapdoor": {
-        "protocol_id": 776
-      },
-      "minecraft:cornflower": {
-        "protocol_id": 241
-      },
-      "minecraft:cow_spawn_egg": {
-        "protocol_id": 1081
-      },
-      "minecraft:cracked_deepslate_bricks": {
-        "protocol_id": 369
-      },
-      "minecraft:cracked_deepslate_tiles": {
-        "protocol_id": 371
-      },
-      "minecraft:cracked_nether_bricks": {
-        "protocol_id": 396
-      },
-      "minecraft:cracked_polished_blackstone_bricks": {
-        "protocol_id": 1303
-      },
-      "minecraft:cracked_stone_bricks": {
-        "protocol_id": 364
-      },
-      "minecraft:crafter": {
-        "protocol_id": 1041
-      },
-      "minecraft:crafting_table": {
-        "protocol_id": 320
-      },
-      "minecraft:creaking_heart": {
-        "protocol_id": 318
-      },
-      "minecraft:creaking_spawn_egg": {
-        "protocol_id": 1144
-      },
-      "minecraft:creeper_banner_pattern": {
-        "protocol_id": 1258
-      },
-      "minecraft:creeper_head": {
-        "protocol_id": 1169
-      },
-      "minecraft:creeper_spawn_egg": {
-        "protocol_id": 1082
-      },
-      "minecraft:crimson_button": {
-        "protocol_id": 724
-      },
-      "minecraft:crimson_door": {
-        "protocol_id": 753
-      },
-      "minecraft:crimson_fence": {
-        "protocol_id": 342
-      },
-      "minecraft:crimson_fence_gate": {
-        "protocol_id": 794
-      },
-      "minecraft:crimson_fungus": {
-        "protocol_id": 249
-      },
-      "minecraft:crimson_hanging_sign": {
         "protocol_id": 948
       },
+      "minecraft:cooked_chicken": {
+        "protocol_id": 950
+      },
+      "minecraft:cooked_cod": {
+        "protocol_id": 899
+      },
+      "minecraft:cooked_mutton": {
+        "protocol_id": 1086
+      },
+      "minecraft:cooked_porkchop": {
+        "protocol_id": 842
+      },
+      "minecraft:cooked_rabbit": {
+        "protocol_id": 1073
+      },
+      "minecraft:cooked_salmon": {
+        "protocol_id": 900
+      },
+      "minecraft:cookie": {
+        "protocol_id": 940
+      },
+      "minecraft:copper_block": {
+        "protocol_id": 75
+      },
+      "minecraft:copper_ingot": {
+        "protocol_id": 772
+      },
+      "minecraft:copper_ore": {
+        "protocol_id": 53
+      },
+      "minecraft:cornflower": {
+        "protocol_id": 206
+      },
+      "minecraft:cow_spawn_egg": {
+        "protocol_id": 977
+      },
+      "minecraft:cracked_deepslate_bricks": {
+        "protocol_id": 325
+      },
+      "minecraft:cracked_deepslate_tiles": {
+        "protocol_id": 327
+      },
+      "minecraft:cracked_nether_bricks": {
+        "protocol_id": 345
+      },
+      "minecraft:cracked_polished_blackstone_bricks": {
+        "protocol_id": 1188
+      },
+      "minecraft:cracked_stone_bricks": {
+        "protocol_id": 320
+      },
+      "minecraft:crafting_table": {
+        "protocol_id": 278
+      },
+      "minecraft:creeper_banner_pattern": {
+        "protocol_id": 1147
+      },
+      "minecraft:creeper_head": {
+        "protocol_id": 1061
+      },
+      "minecraft:creeper_spawn_egg": {
+        "protocol_id": 978
+      },
+      "minecraft:crimson_button": {
+        "protocol_id": 671
+      },
+      "minecraft:crimson_door": {
+        "protocol_id": 698
+      },
+      "minecraft:crimson_fence": {
+        "protocol_id": 298
+      },
+      "minecraft:crimson_fence_gate": {
+        "protocol_id": 721
+      },
+      "minecraft:crimson_fungus": {
+        "protocol_id": 214
+      },
+      "minecraft:crimson_hanging_sign": {
+        "protocol_id": 866
+      },
       "minecraft:crimson_hyphae": {
-        "protocol_id": 180
+        "protocol_id": 152
       },
       "minecraft:crimson_nylium": {
-        "protocol_id": 33
+        "protocol_id": 20
       },
       "minecraft:crimson_planks": {
-        "protocol_id": 46
+        "protocol_id": 32
       },
       "minecraft:crimson_pressure_plate": {
-        "protocol_id": 740
+        "protocol_id": 686
       },
       "minecraft:crimson_roots": {
-        "protocol_id": 251
+        "protocol_id": 216
       },
       "minecraft:crimson_sign": {
-        "protocol_id": 936
+        "protocol_id": 855
       },
       "minecraft:crimson_slab": {
-        "protocol_id": 281
+        "protocol_id": 240
       },
       "minecraft:crimson_stairs": {
-        "protocol_id": 423
+        "protocol_id": 371
       },
       "minecraft:crimson_stem": {
-        "protocol_id": 145
+        "protocol_id": 120
       },
       "minecraft:crimson_trapdoor": {
-        "protocol_id": 774
+        "protocol_id": 710
       },
       "minecraft:crossbow": {
-        "protocol_id": 1254
+        "protocol_id": 1143
       },
       "minecraft:crying_obsidian": {
-        "protocol_id": 1291
+        "protocol_id": 1176
       },
       "minecraft:cut_copper": {
-        "protocol_id": 102
+        "protocol_id": 82
       },
       "minecraft:cut_copper_slab": {
-        "protocol_id": 110
+        "protocol_id": 90
       },
       "minecraft:cut_copper_stairs": {
-        "protocol_id": 106
+        "protocol_id": 86
       },
       "minecraft:cut_red_sandstone": {
-        "protocol_id": 542
+        "protocol_id": 490
       },
       "minecraft:cut_red_sandstone_slab": {
-        "protocol_id": 295
+        "protocol_id": 254
       },
       "minecraft:cut_sandstone": {
-        "protocol_id": 200
+        "protocol_id": 171
       },
       "minecraft:cut_sandstone_slab": {
-        "protocol_id": 286
+        "protocol_id": 245
       },
       "minecraft:cyan_banner": {
-        "protocol_id": 1205
+        "protocol_id": 1096
       },
       "minecraft:cyan_bed": {
-        "protocol_id": 1033
-      },
-      "minecraft:cyan_bundle": {
-        "protocol_id": 984
+        "protocol_id": 933
       },
       "minecraft:cyan_candle": {
-        "protocol_id": 1315
+        "protocol_id": 1200
       },
       "minecraft:cyan_carpet": {
-        "protocol_id": 485
+        "protocol_id": 433
       },
       "minecraft:cyan_concrete": {
-        "protocol_id": 594
+        "protocol_id": 542
       },
       "minecraft:cyan_concrete_powder": {
-        "protocol_id": 610
+        "protocol_id": 558
       },
       "minecraft:cyan_dye": {
-        "protocol_id": 1013
+        "protocol_id": 913
       },
       "minecraft:cyan_glazed_terracotta": {
-        "protocol_id": 578
-      },
-      "minecraft:cyan_shulker_box": {
-        "protocol_id": 562
-      },
-      "minecraft:cyan_stained_glass": {
-        "protocol_id": 510
-      },
-      "minecraft:cyan_stained_glass_pane": {
         "protocol_id": 526
       },
+      "minecraft:cyan_shulker_box": {
+        "protocol_id": 510
+      },
+      "minecraft:cyan_stained_glass": {
+        "protocol_id": 458
+      },
+      "minecraft:cyan_stained_glass_pane": {
+        "protocol_id": 474
+      },
       "minecraft:cyan_terracotta": {
-        "protocol_id": 466
+        "protocol_id": 414
       },
       "minecraft:cyan_wool": {
-        "protocol_id": 222
+        "protocol_id": 189
       },
       "minecraft:damaged_anvil": {
-        "protocol_id": 451
+        "protocol_id": 399
       },
       "minecraft:dandelion": {
-        "protocol_id": 229
+        "protocol_id": 196
       },
       "minecraft:danger_pottery_sherd": {
-        "protocol_id": 1358
+        "protocol_id": 1241
       },
       "minecraft:dark_oak_boat": {
-        "protocol_id": 822
+        "protocol_id": 748
       },
       "minecraft:dark_oak_button": {
-        "protocol_id": 720
+        "protocol_id": 668
       },
       "minecraft:dark_oak_chest_boat": {
-        "protocol_id": 823
-      },
-      "minecraft:dark_oak_door": {
         "protocol_id": 749
       },
+      "minecraft:dark_oak_door": {
+        "protocol_id": 695
+      },
       "minecraft:dark_oak_fence": {
-        "protocol_id": 338
+        "protocol_id": 295
       },
       "minecraft:dark_oak_fence_gate": {
-        "protocol_id": 790
+        "protocol_id": 718
       },
       "minecraft:dark_oak_hanging_sign": {
-        "protocol_id": 944
+        "protocol_id": 863
       },
       "minecraft:dark_oak_leaves": {
-        "protocol_id": 188
+        "protocol_id": 160
       },
       "minecraft:dark_oak_log": {
-        "protocol_id": 141
+        "protocol_id": 116
       },
       "minecraft:dark_oak_planks": {
-        "protocol_id": 42
+        "protocol_id": 29
       },
       "minecraft:dark_oak_pressure_plate": {
-        "protocol_id": 736
+        "protocol_id": 683
       },
       "minecraft:dark_oak_sapling": {
-        "protocol_id": 55
+        "protocol_id": 41
       },
       "minecraft:dark_oak_sign": {
-        "protocol_id": 932
+        "protocol_id": 852
       },
       "minecraft:dark_oak_slab": {
-        "protocol_id": 276
+        "protocol_id": 236
       },
       "minecraft:dark_oak_stairs": {
-        "protocol_id": 418
+        "protocol_id": 367
       },
       "minecraft:dark_oak_trapdoor": {
-        "protocol_id": 770
+        "protocol_id": 707
       },
       "minecraft:dark_oak_wood": {
-        "protocol_id": 178
+        "protocol_id": 150
       },
       "minecraft:dark_prismarine": {
-        "protocol_id": 535
+        "protocol_id": 483
       },
       "minecraft:dark_prismarine_slab": {
-        "protocol_id": 299
+        "protocol_id": 258
       },
       "minecraft:dark_prismarine_stairs": {
-        "protocol_id": 538
+        "protocol_id": 486
       },
       "minecraft:daylight_detector": {
-        "protocol_id": 704
+        "protocol_id": 652
       },
       "minecraft:dead_brain_coral": {
-        "protocol_id": 634
+        "protocol_id": 582
       },
       "minecraft:dead_brain_coral_block": {
-        "protocol_id": 620
+        "protocol_id": 568
       },
       "minecraft:dead_brain_coral_fan": {
-        "protocol_id": 645
+        "protocol_id": 593
       },
       "minecraft:dead_bubble_coral": {
-        "protocol_id": 635
+        "protocol_id": 583
       },
       "minecraft:dead_bubble_coral_block": {
-        "protocol_id": 621
+        "protocol_id": 569
       },
       "minecraft:dead_bubble_coral_fan": {
-        "protocol_id": 646
+        "protocol_id": 594
       },
       "minecraft:dead_bush": {
-        "protocol_id": 207
+        "protocol_id": 177
       },
       "minecraft:dead_fire_coral": {
-        "protocol_id": 636
+        "protocol_id": 584
       },
       "minecraft:dead_fire_coral_block": {
-        "protocol_id": 622
+        "protocol_id": 570
       },
       "minecraft:dead_fire_coral_fan": {
-        "protocol_id": 647
+        "protocol_id": 595
       },
       "minecraft:dead_horn_coral": {
-        "protocol_id": 637
+        "protocol_id": 585
       },
       "minecraft:dead_horn_coral_block": {
-        "protocol_id": 623
+        "protocol_id": 571
       },
       "minecraft:dead_horn_coral_fan": {
-        "protocol_id": 648
+        "protocol_id": 596
       },
       "minecraft:dead_tube_coral": {
-        "protocol_id": 638
+        "protocol_id": 586
       },
       "minecraft:dead_tube_coral_block": {
-        "protocol_id": 619
+        "protocol_id": 567
       },
       "minecraft:dead_tube_coral_fan": {
-        "protocol_id": 644
+        "protocol_id": 592
       },
       "minecraft:debug_stick": {
-        "protocol_id": 1230
+        "protocol_id": 1121
       },
       "minecraft:decorated_pot": {
-        "protocol_id": 307
+        "protocol_id": 266
       },
       "minecraft:deepslate": {
         "protocol_id": 8
       },
       "minecraft:deepslate_brick_slab": {
-        "protocol_id": 684
+        "protocol_id": 632
       },
       "minecraft:deepslate_brick_stairs": {
-        "protocol_id": 667
+        "protocol_id": 615
       },
       "minecraft:deepslate_brick_wall": {
-        "protocol_id": 447
+        "protocol_id": 395
       },
       "minecraft:deepslate_bricks": {
-        "protocol_id": 368
+        "protocol_id": 324
       },
       "minecraft:deepslate_coal_ore": {
-        "protocol_id": 65
+        "protocol_id": 50
       },
       "minecraft:deepslate_copper_ore": {
-        "protocol_id": 69
+        "protocol_id": 54
       },
       "minecraft:deepslate_diamond_ore": {
-        "protocol_id": 79
+        "protocol_id": 64
       },
       "minecraft:deepslate_emerald_ore": {
-        "protocol_id": 75
+        "protocol_id": 60
       },
       "minecraft:deepslate_gold_ore": {
-        "protocol_id": 71
+        "protocol_id": 56
       },
       "minecraft:deepslate_iron_ore": {
-        "protocol_id": 67
+        "protocol_id": 52
       },
       "minecraft:deepslate_lapis_ore": {
-        "protocol_id": 77
+        "protocol_id": 62
       },
       "minecraft:deepslate_redstone_ore": {
-        "protocol_id": 73
+        "protocol_id": 58
       },
       "minecraft:deepslate_tile_slab": {
-        "protocol_id": 685
+        "protocol_id": 633
       },
       "minecraft:deepslate_tile_stairs": {
-        "protocol_id": 668
+        "protocol_id": 616
       },
       "minecraft:deepslate_tile_wall": {
-        "protocol_id": 448
+        "protocol_id": 396
       },
       "minecraft:deepslate_tiles": {
-        "protocol_id": 370
+        "protocol_id": 326
       },
       "minecraft:detector_rail": {
-        "protocol_id": 797
+        "protocol_id": 724
       },
       "minecraft:diamond": {
-        "protocol_id": 845
+        "protocol_id": 764
       },
       "minecraft:diamond_axe": {
-        "protocol_id": 881
+        "protocol_id": 800
       },
       "minecraft:diamond_block": {
-        "protocol_id": 93
+        "protocol_id": 77
       },
       "minecraft:diamond_boots": {
-        "protocol_id": 911
+        "protocol_id": 831
       },
       "minecraft:diamond_chestplate": {
-        "protocol_id": 909
+        "protocol_id": 829
       },
       "minecraft:diamond_helmet": {
-        "protocol_id": 908
+        "protocol_id": 828
       },
       "minecraft:diamond_hoe": {
-        "protocol_id": 882
+        "protocol_id": 801
       },
       "minecraft:diamond_horse_armor": {
-        "protocol_id": 1189
+        "protocol_id": 1080
       },
       "minecraft:diamond_leggings": {
-        "protocol_id": 910
+        "protocol_id": 830
       },
       "minecraft:diamond_ore": {
-        "protocol_id": 78
+        "protocol_id": 63
       },
       "minecraft:diamond_pickaxe": {
-        "protocol_id": 880
+        "protocol_id": 799
       },
       "minecraft:diamond_shovel": {
-        "protocol_id": 879
+        "protocol_id": 798
       },
       "minecraft:diamond_sword": {
-        "protocol_id": 878
+        "protocol_id": 797
       },
       "minecraft:diorite": {
         "protocol_id": 4
       },
       "minecraft:diorite_slab": {
-        "protocol_id": 681
+        "protocol_id": 629
       },
       "minecraft:diorite_stairs": {
-        "protocol_id": 664
+        "protocol_id": 612
       },
       "minecraft:diorite_wall": {
-        "protocol_id": 441
+        "protocol_id": 389
       },
       "minecraft:dirt": {
-        "protocol_id": 28
+        "protocol_id": 15
       },
       "minecraft:dirt_path": {
-        "protocol_id": 494
+        "protocol_id": 442
       },
       "minecraft:disc_fragment_5": {
-        "protocol_id": 1250
+        "protocol_id": 1138
       },
       "minecraft:dispenser": {
-        "protocol_id": 698
+        "protocol_id": 646
       },
       "minecraft:dolphin_spawn_egg": {
-        "protocol_id": 1083
+        "protocol_id": 979
       },
       "minecraft:donkey_spawn_egg": {
-        "protocol_id": 1084
+        "protocol_id": 980
       },
       "minecraft:dragon_breath": {
-        "protocol_id": 1220
+        "protocol_id": 1111
       },
       "minecraft:dragon_egg": {
-        "protocol_id": 408
+        "protocol_id": 357
       },
       "minecraft:dragon_head": {
-        "protocol_id": 1170
+        "protocol_id": 1062
       },
       "minecraft:dried_kelp": {
-        "protocol_id": 1045
+        "protocol_id": 944
       },
       "minecraft:dried_kelp_block": {
-        "protocol_id": 965
+        "protocol_id": 883
       },
       "minecraft:dripstone_block": {
-        "protocol_id": 26
+        "protocol_id": 13
       },
       "minecraft:dropper": {
-        "protocol_id": 699
+        "protocol_id": 647
       },
       "minecraft:drowned_spawn_egg": {
-        "protocol_id": 1085
+        "protocol_id": 981
       },
       "minecraft:dune_armor_trim_smithing_template": {
-        "protocol_id": 1335
+        "protocol_id": 1220
       },
       "minecraft:echo_shard": {
-        "protocol_id": 1331
+        "protocol_id": 1216
       },
       "minecraft:egg": {
-        "protocol_id": 969
+        "protocol_id": 887
       },
       "minecraft:elder_guardian_spawn_egg": {
-        "protocol_id": 1086
+        "protocol_id": 982
       },
       "minecraft:elytra": {
-        "protocol_id": 809
+        "protocol_id": 735
       },
       "minecraft:emerald": {
-        "protocol_id": 846
+        "protocol_id": 765
       },
       "minecraft:emerald_block": {
-        "protocol_id": 411
+        "protocol_id": 360
       },
       "minecraft:emerald_ore": {
-        "protocol_id": 74
+        "protocol_id": 59
       },
       "minecraft:enchanted_book": {
-        "protocol_id": 1176
+        "protocol_id": 1068
       },
       "minecraft:enchanted_golden_apple": {
-        "protocol_id": 925
+        "protocol_id": 845
       },
       "minecraft:enchanting_table": {
-        "protocol_id": 404
+        "protocol_id": 353
       },
       "minecraft:end_crystal": {
-        "protocol_id": 1212
+        "protocol_id": 1103
       },
       "minecraft:end_portal_frame": {
-        "protocol_id": 405
-      },
-      "minecraft:end_rod": {
-        "protocol_id": 311
-      },
-      "minecraft:end_stone": {
-        "protocol_id": 406
-      },
-      "minecraft:end_stone_brick_slab": {
-        "protocol_id": 674
-      },
-      "minecraft:end_stone_brick_stairs": {
-        "protocol_id": 656
-      },
-      "minecraft:end_stone_brick_wall": {
-        "protocol_id": 440
-      },
-      "minecraft:end_stone_bricks": {
-        "protocol_id": 407
-      },
-      "minecraft:ender_chest": {
-        "protocol_id": 410
-      },
-      "minecraft:ender_dragon_spawn_egg": {
-        "protocol_id": 1087
-      },
-      "minecraft:ender_eye": {
-        "protocol_id": 1066
-      },
-      "minecraft:ender_pearl": {
-        "protocol_id": 1053
-      },
-      "minecraft:enderman_spawn_egg": {
-        "protocol_id": 1088
-      },
-      "minecraft:endermite_spawn_egg": {
-        "protocol_id": 1089
-      },
-      "minecraft:evoker_spawn_egg": {
-        "protocol_id": 1090
-      },
-      "minecraft:experience_bottle": {
-        "protocol_id": 1149
-      },
-      "minecraft:explorer_pottery_sherd": {
-        "protocol_id": 1359
-      },
-      "minecraft:exposed_chiseled_copper": {
-        "protocol_id": 99
-      },
-      "minecraft:exposed_copper": {
-        "protocol_id": 95
-      },
-      "minecraft:exposed_copper_bulb": {
-        "protocol_id": 1384
-      },
-      "minecraft:exposed_copper_door": {
-        "protocol_id": 756
-      },
-      "minecraft:exposed_copper_grate": {
-        "protocol_id": 1376
-      },
-      "minecraft:exposed_copper_trapdoor": {
-        "protocol_id": 777
-      },
-      "minecraft:exposed_cut_copper": {
-        "protocol_id": 103
-      },
-      "minecraft:exposed_cut_copper_slab": {
-        "protocol_id": 111
-      },
-      "minecraft:exposed_cut_copper_stairs": {
-        "protocol_id": 107
-      },
-      "minecraft:eye_armor_trim_smithing_template": {
-        "protocol_id": 1339
-      },
-      "minecraft:farmland": {
-        "protocol_id": 321
-      },
-      "minecraft:feather": {
-        "protocol_id": 891
-      },
-      "minecraft:fermented_spider_eye": {
-        "protocol_id": 1061
-      },
-      "minecraft:fern": {
-        "protocol_id": 203
-      },
-      "minecraft:field_masoned_banner_pattern": {
-        "protocol_id": 1265
-      },
-      "minecraft:filled_map": {
-        "protocol_id": 1042
-      },
-      "minecraft:fire_charge": {
-        "protocol_id": 1150
-      },
-      "minecraft:fire_coral": {
-        "protocol_id": 632
-      },
-      "minecraft:fire_coral_block": {
-        "protocol_id": 627
-      },
-      "minecraft:fire_coral_fan": {
-        "protocol_id": 642
-      },
-      "minecraft:firefly_bush": {
-        "protocol_id": 208
-      },
-      "minecraft:firework_rocket": {
-        "protocol_id": 1174
-      },
-      "minecraft:firework_star": {
-        "protocol_id": 1175
-      },
-      "minecraft:fishing_rod": {
-        "protocol_id": 991
-      },
-      "minecraft:fletching_table": {
-        "protocol_id": 1273
-      },
-      "minecraft:flint": {
-        "protocol_id": 920
-      },
-      "minecraft:flint_and_steel": {
-        "protocol_id": 838
-      },
-      "minecraft:flow_armor_trim_smithing_template": {
-        "protocol_id": 1350
-      },
-      "minecraft:flow_banner_pattern": {
-        "protocol_id": 1263
-      },
-      "minecraft:flow_pottery_sherd": {
-        "protocol_id": 1360
-      },
-      "minecraft:flower_banner_pattern": {
-        "protocol_id": 1257
-      },
-      "minecraft:flower_pot": {
-        "protocol_id": 1158
-      },
-      "minecraft:flowering_azalea": {
-        "protocol_id": 206
-      },
-      "minecraft:flowering_azalea_leaves": {
-        "protocol_id": 192
-      },
-      "minecraft:fox_spawn_egg": {
-        "protocol_id": 1091
-      },
-      "minecraft:friend_pottery_sherd": {
-        "protocol_id": 1361
-      },
-      "minecraft:frog_spawn_egg": {
-        "protocol_id": 1092
-      },
-      "minecraft:frogspawn": {
-        "protocol_id": 1330
-      },
-      "minecraft:furnace": {
-        "protocol_id": 322
-      },
-      "minecraft:furnace_minecart": {
-        "protocol_id": 803
-      },
-      "minecraft:ghast_spawn_egg": {
-        "protocol_id": 1093
-      },
-      "minecraft:ghast_tear": {
-        "protocol_id": 1055
-      },
-      "minecraft:gilded_blackstone": {
-        "protocol_id": 1295
-      },
-      "minecraft:glass": {
-        "protocol_id": 195
-      },
-      "minecraft:glass_bottle": {
-        "protocol_id": 1058
-      },
-      "minecraft:glass_pane": {
-        "protocol_id": 379
-      },
-      "minecraft:glistering_melon_slice": {
-        "protocol_id": 1067
-      },
-      "minecraft:globe_banner_pattern": {
-        "protocol_id": 1261
-      },
-      "minecraft:glow_berries": {
-        "protocol_id": 1281
-      },
-      "minecraft:glow_ink_sac": {
-        "protocol_id": 1002
-      },
-      "minecraft:glow_item_frame": {
-        "protocol_id": 1157
-      },
-      "minecraft:glow_lichen": {
-        "protocol_id": 382
-      },
-      "minecraft:glow_squid_spawn_egg": {
-        "protocol_id": 1094
-      },
-      "minecraft:glowstone": {
         "protocol_id": 354
       },
+      "minecraft:end_rod": {
+        "protocol_id": 270
+      },
+      "minecraft:end_stone": {
+        "protocol_id": 355
+      },
+      "minecraft:end_stone_brick_slab": {
+        "protocol_id": 622
+      },
+      "minecraft:end_stone_brick_stairs": {
+        "protocol_id": 604
+      },
+      "minecraft:end_stone_brick_wall": {
+        "protocol_id": 388
+      },
+      "minecraft:end_stone_bricks": {
+        "protocol_id": 356
+      },
+      "minecraft:ender_chest": {
+        "protocol_id": 359
+      },
+      "minecraft:ender_dragon_spawn_egg": {
+        "protocol_id": 983
+      },
+      "minecraft:ender_eye": {
+        "protocol_id": 965
+      },
+      "minecraft:ender_pearl": {
+        "protocol_id": 952
+      },
+      "minecraft:enderman_spawn_egg": {
+        "protocol_id": 984
+      },
+      "minecraft:endermite_spawn_egg": {
+        "protocol_id": 985
+      },
+      "minecraft:evoker_spawn_egg": {
+        "protocol_id": 986
+      },
+      "minecraft:experience_bottle": {
+        "protocol_id": 1044
+      },
+      "minecraft:explorer_pottery_sherd": {
+        "protocol_id": 1242
+      },
+      "minecraft:exposed_copper": {
+        "protocol_id": 79
+      },
+      "minecraft:exposed_cut_copper": {
+        "protocol_id": 83
+      },
+      "minecraft:exposed_cut_copper_slab": {
+        "protocol_id": 91
+      },
+      "minecraft:exposed_cut_copper_stairs": {
+        "protocol_id": 87
+      },
+      "minecraft:eye_armor_trim_smithing_template": {
+        "protocol_id": 1224
+      },
+      "minecraft:farmland": {
+        "protocol_id": 279
+      },
+      "minecraft:feather": {
+        "protocol_id": 811
+      },
+      "minecraft:fermented_spider_eye": {
+        "protocol_id": 960
+      },
+      "minecraft:fern": {
+        "protocol_id": 174
+      },
+      "minecraft:filled_map": {
+        "protocol_id": 941
+      },
+      "minecraft:fire_charge": {
+        "protocol_id": 1045
+      },
+      "minecraft:fire_coral": {
+        "protocol_id": 580
+      },
+      "minecraft:fire_coral_block": {
+        "protocol_id": 575
+      },
+      "minecraft:fire_coral_fan": {
+        "protocol_id": 590
+      },
+      "minecraft:firework_rocket": {
+        "protocol_id": 1066
+      },
+      "minecraft:firework_star": {
+        "protocol_id": 1067
+      },
+      "minecraft:fishing_rod": {
+        "protocol_id": 891
+      },
+      "minecraft:fletching_table": {
+        "protocol_id": 1158
+      },
+      "minecraft:flint": {
+        "protocol_id": 840
+      },
+      "minecraft:flint_and_steel": {
+        "protocol_id": 758
+      },
+      "minecraft:flower_banner_pattern": {
+        "protocol_id": 1146
+      },
+      "minecraft:flower_pot": {
+        "protocol_id": 1050
+      },
+      "minecraft:flowering_azalea": {
+        "protocol_id": 176
+      },
+      "minecraft:flowering_azalea_leaves": {
+        "protocol_id": 163
+      },
+      "minecraft:fox_spawn_egg": {
+        "protocol_id": 987
+      },
+      "minecraft:friend_pottery_sherd": {
+        "protocol_id": 1243
+      },
+      "minecraft:frog_spawn_egg": {
+        "protocol_id": 988
+      },
+      "minecraft:frogspawn": {
+        "protocol_id": 1215
+      },
+      "minecraft:furnace": {
+        "protocol_id": 280
+      },
+      "minecraft:furnace_minecart": {
+        "protocol_id": 730
+      },
+      "minecraft:ghast_spawn_egg": {
+        "protocol_id": 989
+      },
+      "minecraft:ghast_tear": {
+        "protocol_id": 954
+      },
+      "minecraft:gilded_blackstone": {
+        "protocol_id": 1180
+      },
+      "minecraft:glass": {
+        "protocol_id": 166
+      },
+      "minecraft:glass_bottle": {
+        "protocol_id": 958
+      },
+      "minecraft:glass_pane": {
+        "protocol_id": 335
+      },
+      "minecraft:glistering_melon_slice": {
+        "protocol_id": 966
+      },
+      "minecraft:globe_banner_pattern": {
+        "protocol_id": 1150
+      },
+      "minecraft:glow_berries": {
+        "protocol_id": 1166
+      },
+      "minecraft:glow_ink_sac": {
+        "protocol_id": 902
+      },
+      "minecraft:glow_item_frame": {
+        "protocol_id": 1049
+      },
+      "minecraft:glow_lichen": {
+        "protocol_id": 338
+      },
+      "minecraft:glow_squid_spawn_egg": {
+        "protocol_id": 990
+      },
+      "minecraft:glowstone": {
+        "protocol_id": 310
+      },
       "minecraft:glowstone_dust": {
-        "protocol_id": 994
+        "protocol_id": 894
       },
       "minecraft:goat_horn": {
-        "protocol_id": 1267
+        "protocol_id": 1152
       },
       "minecraft:goat_spawn_egg": {
-        "protocol_id": 1095
+        "protocol_id": 991
       },
       "minecraft:gold_block": {
-        "protocol_id": 92
+        "protocol_id": 76
       },
       "minecraft:gold_ingot": {
-        "protocol_id": 855
+        "protocol_id": 774
       },
       "minecraft:gold_nugget": {
-        "protocol_id": 1056
+        "protocol_id": 955
       },
       "minecraft:gold_ore": {
-        "protocol_id": 70
+        "protocol_id": 55
       },
       "minecraft:golden_apple": {
-        "protocol_id": 924
+        "protocol_id": 844
       },
       "minecraft:golden_axe": {
-        "protocol_id": 871
+        "protocol_id": 790
       },
       "minecraft:golden_boots": {
-        "protocol_id": 915
+        "protocol_id": 835
       },
       "minecraft:golden_carrot": {
-        "protocol_id": 1164
+        "protocol_id": 1056
       },
       "minecraft:golden_chestplate": {
-        "protocol_id": 913
+        "protocol_id": 833
       },
       "minecraft:golden_helmet": {
-        "protocol_id": 912
+        "protocol_id": 832
       },
       "minecraft:golden_hoe": {
-        "protocol_id": 872
+        "protocol_id": 791
       },
       "minecraft:golden_horse_armor": {
-        "protocol_id": 1188
+        "protocol_id": 1079
       },
       "minecraft:golden_leggings": {
-        "protocol_id": 914
+        "protocol_id": 834
       },
       "minecraft:golden_pickaxe": {
-        "protocol_id": 870
+        "protocol_id": 789
       },
       "minecraft:golden_shovel": {
-        "protocol_id": 869
+        "protocol_id": 788
       },
       "minecraft:golden_sword": {
-        "protocol_id": 868
+        "protocol_id": 787
       },
       "minecraft:granite": {
         "protocol_id": 2
       },
       "minecraft:granite_slab": {
-        "protocol_id": 677
+        "protocol_id": 625
       },
       "minecraft:granite_stairs": {
-        "protocol_id": 660
-      },
-      "minecraft:granite_wall": {
-        "protocol_id": 433
-      },
-      "minecraft:grass_block": {
-        "protocol_id": 27
-      },
-      "minecraft:gravel": {
-        "protocol_id": 63
-      },
-      "minecraft:gray_banner": {
-        "protocol_id": 1203
-      },
-      "minecraft:gray_bed": {
-        "protocol_id": 1031
-      },
-      "minecraft:gray_bundle": {
-        "protocol_id": 982
-      },
-      "minecraft:gray_candle": {
-        "protocol_id": 1313
-      },
-      "minecraft:gray_carpet": {
-        "protocol_id": 483
-      },
-      "minecraft:gray_concrete": {
-        "protocol_id": 592
-      },
-      "minecraft:gray_concrete_powder": {
         "protocol_id": 608
       },
-      "minecraft:gray_dye": {
-        "protocol_id": 1011
+      "minecraft:granite_wall": {
+        "protocol_id": 381
       },
-      "minecraft:gray_glazed_terracotta": {
-        "protocol_id": 576
+      "minecraft:grass": {
+        "protocol_id": 173
       },
-      "minecraft:gray_shulker_box": {
-        "protocol_id": 560
+      "minecraft:grass_block": {
+        "protocol_id": 14
       },
-      "minecraft:gray_stained_glass": {
-        "protocol_id": 508
+      "minecraft:gravel": {
+        "protocol_id": 48
       },
-      "minecraft:gray_stained_glass_pane": {
-        "protocol_id": 524
+      "minecraft:gray_banner": {
+        "protocol_id": 1094
       },
-      "minecraft:gray_terracotta": {
-        "protocol_id": 464
+      "minecraft:gray_bed": {
+        "protocol_id": 931
       },
-      "minecraft:gray_wool": {
-        "protocol_id": 220
-      },
-      "minecraft:green_banner": {
-        "protocol_id": 1209
-      },
-      "minecraft:green_bed": {
-        "protocol_id": 1037
-      },
-      "minecraft:green_bundle": {
-        "protocol_id": 988
-      },
-      "minecraft:green_candle": {
-        "protocol_id": 1319
-      },
-      "minecraft:green_carpet": {
-        "protocol_id": 489
-      },
-      "minecraft:green_concrete": {
-        "protocol_id": 598
-      },
-      "minecraft:green_concrete_powder": {
-        "protocol_id": 614
-      },
-      "minecraft:green_dye": {
-        "protocol_id": 1017
-      },
-      "minecraft:green_glazed_terracotta": {
-        "protocol_id": 582
-      },
-      "minecraft:green_shulker_box": {
-        "protocol_id": 566
-      },
-      "minecraft:green_stained_glass": {
-        "protocol_id": 514
-      },
-      "minecraft:green_stained_glass_pane": {
-        "protocol_id": 530
-      },
-      "minecraft:green_terracotta": {
-        "protocol_id": 470
-      },
-      "minecraft:green_wool": {
-        "protocol_id": 226
-      },
-      "minecraft:grindstone": {
-        "protocol_id": 1274
-      },
-      "minecraft:guardian_spawn_egg": {
-        "protocol_id": 1096
-      },
-      "minecraft:gunpowder": {
-        "protocol_id": 892
-      },
-      "minecraft:guster_banner_pattern": {
-        "protocol_id": 1264
-      },
-      "minecraft:guster_pottery_sherd": {
-        "protocol_id": 1362
-      },
-      "minecraft:hanging_roots": {
-        "protocol_id": 266
-      },
-      "minecraft:hay_block": {
-        "protocol_id": 475
-      },
-      "minecraft:heart_of_the_sea": {
-        "protocol_id": 1253
-      },
-      "minecraft:heart_pottery_sherd": {
-        "protocol_id": 1363
-      },
-      "minecraft:heartbreak_pottery_sherd": {
-        "protocol_id": 1364
-      },
-      "minecraft:heavy_core": {
-        "protocol_id": 87
-      },
-      "minecraft:heavy_weighted_pressure_plate": {
-        "protocol_id": 729
-      },
-      "minecraft:hoglin_spawn_egg": {
-        "protocol_id": 1097
-      },
-      "minecraft:honey_block": {
-        "protocol_id": 695
-      },
-      "minecraft:honey_bottle": {
-        "protocol_id": 1288
-      },
-      "minecraft:honeycomb": {
-        "protocol_id": 1285
-      },
-      "minecraft:honeycomb_block": {
-        "protocol_id": 1289
-      },
-      "minecraft:hopper": {
-        "protocol_id": 697
-      },
-      "minecraft:hopper_minecart": {
-        "protocol_id": 805
-      },
-      "minecraft:horn_coral": {
-        "protocol_id": 633
-      },
-      "minecraft:horn_coral_block": {
-        "protocol_id": 628
-      },
-      "minecraft:horn_coral_fan": {
-        "protocol_id": 643
-      },
-      "minecraft:horse_spawn_egg": {
-        "protocol_id": 1098
-      },
-      "minecraft:host_armor_trim_smithing_template": {
-        "protocol_id": 1349
-      },
-      "minecraft:howl_pottery_sherd": {
-        "protocol_id": 1365
-      },
-      "minecraft:husk_spawn_egg": {
-        "protocol_id": 1099
-      },
-      "minecraft:ice": {
-        "protocol_id": 326
-      },
-      "minecraft:infested_chiseled_stone_bricks": {
-        "protocol_id": 360
-      },
-      "minecraft:infested_cobblestone": {
-        "protocol_id": 356
-      },
-      "minecraft:infested_cracked_stone_bricks": {
-        "protocol_id": 359
-      },
-      "minecraft:infested_deepslate": {
-        "protocol_id": 361
-      },
-      "minecraft:infested_mossy_stone_bricks": {
-        "protocol_id": 358
-      },
-      "minecraft:infested_stone": {
-        "protocol_id": 355
-      },
-      "minecraft:infested_stone_bricks": {
-        "protocol_id": 357
-      },
-      "minecraft:ink_sac": {
-        "protocol_id": 1001
-      },
-      "minecraft:iron_axe": {
-        "protocol_id": 876
-      },
-      "minecraft:iron_bars": {
-        "protocol_id": 377
-      },
-      "minecraft:iron_block": {
-        "protocol_id": 90
-      },
-      "minecraft:iron_boots": {
-        "protocol_id": 907
-      },
-      "minecraft:iron_chestplate": {
-        "protocol_id": 905
-      },
-      "minecraft:iron_door": {
-        "protocol_id": 742
-      },
-      "minecraft:iron_golem_spawn_egg": {
-        "protocol_id": 1100
-      },
-      "minecraft:iron_helmet": {
-        "protocol_id": 904
-      },
-      "minecraft:iron_hoe": {
-        "protocol_id": 877
-      },
-      "minecraft:iron_horse_armor": {
-        "protocol_id": 1187
-      },
-      "minecraft:iron_ingot": {
-        "protocol_id": 851
-      },
-      "minecraft:iron_leggings": {
-        "protocol_id": 906
-      },
-      "minecraft:iron_nugget": {
-        "protocol_id": 1228
-      },
-      "minecraft:iron_ore": {
-        "protocol_id": 66
-      },
-      "minecraft:iron_pickaxe": {
-        "protocol_id": 875
-      },
-      "minecraft:iron_shovel": {
-        "protocol_id": 874
-      },
-      "minecraft:iron_sword": {
-        "protocol_id": 873
-      },
-      "minecraft:iron_trapdoor": {
-        "protocol_id": 763
-      },
-      "minecraft:item_frame": {
-        "protocol_id": 1156
-      },
-      "minecraft:jack_o_lantern": {
-        "protocol_id": 346
-      },
-      "minecraft:jigsaw": {
-        "protocol_id": 831
-      },
-      "minecraft:jukebox": {
-        "protocol_id": 331
-      },
-      "minecraft:jungle_boat": {
-        "protocol_id": 816
-      },
-      "minecraft:jungle_button": {
-        "protocol_id": 717
-      },
-      "minecraft:jungle_chest_boat": {
-        "protocol_id": 817
-      },
-      "minecraft:jungle_door": {
-        "protocol_id": 746
-      },
-      "minecraft:jungle_fence": {
-        "protocol_id": 335
-      },
-      "minecraft:jungle_fence_gate": {
-        "protocol_id": 787
-      },
-      "minecraft:jungle_hanging_sign": {
-        "protocol_id": 941
-      },
-      "minecraft:jungle_leaves": {
-        "protocol_id": 185
-      },
-      "minecraft:jungle_log": {
-        "protocol_id": 137
-      },
-      "minecraft:jungle_planks": {
-        "protocol_id": 39
-      },
-      "minecraft:jungle_pressure_plate": {
-        "protocol_id": 733
-      },
-      "minecraft:jungle_sapling": {
-        "protocol_id": 52
-      },
-      "minecraft:jungle_sign": {
-        "protocol_id": 929
-      },
-      "minecraft:jungle_slab": {
-        "protocol_id": 273
-      },
-      "minecraft:jungle_stairs": {
-        "protocol_id": 415
-      },
-      "minecraft:jungle_trapdoor": {
-        "protocol_id": 767
-      },
-      "minecraft:jungle_wood": {
-        "protocol_id": 174
-      },
-      "minecraft:kelp": {
-        "protocol_id": 257
-      },
-      "minecraft:knowledge_book": {
-        "protocol_id": 1229
-      },
-      "minecraft:ladder": {
-        "protocol_id": 323
-      },
-      "minecraft:lantern": {
-        "protocol_id": 1278
-      },
-      "minecraft:lapis_block": {
-        "protocol_id": 197
-      },
-      "minecraft:lapis_lazuli": {
-        "protocol_id": 847
-      },
-      "minecraft:lapis_ore": {
-        "protocol_id": 76
-      },
-      "minecraft:large_amethyst_bud": {
-        "protocol_id": 1324
-      },
-      "minecraft:large_fern": {
-        "protocol_id": 500
-      },
-      "minecraft:lava_bucket": {
-        "protocol_id": 952
-      },
-      "minecraft:lead": {
-        "protocol_id": 1191
-      },
-      "minecraft:leaf_litter": {
-        "protocol_id": 260
-      },
-      "minecraft:leather": {
-        "protocol_id": 955
-      },
-      "minecraft:leather_boots": {
-        "protocol_id": 899
-      },
-      "minecraft:leather_chestplate": {
-        "protocol_id": 897
-      },
-      "minecraft:leather_helmet": {
-        "protocol_id": 896
-      },
-      "minecraft:leather_horse_armor": {
-        "protocol_id": 1190
-      },
-      "minecraft:leather_leggings": {
-        "protocol_id": 898
-      },
-      "minecraft:lectern": {
-        "protocol_id": 700
-      },
-      "minecraft:lever": {
-        "protocol_id": 702
-      },
-      "minecraft:light": {
-        "protocol_id": 474
-      },
-      "minecraft:light_blue_banner": {
-        "protocol_id": 1199
-      },
-      "minecraft:light_blue_bed": {
-        "protocol_id": 1027
-      },
-      "minecraft:light_blue_bundle": {
-        "protocol_id": 978
-      },
-      "minecraft:light_blue_candle": {
-        "protocol_id": 1309
-      },
-      "minecraft:light_blue_carpet": {
-        "protocol_id": 479
-      },
-      "minecraft:light_blue_concrete": {
-        "protocol_id": 588
-      },
-      "minecraft:light_blue_concrete_powder": {
-        "protocol_id": 604
-      },
-      "minecraft:light_blue_dye": {
-        "protocol_id": 1007
-      },
-      "minecraft:light_blue_glazed_terracotta": {
-        "protocol_id": 572
-      },
-      "minecraft:light_blue_shulker_box": {
-        "protocol_id": 556
-      },
-      "minecraft:light_blue_stained_glass": {
-        "protocol_id": 504
-      },
-      "minecraft:light_blue_stained_glass_pane": {
-        "protocol_id": 520
-      },
-      "minecraft:light_blue_terracotta": {
-        "protocol_id": 460
-      },
-      "minecraft:light_blue_wool": {
-        "protocol_id": 216
-      },
-      "minecraft:light_gray_banner": {
-        "protocol_id": 1204
-      },
-      "minecraft:light_gray_bed": {
-        "protocol_id": 1032
-      },
-      "minecraft:light_gray_bundle": {
-        "protocol_id": 983
-      },
-      "minecraft:light_gray_candle": {
-        "protocol_id": 1314
-      },
-      "minecraft:light_gray_carpet": {
-        "protocol_id": 484
-      },
-      "minecraft:light_gray_concrete": {
-        "protocol_id": 593
-      },
-      "minecraft:light_gray_concrete_powder": {
-        "protocol_id": 609
-      },
-      "minecraft:light_gray_dye": {
-        "protocol_id": 1012
-      },
-      "minecraft:light_gray_glazed_terracotta": {
-        "protocol_id": 577
-      },
-      "minecraft:light_gray_shulker_box": {
-        "protocol_id": 561
-      },
-      "minecraft:light_gray_stained_glass": {
-        "protocol_id": 509
-      },
-      "minecraft:light_gray_stained_glass_pane": {
-        "protocol_id": 525
-      },
-      "minecraft:light_gray_terracotta": {
-        "protocol_id": 465
-      },
-      "minecraft:light_gray_wool": {
-        "protocol_id": 221
-      },
-      "minecraft:light_weighted_pressure_plate": {
-        "protocol_id": 728
-      },
-      "minecraft:lightning_rod": {
-        "protocol_id": 703
-      },
-      "minecraft:lilac": {
-        "protocol_id": 496
-      },
-      "minecraft:lily_of_the_valley": {
-        "protocol_id": 242
-      },
-      "minecraft:lily_pad": {
-        "protocol_id": 394
-      },
-      "minecraft:lime_banner": {
-        "protocol_id": 1201
-      },
-      "minecraft:lime_bed": {
-        "protocol_id": 1029
-      },
-      "minecraft:lime_bundle": {
-        "protocol_id": 980
-      },
-      "minecraft:lime_candle": {
-        "protocol_id": 1311
-      },
-      "minecraft:lime_carpet": {
-        "protocol_id": 481
-      },
-      "minecraft:lime_concrete": {
-        "protocol_id": 590
-      },
-      "minecraft:lime_concrete_powder": {
-        "protocol_id": 606
-      },
-      "minecraft:lime_dye": {
-        "protocol_id": 1009
-      },
-      "minecraft:lime_glazed_terracotta": {
-        "protocol_id": 574
-      },
-      "minecraft:lime_shulker_box": {
-        "protocol_id": 558
-      },
-      "minecraft:lime_stained_glass": {
-        "protocol_id": 506
-      },
-      "minecraft:lime_stained_glass_pane": {
-        "protocol_id": 522
-      },
-      "minecraft:lime_terracotta": {
-        "protocol_id": 462
-      },
-      "minecraft:lime_wool": {
-        "protocol_id": 218
-      },
-      "minecraft:lingering_potion": {
-        "protocol_id": 1224
-      },
-      "minecraft:llama_spawn_egg": {
-        "protocol_id": 1101
-      },
-      "minecraft:lodestone": {
-        "protocol_id": 1290
-      },
-      "minecraft:loom": {
-        "protocol_id": 1256
-      },
-      "minecraft:mace": {
-        "protocol_id": 1155
-      },
-      "minecraft:magenta_banner": {
+      "minecraft:gray_candle": {
         "protocol_id": 1198
       },
-      "minecraft:magenta_bed": {
-        "protocol_id": 1026
+      "minecraft:gray_carpet": {
+        "protocol_id": 431
       },
-      "minecraft:magenta_bundle": {
-        "protocol_id": 977
+      "minecraft:gray_concrete": {
+        "protocol_id": 540
       },
-      "minecraft:magenta_candle": {
-        "protocol_id": 1308
+      "minecraft:gray_concrete_powder": {
+        "protocol_id": 556
       },
-      "minecraft:magenta_carpet": {
-        "protocol_id": 478
+      "minecraft:gray_dye": {
+        "protocol_id": 911
       },
-      "minecraft:magenta_concrete": {
-        "protocol_id": 587
+      "minecraft:gray_glazed_terracotta": {
+        "protocol_id": 524
       },
-      "minecraft:magenta_concrete_powder": {
-        "protocol_id": 603
+      "minecraft:gray_shulker_box": {
+        "protocol_id": 508
       },
-      "minecraft:magenta_dye": {
-        "protocol_id": 1006
+      "minecraft:gray_stained_glass": {
+        "protocol_id": 456
       },
-      "minecraft:magenta_glazed_terracotta": {
-        "protocol_id": 571
+      "minecraft:gray_stained_glass_pane": {
+        "protocol_id": 472
       },
-      "minecraft:magenta_shulker_box": {
-        "protocol_id": 555
-      },
-      "minecraft:magenta_stained_glass": {
-        "protocol_id": 503
-      },
-      "minecraft:magenta_stained_glass_pane": {
-        "protocol_id": 519
-      },
-      "minecraft:magenta_terracotta": {
-        "protocol_id": 459
-      },
-      "minecraft:magenta_wool": {
-        "protocol_id": 215
-      },
-      "minecraft:magma_block": {
-        "protocol_id": 546
-      },
-      "minecraft:magma_cream": {
-        "protocol_id": 1063
-      },
-      "minecraft:magma_cube_spawn_egg": {
-        "protocol_id": 1102
-      },
-      "minecraft:mangrove_boat": {
-        "protocol_id": 826
-      },
-      "minecraft:mangrove_button": {
-        "protocol_id": 722
-      },
-      "minecraft:mangrove_chest_boat": {
-        "protocol_id": 827
-      },
-      "minecraft:mangrove_door": {
-        "protocol_id": 751
-      },
-      "minecraft:mangrove_fence": {
-        "protocol_id": 340
-      },
-      "minecraft:mangrove_fence_gate": {
-        "protocol_id": 792
-      },
-      "minecraft:mangrove_hanging_sign": {
-        "protocol_id": 946
-      },
-      "minecraft:mangrove_leaves": {
-        "protocol_id": 190
-      },
-      "minecraft:mangrove_log": {
-        "protocol_id": 142
-      },
-      "minecraft:mangrove_planks": {
-        "protocol_id": 44
-      },
-      "minecraft:mangrove_pressure_plate": {
-        "protocol_id": 738
-      },
-      "minecraft:mangrove_propagule": {
-        "protocol_id": 57
-      },
-      "minecraft:mangrove_roots": {
-        "protocol_id": 143
-      },
-      "minecraft:mangrove_sign": {
-        "protocol_id": 934
-      },
-      "minecraft:mangrove_slab": {
-        "protocol_id": 278
-      },
-      "minecraft:mangrove_stairs": {
-        "protocol_id": 420
-      },
-      "minecraft:mangrove_trapdoor": {
-        "protocol_id": 772
-      },
-      "minecraft:mangrove_wood": {
-        "protocol_id": 179
-      },
-      "minecraft:map": {
-        "protocol_id": 1163
-      },
-      "minecraft:medium_amethyst_bud": {
-        "protocol_id": 1323
-      },
-      "minecraft:melon": {
-        "protocol_id": 380
-      },
-      "minecraft:melon_seeds": {
-        "protocol_id": 1047
-      },
-      "minecraft:melon_slice": {
-        "protocol_id": 1044
-      },
-      "minecraft:milk_bucket": {
-        "protocol_id": 956
-      },
-      "minecraft:minecart": {
-        "protocol_id": 801
-      },
-      "minecraft:miner_pottery_sherd": {
-        "protocol_id": 1366
-      },
-      "minecraft:mojang_banner_pattern": {
-        "protocol_id": 1260
-      },
-      "minecraft:mooshroom_spawn_egg": {
-        "protocol_id": 1103
-      },
-      "minecraft:moss_block": {
-        "protocol_id": 262
-      },
-      "minecraft:moss_carpet": {
-        "protocol_id": 261
-      },
-      "minecraft:mossy_cobblestone": {
-        "protocol_id": 308
-      },
-      "minecraft:mossy_cobblestone_slab": {
-        "protocol_id": 673
-      },
-      "minecraft:mossy_cobblestone_stairs": {
-        "protocol_id": 655
-      },
-      "minecraft:mossy_cobblestone_wall": {
-        "protocol_id": 428
-      },
-      "minecraft:mossy_stone_brick_slab": {
-        "protocol_id": 671
-      },
-      "minecraft:mossy_stone_brick_stairs": {
-        "protocol_id": 653
-      },
-      "minecraft:mossy_stone_brick_wall": {
-        "protocol_id": 432
-      },
-      "minecraft:mossy_stone_bricks": {
-        "protocol_id": 363
-      },
-      "minecraft:mourner_pottery_sherd": {
-        "protocol_id": 1367
-      },
-      "minecraft:mud": {
-        "protocol_id": 32
-      },
-      "minecraft:mud_brick_slab": {
-        "protocol_id": 291
-      },
-      "minecraft:mud_brick_stairs": {
-        "protocol_id": 392
-      },
-      "minecraft:mud_brick_wall": {
-        "protocol_id": 435
-      },
-      "minecraft:mud_bricks": {
-        "protocol_id": 367
-      },
-      "minecraft:muddy_mangrove_roots": {
-        "protocol_id": 144
-      },
-      "minecraft:mule_spawn_egg": {
-        "protocol_id": 1104
-      },
-      "minecraft:mushroom_stem": {
-        "protocol_id": 376
-      },
-      "minecraft:mushroom_stew": {
-        "protocol_id": 889
-      },
-      "minecraft:music_disc_11": {
-        "protocol_id": 1243
-      },
-      "minecraft:music_disc_13": {
-        "protocol_id": 1231
-      },
-      "minecraft:music_disc_5": {
-        "protocol_id": 1247
-      },
-      "minecraft:music_disc_blocks": {
-        "protocol_id": 1233
-      },
-      "minecraft:music_disc_cat": {
-        "protocol_id": 1232
-      },
-      "minecraft:music_disc_chirp": {
-        "protocol_id": 1234
-      },
-      "minecraft:music_disc_creator": {
-        "protocol_id": 1235
-      },
-      "minecraft:music_disc_creator_music_box": {
-        "protocol_id": 1236
-      },
-      "minecraft:music_disc_far": {
-        "protocol_id": 1237
-      },
-      "minecraft:music_disc_mall": {
-        "protocol_id": 1238
-      },
-      "minecraft:music_disc_mellohi": {
-        "protocol_id": 1239
-      },
-      "minecraft:music_disc_otherside": {
-        "protocol_id": 1245
-      },
-      "minecraft:music_disc_pigstep": {
-        "protocol_id": 1248
-      },
-      "minecraft:music_disc_precipice": {
-        "protocol_id": 1249
-      },
-      "minecraft:music_disc_relic": {
-        "protocol_id": 1246
-      },
-      "minecraft:music_disc_stal": {
-        "protocol_id": 1240
-      },
-      "minecraft:music_disc_strad": {
-        "protocol_id": 1241
-      },
-      "minecraft:music_disc_wait": {
-        "protocol_id": 1244
-      },
-      "minecraft:music_disc_ward": {
-        "protocol_id": 1242
-      },
-      "minecraft:mutton": {
-        "protocol_id": 1194
-      },
-      "minecraft:mycelium": {
-        "protocol_id": 393
-      },
-      "minecraft:name_tag": {
-        "protocol_id": 1192
-      },
-      "minecraft:nautilus_shell": {
-        "protocol_id": 1252
-      },
-      "minecraft:nether_brick": {
-        "protocol_id": 1177
-      },
-      "minecraft:nether_brick_fence": {
-        "protocol_id": 398
-      },
-      "minecraft:nether_brick_slab": {
-        "protocol_id": 292
-      },
-      "minecraft:nether_brick_stairs": {
-        "protocol_id": 399
-      },
-      "minecraft:nether_brick_wall": {
-        "protocol_id": 436
-      },
-      "minecraft:nether_bricks": {
-        "protocol_id": 395
-      },
-      "minecraft:nether_gold_ore": {
-        "protocol_id": 80
-      },
-      "minecraft:nether_quartz_ore": {
-        "protocol_id": 81
-      },
-      "minecraft:nether_sprouts": {
-        "protocol_id": 253
-      },
-      "minecraft:nether_star": {
-        "protocol_id": 1172
-      },
-      "minecraft:nether_wart": {
-        "protocol_id": 1057
-      },
-      "minecraft:nether_wart_block": {
-        "protocol_id": 547
-      },
-      "minecraft:netherite_axe": {
-        "protocol_id": 886
-      },
-      "minecraft:netherite_block": {
-        "protocol_id": 94
-      },
-      "minecraft:netherite_boots": {
-        "protocol_id": 919
-      },
-      "minecraft:netherite_chestplate": {
-        "protocol_id": 917
-      },
-      "minecraft:netherite_helmet": {
-        "protocol_id": 916
-      },
-      "minecraft:netherite_hoe": {
-        "protocol_id": 887
-      },
-      "minecraft:netherite_ingot": {
-        "protocol_id": 856
-      },
-      "minecraft:netherite_leggings": {
-        "protocol_id": 918
-      },
-      "minecraft:netherite_pickaxe": {
-        "protocol_id": 885
-      },
-      "minecraft:netherite_scrap": {
-        "protocol_id": 857
-      },
-      "minecraft:netherite_shovel": {
-        "protocol_id": 884
-      },
-      "minecraft:netherite_sword": {
-        "protocol_id": 883
-      },
-      "minecraft:netherite_upgrade_smithing_template": {
-        "protocol_id": 1333
-      },
-      "minecraft:netherrack": {
-        "protocol_id": 347
-      },
-      "minecraft:note_block": {
-        "protocol_id": 711
-      },
-      "minecraft:oak_boat": {
-        "protocol_id": 810
-      },
-      "minecraft:oak_button": {
-        "protocol_id": 714
-      },
-      "minecraft:oak_chest_boat": {
-        "protocol_id": 811
-      },
-      "minecraft:oak_door": {
-        "protocol_id": 743
-      },
-      "minecraft:oak_fence": {
-        "protocol_id": 332
-      },
-      "minecraft:oak_fence_gate": {
-        "protocol_id": 784
-      },
-      "minecraft:oak_hanging_sign": {
-        "protocol_id": 938
-      },
-      "minecraft:oak_leaves": {
-        "protocol_id": 182
-      },
-      "minecraft:oak_log": {
-        "protocol_id": 134
-      },
-      "minecraft:oak_planks": {
-        "protocol_id": 36
-      },
-      "minecraft:oak_pressure_plate": {
-        "protocol_id": 730
-      },
-      "minecraft:oak_sapling": {
-        "protocol_id": 49
-      },
-      "minecraft:oak_sign": {
-        "protocol_id": 926
-      },
-      "minecraft:oak_slab": {
-        "protocol_id": 270
-      },
-      "minecraft:oak_stairs": {
+      "minecraft:gray_terracotta": {
         "protocol_id": 412
       },
-      "minecraft:oak_trapdoor": {
-        "protocol_id": 764
+      "minecraft:gray_wool": {
+        "protocol_id": 187
       },
-      "minecraft:oak_wood": {
-        "protocol_id": 171
+      "minecraft:green_banner": {
+        "protocol_id": 1100
       },
-      "minecraft:observer": {
-        "protocol_id": 696
+      "minecraft:green_bed": {
+        "protocol_id": 937
       },
-      "minecraft:obsidian": {
-        "protocol_id": 309
+      "minecraft:green_candle": {
+        "protocol_id": 1204
       },
-      "minecraft:ocelot_spawn_egg": {
-        "protocol_id": 1105
+      "minecraft:green_carpet": {
+        "protocol_id": 437
       },
-      "minecraft:ochre_froglight": {
-        "protocol_id": 1327
+      "minecraft:green_concrete": {
+        "protocol_id": 546
       },
-      "minecraft:ominous_bottle": {
-        "protocol_id": 1395
+      "minecraft:green_concrete_powder": {
+        "protocol_id": 562
       },
-      "minecraft:ominous_trial_key": {
-        "protocol_id": 1393
+      "minecraft:green_dye": {
+        "protocol_id": 917
       },
-      "minecraft:open_eyeblossom": {
-        "protocol_id": 230
+      "minecraft:green_glazed_terracotta": {
+        "protocol_id": 530
       },
-      "minecraft:orange_banner": {
-        "protocol_id": 1197
+      "minecraft:green_shulker_box": {
+        "protocol_id": 514
       },
-      "minecraft:orange_bed": {
-        "protocol_id": 1025
+      "minecraft:green_stained_glass": {
+        "protocol_id": 462
       },
-      "minecraft:orange_bundle": {
-        "protocol_id": 976
+      "minecraft:green_stained_glass_pane": {
+        "protocol_id": 478
       },
-      "minecraft:orange_candle": {
-        "protocol_id": 1307
+      "minecraft:green_terracotta": {
+        "protocol_id": 418
       },
-      "minecraft:orange_carpet": {
-        "protocol_id": 477
+      "minecraft:green_wool": {
+        "protocol_id": 193
       },
-      "minecraft:orange_concrete": {
-        "protocol_id": 586
+      "minecraft:grindstone": {
+        "protocol_id": 1159
       },
-      "minecraft:orange_concrete_powder": {
-        "protocol_id": 602
+      "minecraft:guardian_spawn_egg": {
+        "protocol_id": 992
       },
-      "minecraft:orange_dye": {
-        "protocol_id": 1005
+      "minecraft:gunpowder": {
+        "protocol_id": 812
       },
-      "minecraft:orange_glazed_terracotta": {
-        "protocol_id": 570
+      "minecraft:hanging_roots": {
+        "protocol_id": 226
       },
-      "minecraft:orange_shulker_box": {
-        "protocol_id": 554
+      "minecraft:hay_block": {
+        "protocol_id": 423
       },
-      "minecraft:orange_stained_glass": {
-        "protocol_id": 502
+      "minecraft:heart_of_the_sea": {
+        "protocol_id": 1142
       },
-      "minecraft:orange_stained_glass_pane": {
-        "protocol_id": 518
+      "minecraft:heart_pottery_sherd": {
+        "protocol_id": 1244
       },
-      "minecraft:orange_terracotta": {
-        "protocol_id": 458
+      "minecraft:heartbreak_pottery_sherd": {
+        "protocol_id": 1245
       },
-      "minecraft:orange_tulip": {
-        "protocol_id": 237
+      "minecraft:heavy_weighted_pressure_plate": {
+        "protocol_id": 676
       },
-      "minecraft:orange_wool": {
-        "protocol_id": 214
+      "minecraft:hoglin_spawn_egg": {
+        "protocol_id": 993
       },
-      "minecraft:oxeye_daisy": {
-        "protocol_id": 240
+      "minecraft:honey_block": {
+        "protocol_id": 643
       },
-      "minecraft:oxidized_chiseled_copper": {
-        "protocol_id": 101
+      "minecraft:honey_bottle": {
+        "protocol_id": 1173
       },
-      "minecraft:oxidized_copper": {
-        "protocol_id": 97
+      "minecraft:honeycomb": {
+        "protocol_id": 1170
       },
-      "minecraft:oxidized_copper_bulb": {
-        "protocol_id": 1386
+      "minecraft:honeycomb_block": {
+        "protocol_id": 1174
       },
-      "minecraft:oxidized_copper_door": {
-        "protocol_id": 758
+      "minecraft:hopper": {
+        "protocol_id": 645
       },
-      "minecraft:oxidized_copper_grate": {
-        "protocol_id": 1378
+      "minecraft:hopper_minecart": {
+        "protocol_id": 732
       },
-      "minecraft:oxidized_copper_trapdoor": {
-        "protocol_id": 779
+      "minecraft:horn_coral": {
+        "protocol_id": 581
       },
-      "minecraft:oxidized_cut_copper": {
-        "protocol_id": 105
+      "minecraft:horn_coral_block": {
+        "protocol_id": 576
       },
-      "minecraft:oxidized_cut_copper_slab": {
-        "protocol_id": 113
-      },
-      "minecraft:oxidized_cut_copper_stairs": {
-        "protocol_id": 109
-      },
-      "minecraft:packed_ice": {
-        "protocol_id": 493
-      },
-      "minecraft:packed_mud": {
-        "protocol_id": 366
-      },
-      "minecraft:painting": {
-        "protocol_id": 923
-      },
-      "minecraft:pale_hanging_moss": {
-        "protocol_id": 264
-      },
-      "minecraft:pale_moss_block": {
-        "protocol_id": 265
-      },
-      "minecraft:pale_moss_carpet": {
-        "protocol_id": 263
-      },
-      "minecraft:pale_oak_boat": {
-        "protocol_id": 824
-      },
-      "minecraft:pale_oak_button": {
-        "protocol_id": 721
-      },
-      "minecraft:pale_oak_chest_boat": {
-        "protocol_id": 825
-      },
-      "minecraft:pale_oak_door": {
-        "protocol_id": 750
-      },
-      "minecraft:pale_oak_fence": {
-        "protocol_id": 339
-      },
-      "minecraft:pale_oak_fence_gate": {
-        "protocol_id": 791
-      },
-      "minecraft:pale_oak_hanging_sign": {
-        "protocol_id": 945
-      },
-      "minecraft:pale_oak_leaves": {
-        "protocol_id": 189
-      },
-      "minecraft:pale_oak_log": {
-        "protocol_id": 140
-      },
-      "minecraft:pale_oak_planks": {
-        "protocol_id": 43
-      },
-      "minecraft:pale_oak_pressure_plate": {
-        "protocol_id": 737
-      },
-      "minecraft:pale_oak_sapling": {
-        "protocol_id": 56
-      },
-      "minecraft:pale_oak_sign": {
-        "protocol_id": 933
-      },
-      "minecraft:pale_oak_slab": {
-        "protocol_id": 277
-      },
-      "minecraft:pale_oak_stairs": {
-        "protocol_id": 419
-      },
-      "minecraft:pale_oak_trapdoor": {
-        "protocol_id": 771
-      },
-      "minecraft:pale_oak_wood": {
-        "protocol_id": 177
-      },
-      "minecraft:panda_spawn_egg": {
-        "protocol_id": 1106
-      },
-      "minecraft:paper": {
-        "protocol_id": 966
-      },
-      "minecraft:parrot_spawn_egg": {
-        "protocol_id": 1107
-      },
-      "minecraft:pearlescent_froglight": {
-        "protocol_id": 1329
-      },
-      "minecraft:peony": {
-        "protocol_id": 498
-      },
-      "minecraft:petrified_oak_slab": {
-        "protocol_id": 287
-      },
-      "minecraft:phantom_membrane": {
-        "protocol_id": 808
-      },
-      "minecraft:phantom_spawn_egg": {
-        "protocol_id": 1108
-      },
-      "minecraft:pig_spawn_egg": {
-        "protocol_id": 1109
-      },
-      "minecraft:piglin_banner_pattern": {
-        "protocol_id": 1262
-      },
-      "minecraft:piglin_brute_spawn_egg": {
-        "protocol_id": 1111
-      },
-      "minecraft:piglin_head": {
-        "protocol_id": 1171
-      },
-      "minecraft:piglin_spawn_egg": {
-        "protocol_id": 1110
-      },
-      "minecraft:pillager_spawn_egg": {
-        "protocol_id": 1112
-      },
-      "minecraft:pink_banner": {
-        "protocol_id": 1202
-      },
-      "minecraft:pink_bed": {
-        "protocol_id": 1030
-      },
-      "minecraft:pink_bundle": {
-        "protocol_id": 981
-      },
-      "minecraft:pink_candle": {
-        "protocol_id": 1312
-      },
-      "minecraft:pink_carpet": {
-        "protocol_id": 482
-      },
-      "minecraft:pink_concrete": {
+      "minecraft:horn_coral_fan": {
         "protocol_id": 591
       },
-      "minecraft:pink_concrete_powder": {
-        "protocol_id": 607
+      "minecraft:horse_spawn_egg": {
+        "protocol_id": 994
       },
-      "minecraft:pink_dye": {
-        "protocol_id": 1010
+      "minecraft:host_armor_trim_smithing_template": {
+        "protocol_id": 1234
       },
-      "minecraft:pink_glazed_terracotta": {
-        "protocol_id": 575
+      "minecraft:howl_pottery_sherd": {
+        "protocol_id": 1246
       },
-      "minecraft:pink_petals": {
-        "protocol_id": 258
+      "minecraft:husk_spawn_egg": {
+        "protocol_id": 995
       },
-      "minecraft:pink_shulker_box": {
-        "protocol_id": 559
+      "minecraft:ice": {
+        "protocol_id": 284
       },
-      "minecraft:pink_stained_glass": {
-        "protocol_id": 507
+      "minecraft:infested_chiseled_stone_bricks": {
+        "protocol_id": 316
       },
-      "minecraft:pink_stained_glass_pane": {
-        "protocol_id": 523
+      "minecraft:infested_cobblestone": {
+        "protocol_id": 312
       },
-      "minecraft:pink_terracotta": {
-        "protocol_id": 463
+      "minecraft:infested_cracked_stone_bricks": {
+        "protocol_id": 315
       },
-      "minecraft:pink_tulip": {
-        "protocol_id": 239
+      "minecraft:infested_deepslate": {
+        "protocol_id": 317
       },
-      "minecraft:pink_wool": {
-        "protocol_id": 219
+      "minecraft:infested_mossy_stone_bricks": {
+        "protocol_id": 314
       },
-      "minecraft:piston": {
+      "minecraft:infested_stone": {
+        "protocol_id": 311
+      },
+      "minecraft:infested_stone_bricks": {
+        "protocol_id": 313
+      },
+      "minecraft:ink_sac": {
+        "protocol_id": 901
+      },
+      "minecraft:iron_axe": {
+        "protocol_id": 795
+      },
+      "minecraft:iron_bars": {
+        "protocol_id": 333
+      },
+      "minecraft:iron_block": {
+        "protocol_id": 74
+      },
+      "minecraft:iron_boots": {
+        "protocol_id": 827
+      },
+      "minecraft:iron_chestplate": {
+        "protocol_id": 825
+      },
+      "minecraft:iron_door": {
+        "protocol_id": 688
+      },
+      "minecraft:iron_golem_spawn_egg": {
+        "protocol_id": 996
+      },
+      "minecraft:iron_helmet": {
+        "protocol_id": 824
+      },
+      "minecraft:iron_hoe": {
+        "protocol_id": 796
+      },
+      "minecraft:iron_horse_armor": {
+        "protocol_id": 1078
+      },
+      "minecraft:iron_ingot": {
+        "protocol_id": 770
+      },
+      "minecraft:iron_leggings": {
+        "protocol_id": 826
+      },
+      "minecraft:iron_nugget": {
+        "protocol_id": 1119
+      },
+      "minecraft:iron_ore": {
+        "protocol_id": 51
+      },
+      "minecraft:iron_pickaxe": {
+        "protocol_id": 794
+      },
+      "minecraft:iron_shovel": {
+        "protocol_id": 793
+      },
+      "minecraft:iron_sword": {
+        "protocol_id": 792
+      },
+      "minecraft:iron_trapdoor": {
+        "protocol_id": 700
+      },
+      "minecraft:item_frame": {
+        "protocol_id": 1048
+      },
+      "minecraft:jack_o_lantern": {
+        "protocol_id": 302
+      },
+      "minecraft:jigsaw": {
+        "protocol_id": 755
+      },
+      "minecraft:jukebox": {
+        "protocol_id": 288
+      },
+      "minecraft:jungle_boat": {
+        "protocol_id": 742
+      },
+      "minecraft:jungle_button": {
+        "protocol_id": 665
+      },
+      "minecraft:jungle_chest_boat": {
+        "protocol_id": 743
+      },
+      "minecraft:jungle_door": {
         "protocol_id": 692
       },
-      "minecraft:pitcher_plant": {
-        "protocol_id": 245
+      "minecraft:jungle_fence": {
+        "protocol_id": 292
       },
-      "minecraft:pitcher_pod": {
-        "protocol_id": 1216
+      "minecraft:jungle_fence_gate": {
+        "protocol_id": 715
       },
-      "minecraft:player_head": {
-        "protocol_id": 1167
+      "minecraft:jungle_hanging_sign": {
+        "protocol_id": 860
       },
-      "minecraft:plenty_pottery_sherd": {
-        "protocol_id": 1368
+      "minecraft:jungle_leaves": {
+        "protocol_id": 157
       },
-      "minecraft:podzol": {
+      "minecraft:jungle_log": {
+        "protocol_id": 113
+      },
+      "minecraft:jungle_planks": {
+        "protocol_id": 26
+      },
+      "minecraft:jungle_pressure_plate": {
+        "protocol_id": 680
+      },
+      "minecraft:jungle_sapling": {
+        "protocol_id": 38
+      },
+      "minecraft:jungle_sign": {
+        "protocol_id": 849
+      },
+      "minecraft:jungle_slab": {
+        "protocol_id": 233
+      },
+      "minecraft:jungle_stairs": {
+        "protocol_id": 364
+      },
+      "minecraft:jungle_trapdoor": {
+        "protocol_id": 704
+      },
+      "minecraft:jungle_wood": {
+        "protocol_id": 147
+      },
+      "minecraft:kelp": {
+        "protocol_id": 222
+      },
+      "minecraft:knowledge_book": {
+        "protocol_id": 1120
+      },
+      "minecraft:ladder": {
+        "protocol_id": 281
+      },
+      "minecraft:lantern": {
+        "protocol_id": 1163
+      },
+      "minecraft:lapis_block": {
+        "protocol_id": 168
+      },
+      "minecraft:lapis_lazuli": {
+        "protocol_id": 766
+      },
+      "minecraft:lapis_ore": {
+        "protocol_id": 61
+      },
+      "minecraft:large_amethyst_bud": {
+        "protocol_id": 1209
+      },
+      "minecraft:large_fern": {
+        "protocol_id": 448
+      },
+      "minecraft:lava_bucket": {
+        "protocol_id": 870
+      },
+      "minecraft:lead": {
+        "protocol_id": 1082
+      },
+      "minecraft:leather": {
+        "protocol_id": 873
+      },
+      "minecraft:leather_boots": {
+        "protocol_id": 819
+      },
+      "minecraft:leather_chestplate": {
+        "protocol_id": 817
+      },
+      "minecraft:leather_helmet": {
+        "protocol_id": 816
+      },
+      "minecraft:leather_horse_armor": {
+        "protocol_id": 1081
+      },
+      "minecraft:leather_leggings": {
+        "protocol_id": 818
+      },
+      "minecraft:lectern": {
+        "protocol_id": 648
+      },
+      "minecraft:lever": {
+        "protocol_id": 650
+      },
+      "minecraft:light": {
+        "protocol_id": 422
+      },
+      "minecraft:light_blue_banner": {
+        "protocol_id": 1090
+      },
+      "minecraft:light_blue_bed": {
+        "protocol_id": 927
+      },
+      "minecraft:light_blue_candle": {
+        "protocol_id": 1194
+      },
+      "minecraft:light_blue_carpet": {
+        "protocol_id": 427
+      },
+      "minecraft:light_blue_concrete": {
+        "protocol_id": 536
+      },
+      "minecraft:light_blue_concrete_powder": {
+        "protocol_id": 552
+      },
+      "minecraft:light_blue_dye": {
+        "protocol_id": 907
+      },
+      "minecraft:light_blue_glazed_terracotta": {
+        "protocol_id": 520
+      },
+      "minecraft:light_blue_shulker_box": {
+        "protocol_id": 504
+      },
+      "minecraft:light_blue_stained_glass": {
+        "protocol_id": 452
+      },
+      "minecraft:light_blue_stained_glass_pane": {
+        "protocol_id": 468
+      },
+      "minecraft:light_blue_terracotta": {
+        "protocol_id": 408
+      },
+      "minecraft:light_blue_wool": {
+        "protocol_id": 183
+      },
+      "minecraft:light_gray_banner": {
+        "protocol_id": 1095
+      },
+      "minecraft:light_gray_bed": {
+        "protocol_id": 932
+      },
+      "minecraft:light_gray_candle": {
+        "protocol_id": 1199
+      },
+      "minecraft:light_gray_carpet": {
+        "protocol_id": 432
+      },
+      "minecraft:light_gray_concrete": {
+        "protocol_id": 541
+      },
+      "minecraft:light_gray_concrete_powder": {
+        "protocol_id": 557
+      },
+      "minecraft:light_gray_dye": {
+        "protocol_id": 912
+      },
+      "minecraft:light_gray_glazed_terracotta": {
+        "protocol_id": 525
+      },
+      "minecraft:light_gray_shulker_box": {
+        "protocol_id": 509
+      },
+      "minecraft:light_gray_stained_glass": {
+        "protocol_id": 457
+      },
+      "minecraft:light_gray_stained_glass_pane": {
+        "protocol_id": 473
+      },
+      "minecraft:light_gray_terracotta": {
+        "protocol_id": 413
+      },
+      "minecraft:light_gray_wool": {
+        "protocol_id": 188
+      },
+      "minecraft:light_weighted_pressure_plate": {
+        "protocol_id": 675
+      },
+      "minecraft:lightning_rod": {
+        "protocol_id": 651
+      },
+      "minecraft:lilac": {
+        "protocol_id": 444
+      },
+      "minecraft:lily_of_the_valley": {
+        "protocol_id": 207
+      },
+      "minecraft:lily_pad": {
+        "protocol_id": 343
+      },
+      "minecraft:lime_banner": {
+        "protocol_id": 1092
+      },
+      "minecraft:lime_bed": {
+        "protocol_id": 929
+      },
+      "minecraft:lime_candle": {
+        "protocol_id": 1196
+      },
+      "minecraft:lime_carpet": {
+        "protocol_id": 429
+      },
+      "minecraft:lime_concrete": {
+        "protocol_id": 538
+      },
+      "minecraft:lime_concrete_powder": {
+        "protocol_id": 554
+      },
+      "minecraft:lime_dye": {
+        "protocol_id": 909
+      },
+      "minecraft:lime_glazed_terracotta": {
+        "protocol_id": 522
+      },
+      "minecraft:lime_shulker_box": {
+        "protocol_id": 506
+      },
+      "minecraft:lime_stained_glass": {
+        "protocol_id": 454
+      },
+      "minecraft:lime_stained_glass_pane": {
+        "protocol_id": 470
+      },
+      "minecraft:lime_terracotta": {
+        "protocol_id": 410
+      },
+      "minecraft:lime_wool": {
+        "protocol_id": 185
+      },
+      "minecraft:lingering_potion": {
+        "protocol_id": 1115
+      },
+      "minecraft:llama_spawn_egg": {
+        "protocol_id": 997
+      },
+      "minecraft:lodestone": {
+        "protocol_id": 1175
+      },
+      "minecraft:loom": {
+        "protocol_id": 1145
+      },
+      "minecraft:magenta_banner": {
+        "protocol_id": 1089
+      },
+      "minecraft:magenta_bed": {
+        "protocol_id": 926
+      },
+      "minecraft:magenta_candle": {
+        "protocol_id": 1193
+      },
+      "minecraft:magenta_carpet": {
+        "protocol_id": 426
+      },
+      "minecraft:magenta_concrete": {
+        "protocol_id": 535
+      },
+      "minecraft:magenta_concrete_powder": {
+        "protocol_id": 551
+      },
+      "minecraft:magenta_dye": {
+        "protocol_id": 906
+      },
+      "minecraft:magenta_glazed_terracotta": {
+        "protocol_id": 519
+      },
+      "minecraft:magenta_shulker_box": {
+        "protocol_id": 503
+      },
+      "minecraft:magenta_stained_glass": {
+        "protocol_id": 451
+      },
+      "minecraft:magenta_stained_glass_pane": {
+        "protocol_id": 467
+      },
+      "minecraft:magenta_terracotta": {
+        "protocol_id": 407
+      },
+      "minecraft:magenta_wool": {
+        "protocol_id": 182
+      },
+      "minecraft:magma_block": {
+        "protocol_id": 494
+      },
+      "minecraft:magma_cream": {
+        "protocol_id": 962
+      },
+      "minecraft:magma_cube_spawn_egg": {
+        "protocol_id": 998
+      },
+      "minecraft:mangrove_boat": {
+        "protocol_id": 750
+      },
+      "minecraft:mangrove_button": {
+        "protocol_id": 669
+      },
+      "minecraft:mangrove_chest_boat": {
+        "protocol_id": 751
+      },
+      "minecraft:mangrove_door": {
+        "protocol_id": 696
+      },
+      "minecraft:mangrove_fence": {
+        "protocol_id": 296
+      },
+      "minecraft:mangrove_fence_gate": {
+        "protocol_id": 719
+      },
+      "minecraft:mangrove_hanging_sign": {
+        "protocol_id": 864
+      },
+      "minecraft:mangrove_leaves": {
+        "protocol_id": 161
+      },
+      "minecraft:mangrove_log": {
+        "protocol_id": 117
+      },
+      "minecraft:mangrove_planks": {
         "protocol_id": 30
       },
+      "minecraft:mangrove_pressure_plate": {
+        "protocol_id": 684
+      },
+      "minecraft:mangrove_propagule": {
+        "protocol_id": 42
+      },
+      "minecraft:mangrove_roots": {
+        "protocol_id": 118
+      },
+      "minecraft:mangrove_sign": {
+        "protocol_id": 853
+      },
+      "minecraft:mangrove_slab": {
+        "protocol_id": 237
+      },
+      "minecraft:mangrove_stairs": {
+        "protocol_id": 368
+      },
+      "minecraft:mangrove_trapdoor": {
+        "protocol_id": 708
+      },
+      "minecraft:mangrove_wood": {
+        "protocol_id": 151
+      },
+      "minecraft:map": {
+        "protocol_id": 1055
+      },
+      "minecraft:medium_amethyst_bud": {
+        "protocol_id": 1208
+      },
+      "minecraft:melon": {
+        "protocol_id": 336
+      },
+      "minecraft:melon_seeds": {
+        "protocol_id": 946
+      },
+      "minecraft:melon_slice": {
+        "protocol_id": 943
+      },
+      "minecraft:milk_bucket": {
+        "protocol_id": 874
+      },
+      "minecraft:minecart": {
+        "protocol_id": 728
+      },
+      "minecraft:miner_pottery_sherd": {
+        "protocol_id": 1247
+      },
+      "minecraft:mojang_banner_pattern": {
+        "protocol_id": 1149
+      },
+      "minecraft:mooshroom_spawn_egg": {
+        "protocol_id": 999
+      },
+      "minecraft:moss_block": {
+        "protocol_id": 225
+      },
+      "minecraft:moss_carpet": {
+        "protocol_id": 223
+      },
+      "minecraft:mossy_cobblestone": {
+        "protocol_id": 267
+      },
+      "minecraft:mossy_cobblestone_slab": {
+        "protocol_id": 621
+      },
+      "minecraft:mossy_cobblestone_stairs": {
+        "protocol_id": 603
+      },
+      "minecraft:mossy_cobblestone_wall": {
+        "protocol_id": 376
+      },
+      "minecraft:mossy_stone_brick_slab": {
+        "protocol_id": 619
+      },
+      "minecraft:mossy_stone_brick_stairs": {
+        "protocol_id": 601
+      },
+      "minecraft:mossy_stone_brick_wall": {
+        "protocol_id": 380
+      },
+      "minecraft:mossy_stone_bricks": {
+        "protocol_id": 319
+      },
+      "minecraft:mourner_pottery_sherd": {
+        "protocol_id": 1248
+      },
+      "minecraft:mud": {
+        "protocol_id": 19
+      },
+      "minecraft:mud_brick_slab": {
+        "protocol_id": 250
+      },
+      "minecraft:mud_brick_stairs": {
+        "protocol_id": 341
+      },
+      "minecraft:mud_brick_wall": {
+        "protocol_id": 383
+      },
+      "minecraft:mud_bricks": {
+        "protocol_id": 323
+      },
+      "minecraft:muddy_mangrove_roots": {
+        "protocol_id": 119
+      },
+      "minecraft:mule_spawn_egg": {
+        "protocol_id": 1000
+      },
+      "minecraft:mushroom_stem": {
+        "protocol_id": 332
+      },
+      "minecraft:mushroom_stew": {
+        "protocol_id": 809
+      },
+      "minecraft:music_disc_11": {
+        "protocol_id": 1132
+      },
+      "minecraft:music_disc_13": {
+        "protocol_id": 1122
+      },
+      "minecraft:music_disc_5": {
+        "protocol_id": 1136
+      },
+      "minecraft:music_disc_blocks": {
+        "protocol_id": 1124
+      },
+      "minecraft:music_disc_cat": {
+        "protocol_id": 1123
+      },
+      "minecraft:music_disc_chirp": {
+        "protocol_id": 1125
+      },
+      "minecraft:music_disc_far": {
+        "protocol_id": 1126
+      },
+      "minecraft:music_disc_mall": {
+        "protocol_id": 1127
+      },
+      "minecraft:music_disc_mellohi": {
+        "protocol_id": 1128
+      },
+      "minecraft:music_disc_otherside": {
+        "protocol_id": 1134
+      },
+      "minecraft:music_disc_pigstep": {
+        "protocol_id": 1137
+      },
+      "minecraft:music_disc_relic": {
+        "protocol_id": 1135
+      },
+      "minecraft:music_disc_stal": {
+        "protocol_id": 1129
+      },
+      "minecraft:music_disc_strad": {
+        "protocol_id": 1130
+      },
+      "minecraft:music_disc_wait": {
+        "protocol_id": 1133
+      },
+      "minecraft:music_disc_ward": {
+        "protocol_id": 1131
+      },
+      "minecraft:mutton": {
+        "protocol_id": 1085
+      },
+      "minecraft:mycelium": {
+        "protocol_id": 342
+      },
+      "minecraft:name_tag": {
+        "protocol_id": 1083
+      },
+      "minecraft:nautilus_shell": {
+        "protocol_id": 1141
+      },
+      "minecraft:nether_brick": {
+        "protocol_id": 1069
+      },
+      "minecraft:nether_brick_fence": {
+        "protocol_id": 347
+      },
+      "minecraft:nether_brick_slab": {
+        "protocol_id": 251
+      },
+      "minecraft:nether_brick_stairs": {
+        "protocol_id": 348
+      },
+      "minecraft:nether_brick_wall": {
+        "protocol_id": 384
+      },
+      "minecraft:nether_bricks": {
+        "protocol_id": 344
+      },
+      "minecraft:nether_gold_ore": {
+        "protocol_id": 65
+      },
+      "minecraft:nether_quartz_ore": {
+        "protocol_id": 66
+      },
+      "minecraft:nether_sprouts": {
+        "protocol_id": 218
+      },
+      "minecraft:nether_star": {
+        "protocol_id": 1064
+      },
+      "minecraft:nether_wart": {
+        "protocol_id": 956
+      },
+      "minecraft:nether_wart_block": {
+        "protocol_id": 495
+      },
+      "minecraft:netherite_axe": {
+        "protocol_id": 805
+      },
+      "minecraft:netherite_block": {
+        "protocol_id": 78
+      },
+      "minecraft:netherite_boots": {
+        "protocol_id": 839
+      },
+      "minecraft:netherite_chestplate": {
+        "protocol_id": 837
+      },
+      "minecraft:netherite_helmet": {
+        "protocol_id": 836
+      },
+      "minecraft:netherite_hoe": {
+        "protocol_id": 806
+      },
+      "minecraft:netherite_ingot": {
+        "protocol_id": 775
+      },
+      "minecraft:netherite_leggings": {
+        "protocol_id": 838
+      },
+      "minecraft:netherite_pickaxe": {
+        "protocol_id": 804
+      },
+      "minecraft:netherite_scrap": {
+        "protocol_id": 776
+      },
+      "minecraft:netherite_shovel": {
+        "protocol_id": 803
+      },
+      "minecraft:netherite_sword": {
+        "protocol_id": 802
+      },
+      "minecraft:netherite_upgrade_smithing_template": {
+        "protocol_id": 1218
+      },
+      "minecraft:netherrack": {
+        "protocol_id": 303
+      },
+      "minecraft:note_block": {
+        "protocol_id": 659
+      },
+      "minecraft:oak_boat": {
+        "protocol_id": 736
+      },
+      "minecraft:oak_button": {
+        "protocol_id": 662
+      },
+      "minecraft:oak_chest_boat": {
+        "protocol_id": 737
+      },
+      "minecraft:oak_door": {
+        "protocol_id": 689
+      },
+      "minecraft:oak_fence": {
+        "protocol_id": 289
+      },
+      "minecraft:oak_fence_gate": {
+        "protocol_id": 712
+      },
+      "minecraft:oak_hanging_sign": {
+        "protocol_id": 857
+      },
+      "minecraft:oak_leaves": {
+        "protocol_id": 154
+      },
+      "minecraft:oak_log": {
+        "protocol_id": 110
+      },
+      "minecraft:oak_planks": {
+        "protocol_id": 23
+      },
+      "minecraft:oak_pressure_plate": {
+        "protocol_id": 677
+      },
+      "minecraft:oak_sapling": {
+        "protocol_id": 35
+      },
+      "minecraft:oak_sign": {
+        "protocol_id": 846
+      },
+      "minecraft:oak_slab": {
+        "protocol_id": 230
+      },
+      "minecraft:oak_stairs": {
+        "protocol_id": 361
+      },
+      "minecraft:oak_trapdoor": {
+        "protocol_id": 701
+      },
+      "minecraft:oak_wood": {
+        "protocol_id": 144
+      },
+      "minecraft:observer": {
+        "protocol_id": 644
+      },
+      "minecraft:obsidian": {
+        "protocol_id": 268
+      },
+      "minecraft:ocelot_spawn_egg": {
+        "protocol_id": 1001
+      },
+      "minecraft:ochre_froglight": {
+        "protocol_id": 1212
+      },
+      "minecraft:orange_banner": {
+        "protocol_id": 1088
+      },
+      "minecraft:orange_bed": {
+        "protocol_id": 925
+      },
+      "minecraft:orange_candle": {
+        "protocol_id": 1192
+      },
+      "minecraft:orange_carpet": {
+        "protocol_id": 425
+      },
+      "minecraft:orange_concrete": {
+        "protocol_id": 534
+      },
+      "minecraft:orange_concrete_powder": {
+        "protocol_id": 550
+      },
+      "minecraft:orange_dye": {
+        "protocol_id": 905
+      },
+      "minecraft:orange_glazed_terracotta": {
+        "protocol_id": 518
+      },
+      "minecraft:orange_shulker_box": {
+        "protocol_id": 502
+      },
+      "minecraft:orange_stained_glass": {
+        "protocol_id": 450
+      },
+      "minecraft:orange_stained_glass_pane": {
+        "protocol_id": 466
+      },
+      "minecraft:orange_terracotta": {
+        "protocol_id": 406
+      },
+      "minecraft:orange_tulip": {
+        "protocol_id": 202
+      },
+      "minecraft:orange_wool": {
+        "protocol_id": 181
+      },
+      "minecraft:oxeye_daisy": {
+        "protocol_id": 205
+      },
+      "minecraft:oxidized_copper": {
+        "protocol_id": 81
+      },
+      "minecraft:oxidized_cut_copper": {
+        "protocol_id": 85
+      },
+      "minecraft:oxidized_cut_copper_slab": {
+        "protocol_id": 93
+      },
+      "minecraft:oxidized_cut_copper_stairs": {
+        "protocol_id": 89
+      },
+      "minecraft:packed_ice": {
+        "protocol_id": 441
+      },
+      "minecraft:packed_mud": {
+        "protocol_id": 322
+      },
+      "minecraft:painting": {
+        "protocol_id": 843
+      },
+      "minecraft:panda_spawn_egg": {
+        "protocol_id": 1002
+      },
+      "minecraft:paper": {
+        "protocol_id": 884
+      },
+      "minecraft:parrot_spawn_egg": {
+        "protocol_id": 1003
+      },
+      "minecraft:pearlescent_froglight": {
+        "protocol_id": 1214
+      },
+      "minecraft:peony": {
+        "protocol_id": 446
+      },
+      "minecraft:petrified_oak_slab": {
+        "protocol_id": 246
+      },
+      "minecraft:phantom_membrane": {
+        "protocol_id": 1140
+      },
+      "minecraft:phantom_spawn_egg": {
+        "protocol_id": 1004
+      },
+      "minecraft:pig_spawn_egg": {
+        "protocol_id": 1005
+      },
+      "minecraft:piglin_banner_pattern": {
+        "protocol_id": 1151
+      },
+      "minecraft:piglin_brute_spawn_egg": {
+        "protocol_id": 1007
+      },
+      "minecraft:piglin_head": {
+        "protocol_id": 1063
+      },
+      "minecraft:piglin_spawn_egg": {
+        "protocol_id": 1006
+      },
+      "minecraft:pillager_spawn_egg": {
+        "protocol_id": 1008
+      },
+      "minecraft:pink_banner": {
+        "protocol_id": 1093
+      },
+      "minecraft:pink_bed": {
+        "protocol_id": 930
+      },
+      "minecraft:pink_candle": {
+        "protocol_id": 1197
+      },
+      "minecraft:pink_carpet": {
+        "protocol_id": 430
+      },
+      "minecraft:pink_concrete": {
+        "protocol_id": 539
+      },
+      "minecraft:pink_concrete_powder": {
+        "protocol_id": 555
+      },
+      "minecraft:pink_dye": {
+        "protocol_id": 910
+      },
+      "minecraft:pink_glazed_terracotta": {
+        "protocol_id": 523
+      },
+      "minecraft:pink_petals": {
+        "protocol_id": 224
+      },
+      "minecraft:pink_shulker_box": {
+        "protocol_id": 507
+      },
+      "minecraft:pink_stained_glass": {
+        "protocol_id": 455
+      },
+      "minecraft:pink_stained_glass_pane": {
+        "protocol_id": 471
+      },
+      "minecraft:pink_terracotta": {
+        "protocol_id": 411
+      },
+      "minecraft:pink_tulip": {
+        "protocol_id": 204
+      },
+      "minecraft:pink_wool": {
+        "protocol_id": 186
+      },
+      "minecraft:piston": {
+        "protocol_id": 640
+      },
+      "minecraft:pitcher_plant": {
+        "protocol_id": 210
+      },
+      "minecraft:pitcher_pod": {
+        "protocol_id": 1107
+      },
+      "minecraft:player_head": {
+        "protocol_id": 1059
+      },
+      "minecraft:plenty_pottery_sherd": {
+        "protocol_id": 1249
+      },
+      "minecraft:podzol": {
+        "protocol_id": 17
+      },
       "minecraft:pointed_dripstone": {
-        "protocol_id": 1326
+        "protocol_id": 1211
       },
       "minecraft:poisonous_potato": {
-        "protocol_id": 1162
+        "protocol_id": 1054
       },
       "minecraft:polar_bear_spawn_egg": {
-        "protocol_id": 1113
+        "protocol_id": 1009
       },
       "minecraft:polished_andesite": {
         "protocol_id": 7
       },
       "minecraft:polished_andesite_slab": {
-        "protocol_id": 680
+        "protocol_id": 628
       },
       "minecraft:polished_andesite_stairs": {
-        "protocol_id": 663
+        "protocol_id": 611
       },
       "minecraft:polished_basalt": {
-        "protocol_id": 351
+        "protocol_id": 307
       },
       "minecraft:polished_blackstone": {
-        "protocol_id": 1296
+        "protocol_id": 1181
       },
       "minecraft:polished_blackstone_brick_slab": {
-        "protocol_id": 1301
+        "protocol_id": 1186
       },
       "minecraft:polished_blackstone_brick_stairs": {
-        "protocol_id": 1302
+        "protocol_id": 1187
       },
       "minecraft:polished_blackstone_brick_wall": {
-        "protocol_id": 444
+        "protocol_id": 392
       },
       "minecraft:polished_blackstone_bricks": {
-        "protocol_id": 1300
+        "protocol_id": 1185
       },
       "minecraft:polished_blackstone_button": {
-        "protocol_id": 713
+        "protocol_id": 661
       },
       "minecraft:polished_blackstone_pressure_plate": {
-        "protocol_id": 727
+        "protocol_id": 674
       },
       "minecraft:polished_blackstone_slab": {
-        "protocol_id": 1297
+        "protocol_id": 1182
       },
       "minecraft:polished_blackstone_stairs": {
-        "protocol_id": 1298
+        "protocol_id": 1183
       },
       "minecraft:polished_blackstone_wall": {
-        "protocol_id": 443
+        "protocol_id": 391
       },
       "minecraft:polished_deepslate": {
         "protocol_id": 10
       },
       "minecraft:polished_deepslate_slab": {
-        "protocol_id": 683
+        "protocol_id": 631
       },
       "minecraft:polished_deepslate_stairs": {
-        "protocol_id": 666
+        "protocol_id": 614
       },
       "minecraft:polished_deepslate_wall": {
-        "protocol_id": 446
+        "protocol_id": 394
       },
       "minecraft:polished_diorite": {
         "protocol_id": 5
       },
       "minecraft:polished_diorite_slab": {
-        "protocol_id": 672
+        "protocol_id": 620
       },
       "minecraft:polished_diorite_stairs": {
-        "protocol_id": 654
+        "protocol_id": 602
       },
       "minecraft:polished_granite": {
         "protocol_id": 3
       },
       "minecraft:polished_granite_slab": {
-        "protocol_id": 669
+        "protocol_id": 617
       },
       "minecraft:polished_granite_stairs": {
-        "protocol_id": 651
-      },
-      "minecraft:polished_tuff": {
-        "protocol_id": 17
-      },
-      "minecraft:polished_tuff_slab": {
-        "protocol_id": 18
-      },
-      "minecraft:polished_tuff_stairs": {
-        "protocol_id": 19
-      },
-      "minecraft:polished_tuff_wall": {
-        "protocol_id": 20
-      },
-      "minecraft:popped_chorus_fruit": {
-        "protocol_id": 1214
-      },
-      "minecraft:poppy": {
-        "protocol_id": 232
-      },
-      "minecraft:porkchop": {
-        "protocol_id": 921
-      },
-      "minecraft:potato": {
-        "protocol_id": 1160
-      },
-      "minecraft:potion": {
-        "protocol_id": 1059
-      },
-      "minecraft:powder_snow_bucket": {
-        "protocol_id": 953
-      },
-      "minecraft:powered_rail": {
-        "protocol_id": 796
-      },
-      "minecraft:prismarine": {
-        "protocol_id": 533
-      },
-      "minecraft:prismarine_brick_slab": {
-        "protocol_id": 298
-      },
-      "minecraft:prismarine_brick_stairs": {
-        "protocol_id": 537
-      },
-      "minecraft:prismarine_bricks": {
-        "protocol_id": 534
-      },
-      "minecraft:prismarine_crystals": {
-        "protocol_id": 1180
-      },
-      "minecraft:prismarine_shard": {
-        "protocol_id": 1179
-      },
-      "minecraft:prismarine_slab": {
-        "protocol_id": 297
-      },
-      "minecraft:prismarine_stairs": {
-        "protocol_id": 536
-      },
-      "minecraft:prismarine_wall": {
-        "protocol_id": 430
-      },
-      "minecraft:prize_pottery_sherd": {
-        "protocol_id": 1369
-      },
-      "minecraft:pufferfish": {
-        "protocol_id": 998
-      },
-      "minecraft:pufferfish_bucket": {
-        "protocol_id": 957
-      },
-      "minecraft:pufferfish_spawn_egg": {
-        "protocol_id": 1114
-      },
-      "minecraft:pumpkin": {
-        "protocol_id": 344
-      },
-      "minecraft:pumpkin_pie": {
-        "protocol_id": 1173
-      },
-      "minecraft:pumpkin_seeds": {
-        "protocol_id": 1046
-      },
-      "minecraft:purple_banner": {
-        "protocol_id": 1206
-      },
-      "minecraft:purple_bed": {
-        "protocol_id": 1034
-      },
-      "minecraft:purple_bundle": {
-        "protocol_id": 985
-      },
-      "minecraft:purple_candle": {
-        "protocol_id": 1316
-      },
-      "minecraft:purple_carpet": {
-        "protocol_id": 486
-      },
-      "minecraft:purple_concrete": {
-        "protocol_id": 595
-      },
-      "minecraft:purple_concrete_powder": {
-        "protocol_id": 611
-      },
-      "minecraft:purple_dye": {
-        "protocol_id": 1014
-      },
-      "minecraft:purple_glazed_terracotta": {
-        "protocol_id": 579
-      },
-      "minecraft:purple_shulker_box": {
-        "protocol_id": 563
-      },
-      "minecraft:purple_stained_glass": {
-        "protocol_id": 511
-      },
-      "minecraft:purple_stained_glass_pane": {
-        "protocol_id": 527
-      },
-      "minecraft:purple_terracotta": {
-        "protocol_id": 467
-      },
-      "minecraft:purple_wool": {
-        "protocol_id": 223
-      },
-      "minecraft:purpur_block": {
-        "protocol_id": 314
-      },
-      "minecraft:purpur_pillar": {
-        "protocol_id": 315
-      },
-      "minecraft:purpur_slab": {
-        "protocol_id": 296
-      },
-      "minecraft:purpur_stairs": {
-        "protocol_id": 316
-      },
-      "minecraft:quartz": {
-        "protocol_id": 848
-      },
-      "minecraft:quartz_block": {
-        "protocol_id": 453
-      },
-      "minecraft:quartz_bricks": {
-        "protocol_id": 454
-      },
-      "minecraft:quartz_pillar": {
-        "protocol_id": 455
-      },
-      "minecraft:quartz_slab": {
-        "protocol_id": 293
-      },
-      "minecraft:quartz_stairs": {
-        "protocol_id": 456
-      },
-      "minecraft:rabbit": {
-        "protocol_id": 1181
-      },
-      "minecraft:rabbit_foot": {
-        "protocol_id": 1184
-      },
-      "minecraft:rabbit_hide": {
-        "protocol_id": 1185
-      },
-      "minecraft:rabbit_spawn_egg": {
-        "protocol_id": 1115
-      },
-      "minecraft:rabbit_stew": {
-        "protocol_id": 1183
-      },
-      "minecraft:rail": {
-        "protocol_id": 798
-      },
-      "minecraft:raiser_armor_trim_smithing_template": {
-        "protocol_id": 1348
-      },
-      "minecraft:ravager_spawn_egg": {
-        "protocol_id": 1116
-      },
-      "minecraft:raw_copper": {
-        "protocol_id": 852
-      },
-      "minecraft:raw_copper_block": {
-        "protocol_id": 85
-      },
-      "minecraft:raw_gold": {
-        "protocol_id": 854
-      },
-      "minecraft:raw_gold_block": {
-        "protocol_id": 86
-      },
-      "minecraft:raw_iron": {
-        "protocol_id": 850
-      },
-      "minecraft:raw_iron_block": {
-        "protocol_id": 84
-      },
-      "minecraft:recovery_compass": {
-        "protocol_id": 973
-      },
-      "minecraft:red_banner": {
-        "protocol_id": 1210
-      },
-      "minecraft:red_bed": {
-        "protocol_id": 1038
-      },
-      "minecraft:red_bundle": {
-        "protocol_id": 989
-      },
-      "minecraft:red_candle": {
-        "protocol_id": 1320
-      },
-      "minecraft:red_carpet": {
-        "protocol_id": 490
-      },
-      "minecraft:red_concrete": {
         "protocol_id": 599
       },
-      "minecraft:red_concrete_powder": {
-        "protocol_id": 615
+      "minecraft:popped_chorus_fruit": {
+        "protocol_id": 1105
       },
-      "minecraft:red_dye": {
-        "protocol_id": 1018
+      "minecraft:poppy": {
+        "protocol_id": 197
       },
-      "minecraft:red_glazed_terracotta": {
-        "protocol_id": 583
+      "minecraft:porkchop": {
+        "protocol_id": 841
       },
-      "minecraft:red_mushroom": {
-        "protocol_id": 248
-      },
-      "minecraft:red_mushroom_block": {
-        "protocol_id": 375
-      },
-      "minecraft:red_nether_brick_slab": {
-        "protocol_id": 679
-      },
-      "minecraft:red_nether_brick_stairs": {
-        "protocol_id": 662
-      },
-      "minecraft:red_nether_brick_wall": {
-        "protocol_id": 438
-      },
-      "minecraft:red_nether_bricks": {
-        "protocol_id": 549
-      },
-      "minecraft:red_sand": {
-        "protocol_id": 62
-      },
-      "minecraft:red_sandstone": {
-        "protocol_id": 540
-      },
-      "minecraft:red_sandstone_slab": {
-        "protocol_id": 294
-      },
-      "minecraft:red_sandstone_stairs": {
-        "protocol_id": 543
-      },
-      "minecraft:red_sandstone_wall": {
-        "protocol_id": 431
-      },
-      "minecraft:red_shulker_box": {
-        "protocol_id": 567
-      },
-      "minecraft:red_stained_glass": {
-        "protocol_id": 515
-      },
-      "minecraft:red_stained_glass_pane": {
-        "protocol_id": 531
-      },
-      "minecraft:red_terracotta": {
-        "protocol_id": 471
-      },
-      "minecraft:red_tulip": {
-        "protocol_id": 236
-      },
-      "minecraft:red_wool": {
-        "protocol_id": 227
-      },
-      "minecraft:redstone": {
-        "protocol_id": 687
-      },
-      "minecraft:redstone_block": {
-        "protocol_id": 689
-      },
-      "minecraft:redstone_lamp": {
-        "protocol_id": 710
-      },
-      "minecraft:redstone_ore": {
-        "protocol_id": 72
-      },
-      "minecraft:redstone_torch": {
-        "protocol_id": 688
-      },
-      "minecraft:reinforced_deepslate": {
-        "protocol_id": 373
-      },
-      "minecraft:repeater": {
-        "protocol_id": 690
-      },
-      "minecraft:repeating_command_block": {
-        "protocol_id": 544
-      },
-      "minecraft:resin_block": {
-        "protocol_id": 384
-      },
-      "minecraft:resin_brick": {
-        "protocol_id": 1178
-      },
-      "minecraft:resin_brick_slab": {
-        "protocol_id": 387
-      },
-      "minecraft:resin_brick_stairs": {
-        "protocol_id": 386
-      },
-      "minecraft:resin_brick_wall": {
-        "protocol_id": 388
-      },
-      "minecraft:resin_bricks": {
-        "protocol_id": 385
-      },
-      "minecraft:resin_clump": {
-        "protocol_id": 383
-      },
-      "minecraft:respawn_anchor": {
-        "protocol_id": 1304
-      },
-      "minecraft:rib_armor_trim_smithing_template": {
-        "protocol_id": 1343
-      },
-      "minecraft:rooted_dirt": {
-        "protocol_id": 31
-      },
-      "minecraft:rose_bush": {
-        "protocol_id": 497
-      },
-      "minecraft:rotten_flesh": {
+      "minecraft:potato": {
         "protocol_id": 1052
       },
-      "minecraft:saddle": {
-        "protocol_id": 800
+      "minecraft:potion": {
+        "protocol_id": 957
       },
-      "minecraft:salmon": {
-        "protocol_id": 996
+      "minecraft:powder_snow_bucket": {
+        "protocol_id": 871
       },
-      "minecraft:salmon_bucket": {
-        "protocol_id": 958
+      "minecraft:powered_rail": {
+        "protocol_id": 723
       },
-      "minecraft:salmon_spawn_egg": {
-        "protocol_id": 1117
+      "minecraft:prismarine": {
+        "protocol_id": 481
       },
-      "minecraft:sand": {
-        "protocol_id": 59
+      "minecraft:prismarine_brick_slab": {
+        "protocol_id": 257
       },
-      "minecraft:sandstone": {
-        "protocol_id": 198
+      "minecraft:prismarine_brick_stairs": {
+        "protocol_id": 485
       },
-      "minecraft:sandstone_slab": {
-        "protocol_id": 285
+      "minecraft:prismarine_bricks": {
+        "protocol_id": 482
       },
-      "minecraft:sandstone_stairs": {
-        "protocol_id": 409
+      "minecraft:prismarine_crystals": {
+        "protocol_id": 1071
       },
-      "minecraft:sandstone_wall": {
-        "protocol_id": 439
+      "minecraft:prismarine_shard": {
+        "protocol_id": 1070
       },
-      "minecraft:scaffolding": {
-        "protocol_id": 686
+      "minecraft:prismarine_slab": {
+        "protocol_id": 256
       },
-      "minecraft:scrape_pottery_sherd": {
-        "protocol_id": 1370
+      "minecraft:prismarine_stairs": {
+        "protocol_id": 484
       },
-      "minecraft:sculk": {
-        "protocol_id": 400
+      "minecraft:prismarine_wall": {
+        "protocol_id": 378
       },
-      "minecraft:sculk_catalyst": {
-        "protocol_id": 402
+      "minecraft:prize_pottery_sherd": {
+        "protocol_id": 1250
       },
-      "minecraft:sculk_sensor": {
-        "protocol_id": 705
+      "minecraft:pufferfish": {
+        "protocol_id": 898
       },
-      "minecraft:sculk_shrieker": {
-        "protocol_id": 403
+      "minecraft:pufferfish_bucket": {
+        "protocol_id": 875
       },
-      "minecraft:sculk_vein": {
-        "protocol_id": 401
+      "minecraft:pufferfish_spawn_egg": {
+        "protocol_id": 1010
       },
-      "minecraft:sea_lantern": {
-        "protocol_id": 539
-      },
-      "minecraft:sea_pickle": {
-        "protocol_id": 212
-      },
-      "minecraft:seagrass": {
-        "protocol_id": 211
-      },
-      "minecraft:sentry_armor_trim_smithing_template": {
-        "protocol_id": 1334
-      },
-      "minecraft:shaper_armor_trim_smithing_template": {
-        "protocol_id": 1346
-      },
-      "minecraft:sheaf_pottery_sherd": {
-        "protocol_id": 1371
-      },
-      "minecraft:shears": {
-        "protocol_id": 1043
-      },
-      "minecraft:sheep_spawn_egg": {
-        "protocol_id": 1118
-      },
-      "minecraft:shelter_pottery_sherd": {
-        "protocol_id": 1372
-      },
-      "minecraft:shield": {
-        "protocol_id": 1225
-      },
-      "minecraft:short_dry_grass": {
-        "protocol_id": 209
-      },
-      "minecraft:short_grass": {
-        "protocol_id": 202
-      },
-      "minecraft:shroomlight": {
-        "protocol_id": 1284
-      },
-      "minecraft:shulker_box": {
-        "protocol_id": 552
-      },
-      "minecraft:shulker_shell": {
-        "protocol_id": 1227
-      },
-      "minecraft:shulker_spawn_egg": {
-        "protocol_id": 1119
-      },
-      "minecraft:silence_armor_trim_smithing_template": {
-        "protocol_id": 1347
-      },
-      "minecraft:silverfish_spawn_egg": {
-        "protocol_id": 1120
-      },
-      "minecraft:skeleton_horse_spawn_egg": {
-        "protocol_id": 1122
-      },
-      "minecraft:skeleton_skull": {
-        "protocol_id": 1165
-      },
-      "minecraft:skeleton_spawn_egg": {
-        "protocol_id": 1121
-      },
-      "minecraft:skull_banner_pattern": {
-        "protocol_id": 1259
-      },
-      "minecraft:skull_pottery_sherd": {
-        "protocol_id": 1373
-      },
-      "minecraft:slime_ball": {
-        "protocol_id": 968
-      },
-      "minecraft:slime_block": {
-        "protocol_id": 694
-      },
-      "minecraft:slime_spawn_egg": {
-        "protocol_id": 1123
-      },
-      "minecraft:small_amethyst_bud": {
-        "protocol_id": 1322
-      },
-      "minecraft:small_dripleaf": {
-        "protocol_id": 268
-      },
-      "minecraft:smithing_table": {
-        "protocol_id": 1275
-      },
-      "minecraft:smoker": {
-        "protocol_id": 1270
-      },
-      "minecraft:smooth_basalt": {
-        "protocol_id": 352
-      },
-      "minecraft:smooth_quartz": {
+      "minecraft:pumpkin": {
         "protocol_id": 300
       },
-      "minecraft:smooth_quartz_slab": {
-        "protocol_id": 676
+      "minecraft:pumpkin_pie": {
+        "protocol_id": 1065
       },
-      "minecraft:smooth_quartz_stairs": {
-        "protocol_id": 659
+      "minecraft:pumpkin_seeds": {
+        "protocol_id": 945
       },
-      "minecraft:smooth_red_sandstone": {
-        "protocol_id": 301
+      "minecraft:purple_banner": {
+        "protocol_id": 1097
       },
-      "minecraft:smooth_red_sandstone_slab": {
-        "protocol_id": 670
+      "minecraft:purple_bed": {
+        "protocol_id": 934
       },
-      "minecraft:smooth_red_sandstone_stairs": {
-        "protocol_id": 652
+      "minecraft:purple_candle": {
+        "protocol_id": 1201
       },
-      "minecraft:smooth_sandstone": {
-        "protocol_id": 302
+      "minecraft:purple_carpet": {
+        "protocol_id": 434
       },
-      "minecraft:smooth_sandstone_slab": {
-        "protocol_id": 675
+      "minecraft:purple_concrete": {
+        "protocol_id": 543
       },
-      "minecraft:smooth_sandstone_stairs": {
+      "minecraft:purple_concrete_powder": {
+        "protocol_id": 559
+      },
+      "minecraft:purple_dye": {
+        "protocol_id": 914
+      },
+      "minecraft:purple_glazed_terracotta": {
+        "protocol_id": 527
+      },
+      "minecraft:purple_shulker_box": {
+        "protocol_id": 511
+      },
+      "minecraft:purple_stained_glass": {
+        "protocol_id": 459
+      },
+      "minecraft:purple_stained_glass_pane": {
+        "protocol_id": 475
+      },
+      "minecraft:purple_terracotta": {
+        "protocol_id": 415
+      },
+      "minecraft:purple_wool": {
+        "protocol_id": 190
+      },
+      "minecraft:purpur_block": {
+        "protocol_id": 273
+      },
+      "minecraft:purpur_pillar": {
+        "protocol_id": 274
+      },
+      "minecraft:purpur_slab": {
+        "protocol_id": 255
+      },
+      "minecraft:purpur_stairs": {
+        "protocol_id": 275
+      },
+      "minecraft:quartz": {
+        "protocol_id": 767
+      },
+      "minecraft:quartz_block": {
+        "protocol_id": 401
+      },
+      "minecraft:quartz_bricks": {
+        "protocol_id": 402
+      },
+      "minecraft:quartz_pillar": {
+        "protocol_id": 403
+      },
+      "minecraft:quartz_slab": {
+        "protocol_id": 252
+      },
+      "minecraft:quartz_stairs": {
+        "protocol_id": 404
+      },
+      "minecraft:rabbit": {
+        "protocol_id": 1072
+      },
+      "minecraft:rabbit_foot": {
+        "protocol_id": 1075
+      },
+      "minecraft:rabbit_hide": {
+        "protocol_id": 1076
+      },
+      "minecraft:rabbit_spawn_egg": {
+        "protocol_id": 1011
+      },
+      "minecraft:rabbit_stew": {
+        "protocol_id": 1074
+      },
+      "minecraft:rail": {
+        "protocol_id": 725
+      },
+      "minecraft:raiser_armor_trim_smithing_template": {
+        "protocol_id": 1233
+      },
+      "minecraft:ravager_spawn_egg": {
+        "protocol_id": 1012
+      },
+      "minecraft:raw_copper": {
+        "protocol_id": 771
+      },
+      "minecraft:raw_copper_block": {
+        "protocol_id": 70
+      },
+      "minecraft:raw_gold": {
+        "protocol_id": 773
+      },
+      "minecraft:raw_gold_block": {
+        "protocol_id": 71
+      },
+      "minecraft:raw_iron": {
+        "protocol_id": 769
+      },
+      "minecraft:raw_iron_block": {
+        "protocol_id": 69
+      },
+      "minecraft:recovery_compass": {
+        "protocol_id": 889
+      },
+      "minecraft:red_banner": {
+        "protocol_id": 1101
+      },
+      "minecraft:red_bed": {
+        "protocol_id": 938
+      },
+      "minecraft:red_candle": {
+        "protocol_id": 1205
+      },
+      "minecraft:red_carpet": {
+        "protocol_id": 438
+      },
+      "minecraft:red_concrete": {
+        "protocol_id": 547
+      },
+      "minecraft:red_concrete_powder": {
+        "protocol_id": 563
+      },
+      "minecraft:red_dye": {
+        "protocol_id": 918
+      },
+      "minecraft:red_glazed_terracotta": {
+        "protocol_id": 531
+      },
+      "minecraft:red_mushroom": {
+        "protocol_id": 213
+      },
+      "minecraft:red_mushroom_block": {
+        "protocol_id": 331
+      },
+      "minecraft:red_nether_brick_slab": {
+        "protocol_id": 627
+      },
+      "minecraft:red_nether_brick_stairs": {
+        "protocol_id": 610
+      },
+      "minecraft:red_nether_brick_wall": {
+        "protocol_id": 386
+      },
+      "minecraft:red_nether_bricks": {
+        "protocol_id": 497
+      },
+      "minecraft:red_sand": {
+        "protocol_id": 47
+      },
+      "minecraft:red_sandstone": {
+        "protocol_id": 488
+      },
+      "minecraft:red_sandstone_slab": {
+        "protocol_id": 253
+      },
+      "minecraft:red_sandstone_stairs": {
+        "protocol_id": 491
+      },
+      "minecraft:red_sandstone_wall": {
+        "protocol_id": 379
+      },
+      "minecraft:red_shulker_box": {
+        "protocol_id": 515
+      },
+      "minecraft:red_stained_glass": {
+        "protocol_id": 463
+      },
+      "minecraft:red_stained_glass_pane": {
+        "protocol_id": 479
+      },
+      "minecraft:red_terracotta": {
+        "protocol_id": 419
+      },
+      "minecraft:red_tulip": {
+        "protocol_id": 201
+      },
+      "minecraft:red_wool": {
+        "protocol_id": 194
+      },
+      "minecraft:redstone": {
+        "protocol_id": 635
+      },
+      "minecraft:redstone_block": {
+        "protocol_id": 637
+      },
+      "minecraft:redstone_lamp": {
         "protocol_id": 658
       },
-      "minecraft:smooth_stone": {
-        "protocol_id": 303
+      "minecraft:redstone_ore": {
+        "protocol_id": 57
       },
-      "minecraft:smooth_stone_slab": {
-        "protocol_id": 284
+      "minecraft:redstone_torch": {
+        "protocol_id": 636
       },
-      "minecraft:sniffer_egg": {
-        "protocol_id": 618
+      "minecraft:reinforced_deepslate": {
+        "protocol_id": 329
       },
-      "minecraft:sniffer_spawn_egg": {
-        "protocol_id": 1124
+      "minecraft:repeater": {
+        "protocol_id": 638
       },
-      "minecraft:snort_pottery_sherd": {
-        "protocol_id": 1374
+      "minecraft:repeating_command_block": {
+        "protocol_id": 492
       },
-      "minecraft:snout_armor_trim_smithing_template": {
-        "protocol_id": 1342
+      "minecraft:respawn_anchor": {
+        "protocol_id": 1189
       },
-      "minecraft:snow": {
-        "protocol_id": 325
+      "minecraft:rib_armor_trim_smithing_template": {
+        "protocol_id": 1228
       },
-      "minecraft:snow_block": {
-        "protocol_id": 327
+      "minecraft:rooted_dirt": {
+        "protocol_id": 18
       },
-      "minecraft:snow_golem_spawn_egg": {
-        "protocol_id": 1125
+      "minecraft:rose_bush": {
+        "protocol_id": 445
       },
-      "minecraft:snowball": {
-        "protocol_id": 954
+      "minecraft:rotten_flesh": {
+        "protocol_id": 951
       },
-      "minecraft:soul_campfire": {
-        "protocol_id": 1283
+      "minecraft:saddle": {
+        "protocol_id": 727
       },
-      "minecraft:soul_lantern": {
-        "protocol_id": 1279
+      "minecraft:salmon": {
+        "protocol_id": 896
       },
-      "minecraft:soul_sand": {
-        "protocol_id": 348
+      "minecraft:salmon_bucket": {
+        "protocol_id": 876
       },
-      "minecraft:soul_soil": {
+      "minecraft:salmon_spawn_egg": {
+        "protocol_id": 1013
+      },
+      "minecraft:sand": {
+        "protocol_id": 44
+      },
+      "minecraft:sandstone": {
+        "protocol_id": 169
+      },
+      "minecraft:sandstone_slab": {
+        "protocol_id": 244
+      },
+      "minecraft:sandstone_stairs": {
+        "protocol_id": 358
+      },
+      "minecraft:sandstone_wall": {
+        "protocol_id": 387
+      },
+      "minecraft:scaffolding": {
+        "protocol_id": 634
+      },
+      "minecraft:sculk": {
         "protocol_id": 349
       },
+      "minecraft:sculk_catalyst": {
+        "protocol_id": 351
+      },
+      "minecraft:sculk_sensor": {
+        "protocol_id": 653
+      },
+      "minecraft:sculk_shrieker": {
+        "protocol_id": 352
+      },
+      "minecraft:sculk_vein": {
+        "protocol_id": 350
+      },
+      "minecraft:scute": {
+        "protocol_id": 757
+      },
+      "minecraft:sea_lantern": {
+        "protocol_id": 487
+      },
+      "minecraft:sea_pickle": {
+        "protocol_id": 179
+      },
+      "minecraft:seagrass": {
+        "protocol_id": 178
+      },
+      "minecraft:sentry_armor_trim_smithing_template": {
+        "protocol_id": 1219
+      },
+      "minecraft:shaper_armor_trim_smithing_template": {
+        "protocol_id": 1231
+      },
+      "minecraft:sheaf_pottery_sherd": {
+        "protocol_id": 1251
+      },
+      "minecraft:shears": {
+        "protocol_id": 942
+      },
+      "minecraft:sheep_spawn_egg": {
+        "protocol_id": 1014
+      },
+      "minecraft:shelter_pottery_sherd": {
+        "protocol_id": 1252
+      },
+      "minecraft:shield": {
+        "protocol_id": 1116
+      },
+      "minecraft:shroomlight": {
+        "protocol_id": 1169
+      },
+      "minecraft:shulker_box": {
+        "protocol_id": 500
+      },
+      "minecraft:shulker_shell": {
+        "protocol_id": 1118
+      },
+      "minecraft:shulker_spawn_egg": {
+        "protocol_id": 1015
+      },
+      "minecraft:silence_armor_trim_smithing_template": {
+        "protocol_id": 1232
+      },
+      "minecraft:silverfish_spawn_egg": {
+        "protocol_id": 1016
+      },
+      "minecraft:skeleton_horse_spawn_egg": {
+        "protocol_id": 1018
+      },
+      "minecraft:skeleton_skull": {
+        "protocol_id": 1057
+      },
+      "minecraft:skeleton_spawn_egg": {
+        "protocol_id": 1017
+      },
+      "minecraft:skull_banner_pattern": {
+        "protocol_id": 1148
+      },
+      "minecraft:skull_pottery_sherd": {
+        "protocol_id": 1253
+      },
+      "minecraft:slime_ball": {
+        "protocol_id": 886
+      },
+      "minecraft:slime_block": {
+        "protocol_id": 642
+      },
+      "minecraft:slime_spawn_egg": {
+        "protocol_id": 1019
+      },
+      "minecraft:small_amethyst_bud": {
+        "protocol_id": 1207
+      },
+      "minecraft:small_dripleaf": {
+        "protocol_id": 228
+      },
+      "minecraft:smithing_table": {
+        "protocol_id": 1160
+      },
+      "minecraft:smoker": {
+        "protocol_id": 1155
+      },
+      "minecraft:smooth_basalt": {
+        "protocol_id": 308
+      },
+      "minecraft:smooth_quartz": {
+        "protocol_id": 259
+      },
+      "minecraft:smooth_quartz_slab": {
+        "protocol_id": 624
+      },
+      "minecraft:smooth_quartz_stairs": {
+        "protocol_id": 607
+      },
+      "minecraft:smooth_red_sandstone": {
+        "protocol_id": 260
+      },
+      "minecraft:smooth_red_sandstone_slab": {
+        "protocol_id": 618
+      },
+      "minecraft:smooth_red_sandstone_stairs": {
+        "protocol_id": 600
+      },
+      "minecraft:smooth_sandstone": {
+        "protocol_id": 261
+      },
+      "minecraft:smooth_sandstone_slab": {
+        "protocol_id": 623
+      },
+      "minecraft:smooth_sandstone_stairs": {
+        "protocol_id": 606
+      },
+      "minecraft:smooth_stone": {
+        "protocol_id": 262
+      },
+      "minecraft:smooth_stone_slab": {
+        "protocol_id": 243
+      },
+      "minecraft:sniffer_egg": {
+        "protocol_id": 566
+      },
+      "minecraft:sniffer_spawn_egg": {
+        "protocol_id": 1020
+      },
+      "minecraft:snort_pottery_sherd": {
+        "protocol_id": 1254
+      },
+      "minecraft:snout_armor_trim_smithing_template": {
+        "protocol_id": 1227
+      },
+      "minecraft:snow": {
+        "protocol_id": 283
+      },
+      "minecraft:snow_block": {
+        "protocol_id": 285
+      },
+      "minecraft:snow_golem_spawn_egg": {
+        "protocol_id": 1021
+      },
+      "minecraft:snowball": {
+        "protocol_id": 872
+      },
+      "minecraft:soul_campfire": {
+        "protocol_id": 1168
+      },
+      "minecraft:soul_lantern": {
+        "protocol_id": 1164
+      },
+      "minecraft:soul_sand": {
+        "protocol_id": 304
+      },
+      "minecraft:soul_soil": {
+        "protocol_id": 305
+      },
       "minecraft:soul_torch": {
-        "protocol_id": 353
+        "protocol_id": 309
       },
       "minecraft:spawner": {
-        "protocol_id": 317
+        "protocol_id": 276
       },
       "minecraft:spectral_arrow": {
-        "protocol_id": 1222
+        "protocol_id": 1113
       },
       "minecraft:spider_eye": {
-        "protocol_id": 1060
+        "protocol_id": 959
       },
       "minecraft:spider_spawn_egg": {
-        "protocol_id": 1126
+        "protocol_id": 1022
       },
       "minecraft:spire_armor_trim_smithing_template": {
-        "protocol_id": 1344
+        "protocol_id": 1229
       },
       "minecraft:splash_potion": {
-        "protocol_id": 1221
+        "protocol_id": 1112
       },
       "minecraft:sponge": {
-        "protocol_id": 193
+        "protocol_id": 164
       },
       "minecraft:spore_blossom": {
-        "protocol_id": 246
+        "protocol_id": 211
       },
       "minecraft:spruce_boat": {
-        "protocol_id": 812
+        "protocol_id": 738
       },
       "minecraft:spruce_button": {
-        "protocol_id": 715
+        "protocol_id": 663
       },
       "minecraft:spruce_chest_boat": {
-        "protocol_id": 813
+        "protocol_id": 739
       },
       "minecraft:spruce_door": {
-        "protocol_id": 744
+        "protocol_id": 690
       },
       "minecraft:spruce_fence": {
-        "protocol_id": 333
+        "protocol_id": 290
       },
       "minecraft:spruce_fence_gate": {
-        "protocol_id": 785
+        "protocol_id": 713
       },
       "minecraft:spruce_hanging_sign": {
-        "protocol_id": 939
+        "protocol_id": 858
       },
       "minecraft:spruce_leaves": {
-        "protocol_id": 183
+        "protocol_id": 155
       },
       "minecraft:spruce_log": {
-        "protocol_id": 135
+        "protocol_id": 111
       },
       "minecraft:spruce_planks": {
-        "protocol_id": 37
+        "protocol_id": 24
       },
       "minecraft:spruce_pressure_plate": {
-        "protocol_id": 731
+        "protocol_id": 678
       },
       "minecraft:spruce_sapling": {
-        "protocol_id": 50
+        "protocol_id": 36
       },
       "minecraft:spruce_sign": {
-        "protocol_id": 927
+        "protocol_id": 847
       },
       "minecraft:spruce_slab": {
-        "protocol_id": 271
+        "protocol_id": 231
       },
       "minecraft:spruce_stairs": {
-        "protocol_id": 413
+        "protocol_id": 362
       },
       "minecraft:spruce_trapdoor": {
-        "protocol_id": 765
+        "protocol_id": 702
       },
       "minecraft:spruce_wood": {
-        "protocol_id": 172
+        "protocol_id": 145
       },
       "minecraft:spyglass": {
-        "protocol_id": 993
+        "protocol_id": 893
       },
       "minecraft:squid_spawn_egg": {
-        "protocol_id": 1127
+        "protocol_id": 1023
       },
       "minecraft:stick": {
-        "protocol_id": 888
+        "protocol_id": 807
       },
       "minecraft:sticky_piston": {
-        "protocol_id": 693
+        "protocol_id": 641
       },
       "minecraft:stone": {
         "protocol_id": 1
       },
       "minecraft:stone_axe": {
-        "protocol_id": 866
+        "protocol_id": 785
       },
       "minecraft:stone_brick_slab": {
-        "protocol_id": 290
+        "protocol_id": 249
       },
       "minecraft:stone_brick_stairs": {
-        "protocol_id": 391
+        "protocol_id": 340
       },
       "minecraft:stone_brick_wall": {
-        "protocol_id": 434
+        "protocol_id": 382
       },
       "minecraft:stone_bricks": {
-        "protocol_id": 362
+        "protocol_id": 318
       },
       "minecraft:stone_button": {
-        "protocol_id": 712
+        "protocol_id": 660
       },
       "minecraft:stone_hoe": {
-        "protocol_id": 867
+        "protocol_id": 786
       },
       "minecraft:stone_pickaxe": {
-        "protocol_id": 865
+        "protocol_id": 784
       },
       "minecraft:stone_pressure_plate": {
-        "protocol_id": 726
+        "protocol_id": 673
       },
       "minecraft:stone_shovel": {
-        "protocol_id": 864
+        "protocol_id": 783
       },
       "minecraft:stone_slab": {
-        "protocol_id": 283
+        "protocol_id": 242
       },
       "minecraft:stone_stairs": {
-        "protocol_id": 657
+        "protocol_id": 605
       },
       "minecraft:stone_sword": {
-        "protocol_id": 863
+        "protocol_id": 782
       },
       "minecraft:stonecutter": {
-        "protocol_id": 1276
+        "protocol_id": 1161
       },
       "minecraft:stray_spawn_egg": {
-        "protocol_id": 1128
+        "protocol_id": 1024
       },
       "minecraft:strider_spawn_egg": {
-        "protocol_id": 1129
+        "protocol_id": 1025
       },
       "minecraft:string": {
-        "protocol_id": 890
+        "protocol_id": 810
       },
       "minecraft:stripped_acacia_log": {
-        "protocol_id": 152
+        "protocol_id": 127
       },
       "minecraft:stripped_acacia_wood": {
-        "protocol_id": 163
+        "protocol_id": 137
       },
       "minecraft:stripped_bamboo_block": {
-        "protocol_id": 170
+        "protocol_id": 143
       },
       "minecraft:stripped_birch_log": {
-        "protocol_id": 150
+        "protocol_id": 125
       },
       "minecraft:stripped_birch_wood": {
-        "protocol_id": 161
+        "protocol_id": 135
       },
       "minecraft:stripped_cherry_log": {
-        "protocol_id": 153
+        "protocol_id": 128
       },
       "minecraft:stripped_cherry_wood": {
-        "protocol_id": 164
+        "protocol_id": 138
       },
       "minecraft:stripped_crimson_hyphae": {
-        "protocol_id": 168
+        "protocol_id": 141
       },
       "minecraft:stripped_crimson_stem": {
-        "protocol_id": 157
+        "protocol_id": 131
       },
       "minecraft:stripped_dark_oak_log": {
-        "protocol_id": 154
+        "protocol_id": 129
       },
       "minecraft:stripped_dark_oak_wood": {
-        "protocol_id": 165
+        "protocol_id": 139
       },
       "minecraft:stripped_jungle_log": {
-        "protocol_id": 151
+        "protocol_id": 126
       },
       "minecraft:stripped_jungle_wood": {
-        "protocol_id": 162
+        "protocol_id": 136
       },
       "minecraft:stripped_mangrove_log": {
-        "protocol_id": 156
+        "protocol_id": 130
       },
       "minecraft:stripped_mangrove_wood": {
-        "protocol_id": 167
+        "protocol_id": 140
       },
       "minecraft:stripped_oak_log": {
-        "protocol_id": 148
+        "protocol_id": 123
       },
       "minecraft:stripped_oak_wood": {
-        "protocol_id": 159
-      },
-      "minecraft:stripped_pale_oak_log": {
-        "protocol_id": 155
-      },
-      "minecraft:stripped_pale_oak_wood": {
-        "protocol_id": 166
+        "protocol_id": 133
       },
       "minecraft:stripped_spruce_log": {
-        "protocol_id": 149
+        "protocol_id": 124
       },
       "minecraft:stripped_spruce_wood": {
-        "protocol_id": 160
+        "protocol_id": 134
       },
       "minecraft:stripped_warped_hyphae": {
-        "protocol_id": 169
+        "protocol_id": 142
       },
       "minecraft:stripped_warped_stem": {
-        "protocol_id": 158
+        "protocol_id": 132
       },
       "minecraft:structure_block": {
-        "protocol_id": 830
+        "protocol_id": 754
       },
       "minecraft:structure_void": {
-        "protocol_id": 551
-      },
-      "minecraft:sugar": {
-        "protocol_id": 1022
-      },
-      "minecraft:sugar_cane": {
-        "protocol_id": 256
-      },
-      "minecraft:sunflower": {
-        "protocol_id": 495
-      },
-      "minecraft:suspicious_gravel": {
-        "protocol_id": 61
-      },
-      "minecraft:suspicious_sand": {
-        "protocol_id": 60
-      },
-      "minecraft:suspicious_stew": {
-        "protocol_id": 1255
-      },
-      "minecraft:sweet_berries": {
-        "protocol_id": 1280
-      },
-      "minecraft:tadpole_bucket": {
-        "protocol_id": 962
-      },
-      "minecraft:tadpole_spawn_egg": {
-        "protocol_id": 1130
-      },
-      "minecraft:tall_dry_grass": {
-        "protocol_id": 210
-      },
-      "minecraft:tall_grass": {
         "protocol_id": 499
       },
+      "minecraft:sugar": {
+        "protocol_id": 922
+      },
+      "minecraft:sugar_cane": {
+        "protocol_id": 221
+      },
+      "minecraft:sunflower": {
+        "protocol_id": 443
+      },
+      "minecraft:suspicious_gravel": {
+        "protocol_id": 46
+      },
+      "minecraft:suspicious_sand": {
+        "protocol_id": 45
+      },
+      "minecraft:suspicious_stew": {
+        "protocol_id": 1144
+      },
+      "minecraft:sweet_berries": {
+        "protocol_id": 1165
+      },
+      "minecraft:tadpole_bucket": {
+        "protocol_id": 880
+      },
+      "minecraft:tadpole_spawn_egg": {
+        "protocol_id": 1026
+      },
+      "minecraft:tall_grass": {
+        "protocol_id": 447
+      },
       "minecraft:target": {
-        "protocol_id": 701
+        "protocol_id": 649
       },
       "minecraft:terracotta": {
-        "protocol_id": 492
-      },
-      "minecraft:test_block": {
-        "protocol_id": 832
-      },
-      "minecraft:test_instance_block": {
-        "protocol_id": 833
+        "protocol_id": 440
       },
       "minecraft:tide_armor_trim_smithing_template": {
-        "protocol_id": 1341
-      },
-      "minecraft:tinted_glass": {
-        "protocol_id": 196
-      },
-      "minecraft:tipped_arrow": {
-        "protocol_id": 1223
-      },
-      "minecraft:tnt": {
-        "protocol_id": 709
-      },
-      "minecraft:tnt_minecart": {
-        "protocol_id": 804
-      },
-      "minecraft:torch": {
-        "protocol_id": 310
-      },
-      "minecraft:torchflower": {
-        "protocol_id": 244
-      },
-      "minecraft:torchflower_seeds": {
-        "protocol_id": 1215
-      },
-      "minecraft:totem_of_undying": {
         "protocol_id": 1226
       },
+      "minecraft:tinted_glass": {
+        "protocol_id": 167
+      },
+      "minecraft:tipped_arrow": {
+        "protocol_id": 1114
+      },
+      "minecraft:tnt": {
+        "protocol_id": 657
+      },
+      "minecraft:tnt_minecart": {
+        "protocol_id": 731
+      },
+      "minecraft:torch": {
+        "protocol_id": 269
+      },
+      "minecraft:torchflower": {
+        "protocol_id": 209
+      },
+      "minecraft:torchflower_seeds": {
+        "protocol_id": 1106
+      },
+      "minecraft:totem_of_undying": {
+        "protocol_id": 1117
+      },
       "minecraft:trader_llama_spawn_egg": {
-        "protocol_id": 1131
+        "protocol_id": 1027
       },
       "minecraft:trapped_chest": {
-        "protocol_id": 708
-      },
-      "minecraft:trial_key": {
-        "protocol_id": 1392
-      },
-      "minecraft:trial_spawner": {
-        "protocol_id": 1391
+        "protocol_id": 656
       },
       "minecraft:trident": {
-        "protocol_id": 1251
+        "protocol_id": 1139
       },
       "minecraft:tripwire_hook": {
-        "protocol_id": 707
+        "protocol_id": 655
       },
       "minecraft:tropical_fish": {
-        "protocol_id": 997
+        "protocol_id": 897
       },
       "minecraft:tropical_fish_bucket": {
-        "protocol_id": 960
+        "protocol_id": 878
       },
       "minecraft:tropical_fish_spawn_egg": {
-        "protocol_id": 1132
+        "protocol_id": 1028
       },
       "minecraft:tube_coral": {
-        "protocol_id": 629
+        "protocol_id": 577
       },
       "minecraft:tube_coral_block": {
-        "protocol_id": 624
+        "protocol_id": 572
       },
       "minecraft:tube_coral_fan": {
-        "protocol_id": 639
+        "protocol_id": 587
       },
       "minecraft:tuff": {
         "protocol_id": 12
       },
-      "minecraft:tuff_brick_slab": {
-        "protocol_id": 22
-      },
-      "minecraft:tuff_brick_stairs": {
-        "protocol_id": 23
-      },
-      "minecraft:tuff_brick_wall": {
-        "protocol_id": 24
-      },
-      "minecraft:tuff_bricks": {
-        "protocol_id": 21
-      },
-      "minecraft:tuff_slab": {
-        "protocol_id": 13
-      },
-      "minecraft:tuff_stairs": {
-        "protocol_id": 14
-      },
-      "minecraft:tuff_wall": {
-        "protocol_id": 15
-      },
       "minecraft:turtle_egg": {
-        "protocol_id": 617
+        "protocol_id": 565
       },
       "minecraft:turtle_helmet": {
-        "protocol_id": 834
-      },
-      "minecraft:turtle_scute": {
-        "protocol_id": 835
+        "protocol_id": 756
       },
       "minecraft:turtle_spawn_egg": {
-        "protocol_id": 1133
+        "protocol_id": 1029
       },
       "minecraft:twisting_vines": {
-        "protocol_id": 255
-      },
-      "minecraft:vault": {
-        "protocol_id": 1394
+        "protocol_id": 220
       },
       "minecraft:verdant_froglight": {
-        "protocol_id": 1328
+        "protocol_id": 1213
       },
       "minecraft:vex_armor_trim_smithing_template": {
-        "protocol_id": 1340
+        "protocol_id": 1225
       },
       "minecraft:vex_spawn_egg": {
-        "protocol_id": 1134
+        "protocol_id": 1030
       },
       "minecraft:villager_spawn_egg": {
-        "protocol_id": 1135
+        "protocol_id": 1031
       },
       "minecraft:vindicator_spawn_egg": {
-        "protocol_id": 1136
+        "protocol_id": 1032
       },
       "minecraft:vine": {
-        "protocol_id": 381
+        "protocol_id": 337
       },
       "minecraft:wandering_trader_spawn_egg": {
-        "protocol_id": 1137
+        "protocol_id": 1033
       },
       "minecraft:ward_armor_trim_smithing_template": {
-        "protocol_id": 1338
+        "protocol_id": 1223
       },
       "minecraft:warden_spawn_egg": {
-        "protocol_id": 1138
+        "protocol_id": 1034
       },
       "minecraft:warped_button": {
-        "protocol_id": 725
+        "protocol_id": 672
       },
       "minecraft:warped_door": {
-        "protocol_id": 754
+        "protocol_id": 699
       },
       "minecraft:warped_fence": {
-        "protocol_id": 343
+        "protocol_id": 299
       },
       "minecraft:warped_fence_gate": {
-        "protocol_id": 795
+        "protocol_id": 722
       },
       "minecraft:warped_fungus": {
-        "protocol_id": 250
+        "protocol_id": 215
       },
       "minecraft:warped_fungus_on_a_stick": {
-        "protocol_id": 807
+        "protocol_id": 734
       },
       "minecraft:warped_hanging_sign": {
-        "protocol_id": 949
+        "protocol_id": 867
       },
       "minecraft:warped_hyphae": {
-        "protocol_id": 181
+        "protocol_id": 153
       },
       "minecraft:warped_nylium": {
-        "protocol_id": 34
+        "protocol_id": 21
       },
       "minecraft:warped_planks": {
-        "protocol_id": 47
+        "protocol_id": 33
       },
       "minecraft:warped_pressure_plate": {
-        "protocol_id": 741
+        "protocol_id": 687
       },
       "minecraft:warped_roots": {
-        "protocol_id": 252
-      },
-      "minecraft:warped_sign": {
-        "protocol_id": 937
-      },
-      "minecraft:warped_slab": {
-        "protocol_id": 282
-      },
-      "minecraft:warped_stairs": {
-        "protocol_id": 424
-      },
-      "minecraft:warped_stem": {
-        "protocol_id": 146
-      },
-      "minecraft:warped_trapdoor": {
-        "protocol_id": 775
-      },
-      "minecraft:warped_wart_block": {
-        "protocol_id": 548
-      },
-      "minecraft:water_bucket": {
-        "protocol_id": 951
-      },
-      "minecraft:waxed_chiseled_copper": {
-        "protocol_id": 118
-      },
-      "minecraft:waxed_copper_block": {
-        "protocol_id": 114
-      },
-      "minecraft:waxed_copper_bulb": {
-        "protocol_id": 1387
-      },
-      "minecraft:waxed_copper_door": {
-        "protocol_id": 759
-      },
-      "minecraft:waxed_copper_grate": {
-        "protocol_id": 1379
-      },
-      "minecraft:waxed_copper_trapdoor": {
-        "protocol_id": 780
-      },
-      "minecraft:waxed_cut_copper": {
-        "protocol_id": 122
-      },
-      "minecraft:waxed_cut_copper_slab": {
-        "protocol_id": 130
-      },
-      "minecraft:waxed_cut_copper_stairs": {
-        "protocol_id": 126
-      },
-      "minecraft:waxed_exposed_chiseled_copper": {
-        "protocol_id": 119
-      },
-      "minecraft:waxed_exposed_copper": {
-        "protocol_id": 115
-      },
-      "minecraft:waxed_exposed_copper_bulb": {
-        "protocol_id": 1388
-      },
-      "minecraft:waxed_exposed_copper_door": {
-        "protocol_id": 760
-      },
-      "minecraft:waxed_exposed_copper_grate": {
-        "protocol_id": 1380
-      },
-      "minecraft:waxed_exposed_copper_trapdoor": {
-        "protocol_id": 781
-      },
-      "minecraft:waxed_exposed_cut_copper": {
-        "protocol_id": 123
-      },
-      "minecraft:waxed_exposed_cut_copper_slab": {
-        "protocol_id": 131
-      },
-      "minecraft:waxed_exposed_cut_copper_stairs": {
-        "protocol_id": 127
-      },
-      "minecraft:waxed_oxidized_chiseled_copper": {
-        "protocol_id": 121
-      },
-      "minecraft:waxed_oxidized_copper": {
-        "protocol_id": 117
-      },
-      "minecraft:waxed_oxidized_copper_bulb": {
-        "protocol_id": 1390
-      },
-      "minecraft:waxed_oxidized_copper_door": {
-        "protocol_id": 762
-      },
-      "minecraft:waxed_oxidized_copper_grate": {
-        "protocol_id": 1382
-      },
-      "minecraft:waxed_oxidized_copper_trapdoor": {
-        "protocol_id": 783
-      },
-      "minecraft:waxed_oxidized_cut_copper": {
-        "protocol_id": 125
-      },
-      "minecraft:waxed_oxidized_cut_copper_slab": {
-        "protocol_id": 133
-      },
-      "minecraft:waxed_oxidized_cut_copper_stairs": {
-        "protocol_id": 129
-      },
-      "minecraft:waxed_weathered_chiseled_copper": {
-        "protocol_id": 120
-      },
-      "minecraft:waxed_weathered_copper": {
-        "protocol_id": 116
-      },
-      "minecraft:waxed_weathered_copper_bulb": {
-        "protocol_id": 1389
-      },
-      "minecraft:waxed_weathered_copper_door": {
-        "protocol_id": 761
-      },
-      "minecraft:waxed_weathered_copper_grate": {
-        "protocol_id": 1381
-      },
-      "minecraft:waxed_weathered_copper_trapdoor": {
-        "protocol_id": 782
-      },
-      "minecraft:waxed_weathered_cut_copper": {
-        "protocol_id": 124
-      },
-      "minecraft:waxed_weathered_cut_copper_slab": {
-        "protocol_id": 132
-      },
-      "minecraft:waxed_weathered_cut_copper_stairs": {
-        "protocol_id": 128
-      },
-      "minecraft:wayfinder_armor_trim_smithing_template": {
-        "protocol_id": 1345
-      },
-      "minecraft:weathered_chiseled_copper": {
-        "protocol_id": 100
-      },
-      "minecraft:weathered_copper": {
-        "protocol_id": 96
-      },
-      "minecraft:weathered_copper_bulb": {
-        "protocol_id": 1385
-      },
-      "minecraft:weathered_copper_door": {
-        "protocol_id": 757
-      },
-      "minecraft:weathered_copper_grate": {
-        "protocol_id": 1377
-      },
-      "minecraft:weathered_copper_trapdoor": {
-        "protocol_id": 778
-      },
-      "minecraft:weathered_cut_copper": {
-        "protocol_id": 104
-      },
-      "minecraft:weathered_cut_copper_slab": {
-        "protocol_id": 112
-      },
-      "minecraft:weathered_cut_copper_stairs": {
-        "protocol_id": 108
-      },
-      "minecraft:weeping_vines": {
-        "protocol_id": 254
-      },
-      "minecraft:wet_sponge": {
-        "protocol_id": 194
-      },
-      "minecraft:wheat": {
-        "protocol_id": 894
-      },
-      "minecraft:wheat_seeds": {
-        "protocol_id": 893
-      },
-      "minecraft:white_banner": {
-        "protocol_id": 1196
-      },
-      "minecraft:white_bed": {
-        "protocol_id": 1024
-      },
-      "minecraft:white_bundle": {
-        "protocol_id": 975
-      },
-      "minecraft:white_candle": {
-        "protocol_id": 1306
-      },
-      "minecraft:white_carpet": {
-        "protocol_id": 476
-      },
-      "minecraft:white_concrete": {
-        "protocol_id": 585
-      },
-      "minecraft:white_concrete_powder": {
-        "protocol_id": 601
-      },
-      "minecraft:white_dye": {
-        "protocol_id": 1004
-      },
-      "minecraft:white_glazed_terracotta": {
-        "protocol_id": 569
-      },
-      "minecraft:white_shulker_box": {
-        "protocol_id": 553
-      },
-      "minecraft:white_stained_glass": {
-        "protocol_id": 501
-      },
-      "minecraft:white_stained_glass_pane": {
-        "protocol_id": 517
-      },
-      "minecraft:white_terracotta": {
-        "protocol_id": 457
-      },
-      "minecraft:white_tulip": {
-        "protocol_id": 238
-      },
-      "minecraft:white_wool": {
-        "protocol_id": 213
-      },
-      "minecraft:wild_armor_trim_smithing_template": {
-        "protocol_id": 1337
-      },
-      "minecraft:wildflowers": {
-        "protocol_id": 259
-      },
-      "minecraft:wind_charge": {
-        "protocol_id": 1151
-      },
-      "minecraft:witch_spawn_egg": {
-        "protocol_id": 1139
-      },
-      "minecraft:wither_rose": {
-        "protocol_id": 243
-      },
-      "minecraft:wither_skeleton_skull": {
-        "protocol_id": 1166
-      },
-      "minecraft:wither_skeleton_spawn_egg": {
-        "protocol_id": 1141
-      },
-      "minecraft:wither_spawn_egg": {
-        "protocol_id": 1140
-      },
-      "minecraft:wolf_armor": {
-        "protocol_id": 837
-      },
-      "minecraft:wolf_spawn_egg": {
-        "protocol_id": 1142
-      },
-      "minecraft:wooden_axe": {
-        "protocol_id": 861
-      },
-      "minecraft:wooden_hoe": {
-        "protocol_id": 862
-      },
-      "minecraft:wooden_pickaxe": {
-        "protocol_id": 860
-      },
-      "minecraft:wooden_shovel": {
-        "protocol_id": 859
-      },
-      "minecraft:wooden_sword": {
-        "protocol_id": 858
-      },
-      "minecraft:writable_book": {
-        "protocol_id": 1152
-      },
-      "minecraft:written_book": {
-        "protocol_id": 1153
-      },
-      "minecraft:yellow_banner": {
-        "protocol_id": 1200
-      },
-      "minecraft:yellow_bed": {
-        "protocol_id": 1028
-      },
-      "minecraft:yellow_bundle": {
-        "protocol_id": 979
-      },
-      "minecraft:yellow_candle": {
-        "protocol_id": 1310
-      },
-      "minecraft:yellow_carpet": {
-        "protocol_id": 480
-      },
-      "minecraft:yellow_concrete": {
-        "protocol_id": 589
-      },
-      "minecraft:yellow_concrete_powder": {
-        "protocol_id": 605
-      },
-      "minecraft:yellow_dye": {
-        "protocol_id": 1008
-      },
-      "minecraft:yellow_glazed_terracotta": {
-        "protocol_id": 573
-      },
-      "minecraft:yellow_shulker_box": {
-        "protocol_id": 557
-      },
-      "minecraft:yellow_stained_glass": {
-        "protocol_id": 505
-      },
-      "minecraft:yellow_stained_glass_pane": {
-        "protocol_id": 521
-      },
-      "minecraft:yellow_terracotta": {
-        "protocol_id": 461
-      },
-      "minecraft:yellow_wool": {
         "protocol_id": 217
       },
+      "minecraft:warped_sign": {
+        "protocol_id": 856
+      },
+      "minecraft:warped_slab": {
+        "protocol_id": 241
+      },
+      "minecraft:warped_stairs": {
+        "protocol_id": 372
+      },
+      "minecraft:warped_stem": {
+        "protocol_id": 121
+      },
+      "minecraft:warped_trapdoor": {
+        "protocol_id": 711
+      },
+      "minecraft:warped_wart_block": {
+        "protocol_id": 496
+      },
+      "minecraft:water_bucket": {
+        "protocol_id": 869
+      },
+      "minecraft:waxed_copper_block": {
+        "protocol_id": 94
+      },
+      "minecraft:waxed_cut_copper": {
+        "protocol_id": 98
+      },
+      "minecraft:waxed_cut_copper_slab": {
+        "protocol_id": 106
+      },
+      "minecraft:waxed_cut_copper_stairs": {
+        "protocol_id": 102
+      },
+      "minecraft:waxed_exposed_copper": {
+        "protocol_id": 95
+      },
+      "minecraft:waxed_exposed_cut_copper": {
+        "protocol_id": 99
+      },
+      "minecraft:waxed_exposed_cut_copper_slab": {
+        "protocol_id": 107
+      },
+      "minecraft:waxed_exposed_cut_copper_stairs": {
+        "protocol_id": 103
+      },
+      "minecraft:waxed_oxidized_copper": {
+        "protocol_id": 97
+      },
+      "minecraft:waxed_oxidized_cut_copper": {
+        "protocol_id": 101
+      },
+      "minecraft:waxed_oxidized_cut_copper_slab": {
+        "protocol_id": 109
+      },
+      "minecraft:waxed_oxidized_cut_copper_stairs": {
+        "protocol_id": 105
+      },
+      "minecraft:waxed_weathered_copper": {
+        "protocol_id": 96
+      },
+      "minecraft:waxed_weathered_cut_copper": {
+        "protocol_id": 100
+      },
+      "minecraft:waxed_weathered_cut_copper_slab": {
+        "protocol_id": 108
+      },
+      "minecraft:waxed_weathered_cut_copper_stairs": {
+        "protocol_id": 104
+      },
+      "minecraft:wayfinder_armor_trim_smithing_template": {
+        "protocol_id": 1230
+      },
+      "minecraft:weathered_copper": {
+        "protocol_id": 80
+      },
+      "minecraft:weathered_cut_copper": {
+        "protocol_id": 84
+      },
+      "minecraft:weathered_cut_copper_slab": {
+        "protocol_id": 92
+      },
+      "minecraft:weathered_cut_copper_stairs": {
+        "protocol_id": 88
+      },
+      "minecraft:weeping_vines": {
+        "protocol_id": 219
+      },
+      "minecraft:wet_sponge": {
+        "protocol_id": 165
+      },
+      "minecraft:wheat": {
+        "protocol_id": 814
+      },
+      "minecraft:wheat_seeds": {
+        "protocol_id": 813
+      },
+      "minecraft:white_banner": {
+        "protocol_id": 1087
+      },
+      "minecraft:white_bed": {
+        "protocol_id": 924
+      },
+      "minecraft:white_candle": {
+        "protocol_id": 1191
+      },
+      "minecraft:white_carpet": {
+        "protocol_id": 424
+      },
+      "minecraft:white_concrete": {
+        "protocol_id": 533
+      },
+      "minecraft:white_concrete_powder": {
+        "protocol_id": 549
+      },
+      "minecraft:white_dye": {
+        "protocol_id": 904
+      },
+      "minecraft:white_glazed_terracotta": {
+        "protocol_id": 517
+      },
+      "minecraft:white_shulker_box": {
+        "protocol_id": 501
+      },
+      "minecraft:white_stained_glass": {
+        "protocol_id": 449
+      },
+      "minecraft:white_stained_glass_pane": {
+        "protocol_id": 465
+      },
+      "minecraft:white_terracotta": {
+        "protocol_id": 405
+      },
+      "minecraft:white_tulip": {
+        "protocol_id": 203
+      },
+      "minecraft:white_wool": {
+        "protocol_id": 180
+      },
+      "minecraft:wild_armor_trim_smithing_template": {
+        "protocol_id": 1222
+      },
+      "minecraft:witch_spawn_egg": {
+        "protocol_id": 1035
+      },
+      "minecraft:wither_rose": {
+        "protocol_id": 208
+      },
+      "minecraft:wither_skeleton_skull": {
+        "protocol_id": 1058
+      },
+      "minecraft:wither_skeleton_spawn_egg": {
+        "protocol_id": 1037
+      },
+      "minecraft:wither_spawn_egg": {
+        "protocol_id": 1036
+      },
+      "minecraft:wolf_spawn_egg": {
+        "protocol_id": 1038
+      },
+      "minecraft:wooden_axe": {
+        "protocol_id": 780
+      },
+      "minecraft:wooden_hoe": {
+        "protocol_id": 781
+      },
+      "minecraft:wooden_pickaxe": {
+        "protocol_id": 779
+      },
+      "minecraft:wooden_shovel": {
+        "protocol_id": 778
+      },
+      "minecraft:wooden_sword": {
+        "protocol_id": 777
+      },
+      "minecraft:writable_book": {
+        "protocol_id": 1046
+      },
+      "minecraft:written_book": {
+        "protocol_id": 1047
+      },
+      "minecraft:yellow_banner": {
+        "protocol_id": 1091
+      },
+      "minecraft:yellow_bed": {
+        "protocol_id": 928
+      },
+      "minecraft:yellow_candle": {
+        "protocol_id": 1195
+      },
+      "minecraft:yellow_carpet": {
+        "protocol_id": 428
+      },
+      "minecraft:yellow_concrete": {
+        "protocol_id": 537
+      },
+      "minecraft:yellow_concrete_powder": {
+        "protocol_id": 553
+      },
+      "minecraft:yellow_dye": {
+        "protocol_id": 908
+      },
+      "minecraft:yellow_glazed_terracotta": {
+        "protocol_id": 521
+      },
+      "minecraft:yellow_shulker_box": {
+        "protocol_id": 505
+      },
+      "minecraft:yellow_stained_glass": {
+        "protocol_id": 453
+      },
+      "minecraft:yellow_stained_glass_pane": {
+        "protocol_id": 469
+      },
+      "minecraft:yellow_terracotta": {
+        "protocol_id": 409
+      },
+      "minecraft:yellow_wool": {
+        "protocol_id": 184
+      },
       "minecraft:zoglin_spawn_egg": {
-        "protocol_id": 1143
+        "protocol_id": 1039
       },
       "minecraft:zombie_head": {
-        "protocol_id": 1168
+        "protocol_id": 1060
       },
       "minecraft:zombie_horse_spawn_egg": {
-        "protocol_id": 1146
+        "protocol_id": 1041
       },
       "minecraft:zombie_spawn_egg": {
-        "protocol_id": 1145
+        "protocol_id": 1040
       },
       "minecraft:zombie_villager_spawn_egg": {
-        "protocol_id": 1147
+        "protocol_id": 1042
       },
       "minecraft:zombified_piglin_spawn_egg": {
-        "protocol_id": 1148
+        "protocol_id": 1043
       }
     },
-    "protocol_id": 6
+    "protocol_id": 7
   },
   "minecraft:loot_condition_type": {
     "entries": {
@@ -10583,9 +8615,6 @@
       },
       "minecraft:damage_source_properties": {
         "protocol_id": 12
-      },
-      "minecraft:enchantment_active_check": {
-        "protocol_id": 18
       },
       "minecraft:entity_properties": {
         "protocol_id": 5
@@ -10608,7 +8637,7 @@
       "minecraft:random_chance": {
         "protocol_id": 3
       },
-      "minecraft:random_chance_with_enchanted_bonus": {
+      "minecraft:random_chance_with_looting": {
         "protocol_id": 4
       },
       "minecraft:reference": {
@@ -10630,132 +8659,90 @@
         "protocol_id": 14
       }
     },
-    "protocol_id": 31
+    "protocol_id": 33
   },
   "minecraft:loot_function_type": {
     "entries": {
       "minecraft:apply_bonus": {
-        "protocol_id": 19
-      },
-      "minecraft:copy_components": {
-        "protocol_id": 31
-      },
-      "minecraft:copy_custom_data": {
-        "protocol_id": 24
+        "protocol_id": 15
       },
       "minecraft:copy_name": {
-        "protocol_id": 14
-      },
-      "minecraft:copy_state": {
-        "protocol_id": 25
-      },
-      "minecraft:enchant_randomly": {
-        "protocol_id": 3
-      },
-      "minecraft:enchant_with_levels": {
-        "protocol_id": 2
-      },
-      "minecraft:enchanted_count_increase": {
-        "protocol_id": 8
-      },
-      "minecraft:exploration_map": {
         "protocol_id": 12
       },
-      "minecraft:explosion_decay": {
+      "minecraft:copy_nbt": {
+        "protocol_id": 20
+      },
+      "minecraft:copy_state": {
         "protocol_id": 21
       },
-      "minecraft:fill_player_head": {
-        "protocol_id": 23
+      "minecraft:enchant_randomly": {
+        "protocol_id": 2
       },
-      "minecraft:filtered": {
-        "protocol_id": 17
+      "minecraft:enchant_with_levels": {
+        "protocol_id": 1
       },
-      "minecraft:furnace_smelt": {
-        "protocol_id": 7
-      },
-      "minecraft:limit_count": {
-        "protocol_id": 18
-      },
-      "minecraft:modify_contents": {
-        "protocol_id": 16
-      },
-      "minecraft:reference": {
-        "protocol_id": 29
-      },
-      "minecraft:sequence": {
-        "protocol_id": 30
-      },
-      "minecraft:set_attributes": {
+      "minecraft:exploration_map": {
         "protocol_id": 10
       },
-      "minecraft:set_banner_pattern": {
-        "protocol_id": 26
+      "minecraft:explosion_decay": {
+        "protocol_id": 17
       },
-      "minecraft:set_book_cover": {
-        "protocol_id": 34
+      "minecraft:fill_player_head": {
+        "protocol_id": 19
       },
-      "minecraft:set_components": {
+      "minecraft:furnace_smelt": {
+        "protocol_id": 5
+      },
+      "minecraft:limit_count": {
+        "protocol_id": 14
+      },
+      "minecraft:looting_enchant": {
         "protocol_id": 6
       },
+      "minecraft:reference": {
+        "protocol_id": 25
+      },
+      "minecraft:set_attributes": {
+        "protocol_id": 8
+      },
+      "minecraft:set_banner_pattern": {
+        "protocol_id": 22
+      },
       "minecraft:set_contents": {
-        "protocol_id": 15
+        "protocol_id": 13
       },
       "minecraft:set_count": {
         "protocol_id": 0
       },
-      "minecraft:set_custom_data": {
-        "protocol_id": 5
-      },
-      "minecraft:set_custom_model_data": {
-        "protocol_id": 39
-      },
       "minecraft:set_damage": {
-        "protocol_id": 9
+        "protocol_id": 7
       },
       "minecraft:set_enchantments": {
-        "protocol_id": 4
-      },
-      "minecraft:set_firework_explosion": {
-        "protocol_id": 33
-      },
-      "minecraft:set_fireworks": {
-        "protocol_id": 32
+        "protocol_id": 3
       },
       "minecraft:set_instrument": {
-        "protocol_id": 28
-      },
-      "minecraft:set_item": {
-        "protocol_id": 1
+        "protocol_id": 24
       },
       "minecraft:set_loot_table": {
-        "protocol_id": 20
+        "protocol_id": 16
       },
       "minecraft:set_lore": {
-        "protocol_id": 22
+        "protocol_id": 18
       },
       "minecraft:set_name": {
-        "protocol_id": 11
+        "protocol_id": 9
       },
-      "minecraft:set_ominous_bottle_amplifier": {
-        "protocol_id": 38
+      "minecraft:set_nbt": {
+        "protocol_id": 4
       },
       "minecraft:set_potion": {
-        "protocol_id": 27
+        "protocol_id": 23
       },
       "minecraft:set_stew_effect": {
-        "protocol_id": 13
-      },
-      "minecraft:set_writable_book_pages": {
-        "protocol_id": 36
-      },
-      "minecraft:set_written_book_pages": {
-        "protocol_id": 35
-      },
-      "minecraft:toggle_tooltips": {
-        "protocol_id": 37
+        "protocol_id": 11
       }
     },
-    "protocol_id": 30
+    "protocol_id": 32
   },
   "minecraft:loot_nbt_provider_type": {
     "entries": {
@@ -10766,7 +8753,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 33
+    "protocol_id": 35
   },
   "minecraft:loot_number_provider_type": {
     "entries": {
@@ -10776,20 +8763,14 @@
       "minecraft:constant": {
         "protocol_id": 0
       },
-      "minecraft:enchantment_level": {
-        "protocol_id": 5
-      },
       "minecraft:score": {
         "protocol_id": 3
-      },
-      "minecraft:storage": {
-        "protocol_id": 4
       },
       "minecraft:uniform": {
         "protocol_id": 1
       }
     },
-    "protocol_id": 32
+    "protocol_id": 34
   },
   "minecraft:loot_pool_entry_type": {
     "entries": {
@@ -10818,7 +8799,7 @@
         "protocol_id": 4
       }
     },
-    "protocol_id": 29
+    "protocol_id": 31
   },
   "minecraft:loot_score_provider_type": {
     "entries": {
@@ -10829,279 +8810,142 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 34
-  },
-  "minecraft:map_decoration_type": {
-    "entries": {
-      "minecraft:banner_black": {
-        "protocol_id": 25
-      },
-      "minecraft:banner_blue": {
-        "protocol_id": 21
-      },
-      "minecraft:banner_brown": {
-        "protocol_id": 22
-      },
-      "minecraft:banner_cyan": {
-        "protocol_id": 19
-      },
-      "minecraft:banner_gray": {
-        "protocol_id": 17
-      },
-      "minecraft:banner_green": {
-        "protocol_id": 23
-      },
-      "minecraft:banner_light_blue": {
-        "protocol_id": 13
-      },
-      "minecraft:banner_light_gray": {
-        "protocol_id": 18
-      },
-      "minecraft:banner_lime": {
-        "protocol_id": 15
-      },
-      "minecraft:banner_magenta": {
-        "protocol_id": 12
-      },
-      "minecraft:banner_orange": {
-        "protocol_id": 11
-      },
-      "minecraft:banner_pink": {
-        "protocol_id": 16
-      },
-      "minecraft:banner_purple": {
-        "protocol_id": 20
-      },
-      "minecraft:banner_red": {
-        "protocol_id": 24
-      },
-      "minecraft:banner_white": {
-        "protocol_id": 10
-      },
-      "minecraft:banner_yellow": {
-        "protocol_id": 14
-      },
-      "minecraft:blue_marker": {
-        "protocol_id": 3
-      },
-      "minecraft:frame": {
-        "protocol_id": 1
-      },
-      "minecraft:jungle_temple": {
-        "protocol_id": 32
-      },
-      "minecraft:mansion": {
-        "protocol_id": 8
-      },
-      "minecraft:monument": {
-        "protocol_id": 9
-      },
-      "minecraft:player": {
-        "protocol_id": 0
-      },
-      "minecraft:player_off_limits": {
-        "protocol_id": 7
-      },
-      "minecraft:player_off_map": {
-        "protocol_id": 6
-      },
-      "minecraft:red_marker": {
-        "protocol_id": 2
-      },
-      "minecraft:red_x": {
-        "protocol_id": 26
-      },
-      "minecraft:swamp_hut": {
-        "protocol_id": 33
-      },
-      "minecraft:target_point": {
-        "protocol_id": 5
-      },
-      "minecraft:target_x": {
-        "protocol_id": 4
-      },
-      "minecraft:trial_chambers": {
-        "protocol_id": 34
-      },
-      "minecraft:village_desert": {
-        "protocol_id": 27
-      },
-      "minecraft:village_plains": {
-        "protocol_id": 28
-      },
-      "minecraft:village_savanna": {
-        "protocol_id": 29
-      },
-      "minecraft:village_snowy": {
-        "protocol_id": 30
-      },
-      "minecraft:village_taiga": {
-        "protocol_id": 31
-      }
-    },
-    "protocol_id": 67
+    "protocol_id": 36
   },
   "minecraft:memory_module_type": {
     "default": "minecraft:dummy",
     "entries": {
       "minecraft:admiring_disabled": {
-        "protocol_id": 59
+        "protocol_id": 57
       },
       "minecraft:admiring_item": {
-        "protocol_id": 56
-      },
-      "minecraft:angry_at": {
         "protocol_id": 54
       },
+      "minecraft:angry_at": {
+        "protocol_id": 52
+      },
       "minecraft:ate_recently": {
-        "protocol_id": 74
+        "protocol_id": 72
       },
       "minecraft:attack_cooling_down": {
-        "protocol_id": 16
-      },
-      "minecraft:attack_target": {
         "protocol_id": 15
       },
+      "minecraft:attack_target": {
+        "protocol_id": 14
+      },
       "minecraft:avoid_target": {
-        "protocol_id": 26
+        "protocol_id": 25
       },
       "minecraft:breed_target": {
-        "protocol_id": 18
-      },
-      "minecraft:breeze_jump_cooldown": {
-        "protocol_id": 99
-      },
-      "minecraft:breeze_jump_inhaling": {
-        "protocol_id": 104
-      },
-      "minecraft:breeze_jump_target": {
-        "protocol_id": 105
-      },
-      "minecraft:breeze_leaving_water": {
-        "protocol_id": 106
-      },
-      "minecraft:breeze_shoot": {
-        "protocol_id": 100
-      },
-      "minecraft:breeze_shoot_charging": {
-        "protocol_id": 101
-      },
-      "minecraft:breeze_shoot_cooldown": {
-        "protocol_id": 103
-      },
-      "minecraft:breeze_shoot_recover": {
-        "protocol_id": 102
+        "protocol_id": 17
       },
       "minecraft:cant_reach_walk_target_since": {
-        "protocol_id": 31
+        "protocol_id": 30
       },
       "minecraft:celebrate_location": {
-        "protocol_id": 61
+        "protocol_id": 59
       },
       "minecraft:dancing": {
-        "protocol_id": 62
-      },
-      "minecraft:danger_detected_recently": {
-        "protocol_id": 33
+        "protocol_id": 60
       },
       "minecraft:dig_cooldown": {
-        "protocol_id": 83
+        "protocol_id": 81
       },
       "minecraft:disable_walk_to_admire_item": {
-        "protocol_id": 58
+        "protocol_id": 56
       },
       "minecraft:disturbance_location": {
-        "protocol_id": 78
+        "protocol_id": 76
       },
       "minecraft:doors_to_close": {
-        "protocol_id": 22
+        "protocol_id": 21
       },
       "minecraft:dummy": {
         "protocol_id": 0
       },
       "minecraft:gaze_cooldown_ticks": {
-        "protocol_id": 43
+        "protocol_id": 41
       },
       "minecraft:golem_detected_recently": {
-        "protocol_id": 32
+        "protocol_id": 31
       },
       "minecraft:has_hunting_cooldown": {
-        "protocol_id": 47
+        "protocol_id": 45
       },
       "minecraft:heard_bell_time": {
-        "protocol_id": 30
+        "protocol_id": 29
       },
       "minecraft:hiding_place": {
-        "protocol_id": 29
+        "protocol_id": 28
       },
       "minecraft:home": {
         "protocol_id": 1
       },
       "minecraft:hunted_recently": {
-        "protocol_id": 60
+        "protocol_id": 58
       },
       "minecraft:hurt_by": {
-        "protocol_id": 24
+        "protocol_id": 23
       },
       "minecraft:hurt_by_entity": {
-        "protocol_id": 25
+        "protocol_id": 24
       },
       "minecraft:interactable_doors": {
-        "protocol_id": 21
+        "protocol_id": 20
       },
       "minecraft:interaction_target": {
-        "protocol_id": 17
+        "protocol_id": 16
       },
       "minecraft:is_emerging": {
-        "protocol_id": 81
+        "protocol_id": 79
       },
       "minecraft:is_in_water": {
-        "protocol_id": 50
+        "protocol_id": 48
       },
       "minecraft:is_panicking": {
-        "protocol_id": 52
+        "protocol_id": 50
       },
       "minecraft:is_pregnant": {
-        "protocol_id": 51
+        "protocol_id": 49
       },
       "minecraft:is_sniffing": {
-        "protocol_id": 80
+        "protocol_id": 78
       },
       "minecraft:is_tempted": {
-        "protocol_id": 44
+        "protocol_id": 42
       },
       "minecraft:item_pickup_cooldown_ticks": {
-        "protocol_id": 94
+        "protocol_id": 92
       },
       "minecraft:job_site": {
         "protocol_id": 2
       },
       "minecraft:last_slept": {
-        "protocol_id": 34
+        "protocol_id": 32
       },
       "minecraft:last_woken": {
-        "protocol_id": 35
+        "protocol_id": 33
       },
       "minecraft:last_worked_at_poi": {
-        "protocol_id": 36
+        "protocol_id": 34
       },
       "minecraft:liked_noteblock": {
-        "protocol_id": 92
+        "protocol_id": 90
       },
       "minecraft:liked_noteblock_cooldown_ticks": {
-        "protocol_id": 93
-      },
-      "minecraft:liked_player": {
         "protocol_id": 91
       },
+      "minecraft:liked_player": {
+        "protocol_id": 89
+      },
       "minecraft:long_jump_cooling_down": {
-        "protocol_id": 45
+        "protocol_id": 43
       },
       "minecraft:long_jump_mid_jump": {
-        "protocol_id": 46
+        "protocol_id": 44
       },
       "minecraft:look_target": {
-        "protocol_id": 14
+        "protocol_id": 13
       },
       "minecraft:meeting_point": {
         "protocol_id": 4
@@ -11110,49 +8954,49 @@
         "protocol_id": 6
       },
       "minecraft:nearby_adult_piglins": {
-        "protocol_id": 66
+        "protocol_id": 64
       },
       "minecraft:nearest_attackable": {
-        "protocol_id": 28
-      },
-      "minecraft:nearest_bed": {
-        "protocol_id": 23
-      },
-      "minecraft:nearest_hostile": {
         "protocol_id": 27
       },
+      "minecraft:nearest_bed": {
+        "protocol_id": 22
+      },
+      "minecraft:nearest_hostile": {
+        "protocol_id": 26
+      },
       "minecraft:nearest_player_holding_wanted_item": {
-        "protocol_id": 73
+        "protocol_id": 71
       },
       "minecraft:nearest_players": {
         "protocol_id": 9
       },
       "minecraft:nearest_repellent": {
-        "protocol_id": 75
+        "protocol_id": 73
       },
       "minecraft:nearest_targetable_player_not_wearing_gold": {
-        "protocol_id": 65
-      },
-      "minecraft:nearest_visible_adult": {
-        "protocol_id": 37
-      },
-      "minecraft:nearest_visible_adult_hoglins": {
-        "protocol_id": 68
-      },
-      "minecraft:nearest_visible_adult_piglin": {
-        "protocol_id": 69
-      },
-      "minecraft:nearest_visible_adult_piglins": {
-        "protocol_id": 67
-      },
-      "minecraft:nearest_visible_baby_hoglin": {
-        "protocol_id": 64
-      },
-      "minecraft:nearest_visible_huntable_hoglin": {
         "protocol_id": 63
       },
+      "minecraft:nearest_visible_adult": {
+        "protocol_id": 35
+      },
+      "minecraft:nearest_visible_adult_hoglins": {
+        "protocol_id": 66
+      },
+      "minecraft:nearest_visible_adult_piglin": {
+        "protocol_id": 67
+      },
+      "minecraft:nearest_visible_adult_piglins": {
+        "protocol_id": 65
+      },
+      "minecraft:nearest_visible_baby_hoglin": {
+        "protocol_id": 62
+      },
+      "minecraft:nearest_visible_huntable_hoglin": {
+        "protocol_id": 61
+      },
       "minecraft:nearest_visible_nemesis": {
-        "protocol_id": 39
+        "protocol_id": 37
       },
       "minecraft:nearest_visible_player": {
         "protocol_id": 10
@@ -11160,101 +9004,98 @@
       "minecraft:nearest_visible_targetable_player": {
         "protocol_id": 11
       },
-      "minecraft:nearest_visible_targetable_players": {
-        "protocol_id": 12
-      },
       "minecraft:nearest_visible_wanted_item": {
-        "protocol_id": 38
+        "protocol_id": 36
       },
       "minecraft:nearest_visible_zombified": {
-        "protocol_id": 70
+        "protocol_id": 68
       },
       "minecraft:pacified": {
-        "protocol_id": 76
+        "protocol_id": 74
       },
       "minecraft:path": {
-        "protocol_id": 20
+        "protocol_id": 19
       },
       "minecraft:play_dead_ticks": {
-        "protocol_id": 40
+        "protocol_id": 38
       },
       "minecraft:potential_job_site": {
         "protocol_id": 3
       },
       "minecraft:ram_cooldown_ticks": {
-        "protocol_id": 48
+        "protocol_id": 46
       },
       "minecraft:ram_target": {
-        "protocol_id": 49
+        "protocol_id": 47
       },
       "minecraft:recent_projectile": {
-        "protocol_id": 79
+        "protocol_id": 77
       },
       "minecraft:ride_target": {
-        "protocol_id": 19
+        "protocol_id": 18
       },
       "minecraft:roar_sound_cooldown": {
-        "protocol_id": 84
-      },
-      "minecraft:roar_sound_delay": {
         "protocol_id": 82
       },
+      "minecraft:roar_sound_delay": {
+        "protocol_id": 80
+      },
       "minecraft:roar_target": {
-        "protocol_id": 77
+        "protocol_id": 75
       },
       "minecraft:secondary_job_site": {
         "protocol_id": 5
       },
       "minecraft:sniff_cooldown": {
-        "protocol_id": 85
+        "protocol_id": 83
       },
       "minecraft:sniffer_digging": {
-        "protocol_id": 97
-      },
-      "minecraft:sniffer_explored_positions": {
         "protocol_id": 95
       },
-      "minecraft:sniffer_happy": {
-        "protocol_id": 98
+      "minecraft:sniffer_explored_positions": {
+        "protocol_id": 93
       },
-      "minecraft:sniffer_sniffing_target": {
+      "minecraft:sniffer_happy": {
         "protocol_id": 96
       },
+      "minecraft:sniffer_sniffing_target": {
+        "protocol_id": 94
+      },
       "minecraft:sonic_boom_cooldown": {
-        "protocol_id": 88
-      },
-      "minecraft:sonic_boom_sound_cooldown": {
-        "protocol_id": 89
-      },
-      "minecraft:sonic_boom_sound_delay": {
-        "protocol_id": 90
-      },
-      "minecraft:temptation_cooldown_ticks": {
-        "protocol_id": 42
-      },
-      "minecraft:tempting_player": {
-        "protocol_id": 41
-      },
-      "minecraft:time_trying_to_reach_admire_item": {
-        "protocol_id": 57
-      },
-      "minecraft:touch_cooldown": {
         "protocol_id": 86
       },
-      "minecraft:universal_anger": {
-        "protocol_id": 55
-      },
-      "minecraft:unreachable_tongue_targets": {
-        "protocol_id": 53
-      },
-      "minecraft:vibration_cooldown": {
+      "minecraft:sonic_boom_sound_cooldown": {
         "protocol_id": 87
       },
+      "minecraft:sonic_boom_sound_delay": {
+        "protocol_id": 88
+      },
+      "minecraft:temptation_cooldown_ticks": {
+        "protocol_id": 40
+      },
+      "minecraft:tempting_player": {
+        "protocol_id": 39
+      },
+      "minecraft:time_trying_to_reach_admire_item": {
+        "protocol_id": 55
+      },
+      "minecraft:touch_cooldown": {
+        "protocol_id": 84
+      },
+      "minecraft:universal_anger": {
+        "protocol_id": 53
+      },
+      "minecraft:unreachable_tongue_targets": {
+        "protocol_id": 51
+      },
+      "minecraft:vibration_cooldown": {
+        "protocol_id": 85
+      },
       "minecraft:visible_adult_hoglin_count": {
-        "protocol_id": 72
+        "protocol_id": 70
       },
       "minecraft:visible_adult_piglin_count": {
-        "protocol_id": 71
+        "protocol_id": 69
       },
       "minecraft:visible_mobs": {
         "protocol_id": 7
@@ -11263,39 +9104,36 @@
         "protocol_id": 8
       },
       "minecraft:walk_target": {
-        "protocol_id": 13
+        "protocol_id": 12
       }
     },
-    "protocol_id": 25
+    "protocol_id": 27
   },
   "minecraft:menu": {
     "entries": {
       "minecraft:anvil": {
-        "protocol_id": 8
-      },
-      "minecraft:beacon": {
-        "protocol_id": 9
-      },
-      "minecraft:blast_furnace": {
-        "protocol_id": 10
-      },
-      "minecraft:brewing_stand": {
-        "protocol_id": 11
-      },
-      "minecraft:cartography_table": {
-        "protocol_id": 23
-      },
-      "minecraft:crafter_3x3": {
         "protocol_id": 7
       },
+      "minecraft:beacon": {
+        "protocol_id": 8
+      },
+      "minecraft:blast_furnace": {
+        "protocol_id": 9
+      },
+      "minecraft:brewing_stand": {
+        "protocol_id": 10
+      },
+      "minecraft:cartography_table": {
+        "protocol_id": 22
+      },
       "minecraft:crafting": {
-        "protocol_id": 12
+        "protocol_id": 11
       },
       "minecraft:enchantment": {
-        "protocol_id": 13
+        "protocol_id": 12
       },
       "minecraft:furnace": {
-        "protocol_id": 14
+        "protocol_id": 13
       },
       "minecraft:generic_3x3": {
         "protocol_id": 6
@@ -11319,517 +9157,524 @@
         "protocol_id": 5
       },
       "minecraft:grindstone": {
-        "protocol_id": 15
+        "protocol_id": 14
       },
       "minecraft:hopper": {
-        "protocol_id": 16
+        "protocol_id": 15
       },
       "minecraft:lectern": {
-        "protocol_id": 17
+        "protocol_id": 16
       },
       "minecraft:loom": {
-        "protocol_id": 18
+        "protocol_id": 17
       },
       "minecraft:merchant": {
-        "protocol_id": 19
+        "protocol_id": 18
       },
       "minecraft:shulker_box": {
-        "protocol_id": 20
+        "protocol_id": 19
       },
       "minecraft:smithing": {
-        "protocol_id": 21
+        "protocol_id": 20
       },
       "minecraft:smoker": {
-        "protocol_id": 22
+        "protocol_id": 21
       },
       "minecraft:stonecutter": {
-        "protocol_id": 24
+        "protocol_id": 23
       }
     },
-    "protocol_id": 15
+    "protocol_id": 17
   },
   "minecraft:mob_effect": {
     "entries": {
       "minecraft:absorption": {
-        "protocol_id": 21
-      },
-      "minecraft:bad_omen": {
-        "protocol_id": 30
-      },
-      "minecraft:blindness": {
-        "protocol_id": 14
-      },
-      "minecraft:conduit_power": {
-        "protocol_id": 28
-      },
-      "minecraft:darkness": {
-        "protocol_id": 32
-      },
-      "minecraft:dolphins_grace": {
-        "protocol_id": 29
-      },
-      "minecraft:fire_resistance": {
-        "protocol_id": 11
-      },
-      "minecraft:glowing": {
-        "protocol_id": 23
-      },
-      "minecraft:haste": {
-        "protocol_id": 2
-      },
-      "minecraft:health_boost": {
-        "protocol_id": 20
-      },
-      "minecraft:hero_of_the_village": {
-        "protocol_id": 31
-      },
-      "minecraft:hunger": {
-        "protocol_id": 16
-      },
-      "minecraft:infested": {
-        "protocol_id": 38
-      },
-      "minecraft:instant_damage": {
-        "protocol_id": 6
-      },
-      "minecraft:instant_health": {
-        "protocol_id": 5
-      },
-      "minecraft:invisibility": {
-        "protocol_id": 13
-      },
-      "minecraft:jump_boost": {
-        "protocol_id": 7
-      },
-      "minecraft:levitation": {
-        "protocol_id": 24
-      },
-      "minecraft:luck": {
-        "protocol_id": 25
-      },
-      "minecraft:mining_fatigue": {
-        "protocol_id": 3
-      },
-      "minecraft:nausea": {
-        "protocol_id": 8
-      },
-      "minecraft:night_vision": {
-        "protocol_id": 15
-      },
-      "minecraft:oozing": {
-        "protocol_id": 37
-      },
-      "minecraft:poison": {
-        "protocol_id": 18
-      },
-      "minecraft:raid_omen": {
-        "protocol_id": 34
-      },
-      "minecraft:regeneration": {
-        "protocol_id": 9
-      },
-      "minecraft:resistance": {
-        "protocol_id": 10
-      },
-      "minecraft:saturation": {
         "protocol_id": 22
       },
-      "minecraft:slow_falling": {
-        "protocol_id": 27
+      "minecraft:bad_omen": {
+        "protocol_id": 31
       },
-      "minecraft:slowness": {
-        "protocol_id": 1
+      "minecraft:blindness": {
+        "protocol_id": 15
       },
-      "minecraft:speed": {
-        "protocol_id": 0
+      "minecraft:conduit_power": {
+        "protocol_id": 29
       },
-      "minecraft:strength": {
-        "protocol_id": 4
-      },
-      "minecraft:trial_omen": {
+      "minecraft:darkness": {
         "protocol_id": 33
       },
-      "minecraft:unluck": {
-        "protocol_id": 26
+      "minecraft:dolphins_grace": {
+        "protocol_id": 30
       },
-      "minecraft:water_breathing": {
+      "minecraft:fire_resistance": {
         "protocol_id": 12
       },
-      "minecraft:weakness": {
+      "minecraft:glowing": {
+        "protocol_id": 24
+      },
+      "minecraft:haste": {
+        "protocol_id": 3
+      },
+      "minecraft:health_boost": {
+        "protocol_id": 21
+      },
+      "minecraft:hero_of_the_village": {
+        "protocol_id": 32
+      },
+      "minecraft:hunger": {
         "protocol_id": 17
       },
-      "minecraft:weaving": {
-        "protocol_id": 36
+      "minecraft:instant_damage": {
+        "protocol_id": 7
       },
-      "minecraft:wind_charged": {
-        "protocol_id": 35
+      "minecraft:instant_health": {
+        "protocol_id": 6
+      },
+      "minecraft:invisibility": {
+        "protocol_id": 14
+      },
+      "minecraft:jump_boost": {
+        "protocol_id": 8
+      },
+      "minecraft:levitation": {
+        "protocol_id": 25
+      },
+      "minecraft:luck": {
+        "protocol_id": 26
+      },
+      "minecraft:mining_fatigue": {
+        "protocol_id": 4
+      },
+      "minecraft:nausea": {
+        "protocol_id": 9
+      },
+      "minecraft:night_vision": {
+        "protocol_id": 16
+      },
+      "minecraft:poison": {
+        "protocol_id": 19
+      },
+      "minecraft:regeneration": {
+        "protocol_id": 10
+      },
+      "minecraft:resistance": {
+        "protocol_id": 11
+      },
+      "minecraft:saturation": {
+        "protocol_id": 23
+      },
+      "minecraft:slow_falling": {
+        "protocol_id": 28
+      },
+      "minecraft:slowness": {
+        "protocol_id": 2
+      },
+      "minecraft:speed": {
+        "protocol_id": 1
+      },
+      "minecraft:strength": {
+        "protocol_id": 5
+      },
+      "minecraft:unluck": {
+        "protocol_id": 27
+      },
+      "minecraft:water_breathing": {
+        "protocol_id": 13
+      },
+      "minecraft:weakness": {
+        "protocol_id": 18
+      },
+      "minecraft:wither": {
+        "protocol_id": 20
+      }
+    },
+    "protocol_id": 3
+  },
+  "minecraft:painting_variant": {
+    "default": "minecraft:kebab",
+    "entries": {
+      "minecraft:alban": {
+        "protocol_id": 2
+      },
+      "minecraft:aztec": {
+        "protocol_id": 1
+      },
+      "minecraft:aztec2": {
+        "protocol_id": 3
+      },
+      "minecraft:bomb": {
+        "protocol_id": 4
+      },
+      "minecraft:burning_skull": {
+        "protocol_id": 23
+      },
+      "minecraft:bust": {
+        "protocol_id": 15
+      },
+      "minecraft:courbet": {
+        "protocol_id": 8
+      },
+      "minecraft:creebet": {
+        "protocol_id": 11
+      },
+      "minecraft:donkey_kong": {
+        "protocol_id": 29
+      },
+      "minecraft:earth": {
+        "protocol_id": 25
+      },
+      "minecraft:fighters": {
+        "protocol_id": 20
+      },
+      "minecraft:fire": {
+        "protocol_id": 28
+      },
+      "minecraft:graham": {
+        "protocol_id": 13
+      },
+      "minecraft:kebab": {
+        "protocol_id": 0
+      },
+      "minecraft:match": {
+        "protocol_id": 14
+      },
+      "minecraft:pigscene": {
+        "protocol_id": 22
+      },
+      "minecraft:plant": {
+        "protocol_id": 5
+      },
+      "minecraft:pointer": {
+        "protocol_id": 21
+      },
+      "minecraft:pool": {
+        "protocol_id": 7
+      },
+      "minecraft:sea": {
+        "protocol_id": 9
+      },
+      "minecraft:skeleton": {
+        "protocol_id": 24
+      },
+      "minecraft:skull_and_roses": {
+        "protocol_id": 18
+      },
+      "minecraft:stage": {
+        "protocol_id": 16
+      },
+      "minecraft:sunset": {
+        "protocol_id": 10
+      },
+      "minecraft:void": {
+        "protocol_id": 17
+      },
+      "minecraft:wanderer": {
+        "protocol_id": 12
+      },
+      "minecraft:wasteland": {
+        "protocol_id": 6
+      },
+      "minecraft:water": {
+        "protocol_id": 27
+      },
+      "minecraft:wind": {
+        "protocol_id": 26
       },
       "minecraft:wither": {
         "protocol_id": 19
       }
     },
-    "protocol_id": 3
-  },
-  "minecraft:number_format_type": {
-    "entries": {
-      "minecraft:blank": {
-        "protocol_id": 0
-      },
-      "minecraft:fixed": {
-        "protocol_id": 2
-      },
-      "minecraft:styled": {
-        "protocol_id": 1
-      }
-    },
-    "protocol_id": 63
+    "protocol_id": 11
   },
   "minecraft:particle_type": {
     "entries": {
-      "minecraft:angry_villager": {
+      "minecraft:ambient_entity_effect": {
         "protocol_id": 0
       },
-      "minecraft:ash": {
-        "protocol_id": 81
-      },
-      "minecraft:block": {
+      "minecraft:angry_villager": {
         "protocol_id": 1
       },
-      "minecraft:block_crumble": {
-        "protocol_id": 112
-      },
-      "minecraft:block_marker": {
-        "protocol_id": 2
-      },
-      "minecraft:bubble": {
-        "protocol_id": 3
-      },
-      "minecraft:bubble_column_up": {
-        "protocol_id": 71
-      },
-      "minecraft:bubble_pop": {
-        "protocol_id": 69
-      },
-      "minecraft:campfire_cosy_smoke": {
-        "protocol_id": 74
-      },
-      "minecraft:campfire_signal_smoke": {
-        "protocol_id": 75
-      },
-      "minecraft:cherry_leaves": {
-        "protocol_id": 33
-      },
-      "minecraft:cloud": {
-        "protocol_id": 4
-      },
-      "minecraft:composter": {
-        "protocol_id": 43
-      },
-      "minecraft:crimson_spore": {
-        "protocol_id": 82
-      },
-      "minecraft:crit": {
-        "protocol_id": 5
-      },
-      "minecraft:current_down": {
-        "protocol_id": 70
-      },
-      "minecraft:damage_indicator": {
-        "protocol_id": 6
-      },
-      "minecraft:dolphin": {
-        "protocol_id": 73
-      },
-      "minecraft:dragon_breath": {
-        "protocol_id": 7
-      },
-      "minecraft:dripping_dripstone_lava": {
-        "protocol_id": 92
-      },
-      "minecraft:dripping_dripstone_water": {
-        "protocol_id": 94
-      },
-      "minecraft:dripping_honey": {
-        "protocol_id": 76
-      },
-      "minecraft:dripping_lava": {
-        "protocol_id": 8
-      },
-      "minecraft:dripping_obsidian_tear": {
-        "protocol_id": 85
-      },
-      "minecraft:dripping_water": {
-        "protocol_id": 11
-      },
-      "minecraft:dust": {
-        "protocol_id": 13
-      },
-      "minecraft:dust_color_transition": {
-        "protocol_id": 14
-      },
-      "minecraft:dust_pillar": {
-        "protocol_id": 108
-      },
-      "minecraft:dust_plume": {
-        "protocol_id": 104
-      },
-      "minecraft:effect": {
-        "protocol_id": 15
-      },
-      "minecraft:egg_crack": {
-        "protocol_id": 103
-      },
-      "minecraft:elder_guardian": {
-        "protocol_id": 16
-      },
-      "minecraft:electric_spark": {
-        "protocol_id": 100
-      },
-      "minecraft:enchant": {
-        "protocol_id": 18
-      },
-      "minecraft:enchanted_hit": {
-        "protocol_id": 17
-      },
-      "minecraft:end_rod": {
-        "protocol_id": 19
-      },
-      "minecraft:entity_effect": {
-        "protocol_id": 20
-      },
-      "minecraft:explosion": {
-        "protocol_id": 22
-      },
-      "minecraft:explosion_emitter": {
-        "protocol_id": 21
-      },
-      "minecraft:falling_dripstone_lava": {
-        "protocol_id": 93
-      },
-      "minecraft:falling_dripstone_water": {
-        "protocol_id": 95
-      },
-      "minecraft:falling_dust": {
-        "protocol_id": 28
-      },
-      "minecraft:falling_honey": {
-        "protocol_id": 77
-      },
-      "minecraft:falling_lava": {
-        "protocol_id": 9
-      },
-      "minecraft:falling_nectar": {
-        "protocol_id": 79
-      },
-      "minecraft:falling_obsidian_tear": {
-        "protocol_id": 86
-      },
-      "minecraft:falling_spore_blossom": {
-        "protocol_id": 80
-      },
-      "minecraft:falling_water": {
-        "protocol_id": 12
-      },
-      "minecraft:firefly": {
-        "protocol_id": 113
-      },
-      "minecraft:firework": {
-        "protocol_id": 29
-      },
-      "minecraft:fishing": {
-        "protocol_id": 30
-      },
-      "minecraft:flame": {
-        "protocol_id": 31
-      },
-      "minecraft:flash": {
-        "protocol_id": 41
-      },
-      "minecraft:glow": {
-        "protocol_id": 97
-      },
-      "minecraft:glow_squid_ink": {
-        "protocol_id": 96
-      },
-      "minecraft:gust": {
-        "protocol_id": 23
-      },
-      "minecraft:gust_emitter_large": {
-        "protocol_id": 25
-      },
-      "minecraft:gust_emitter_small": {
-        "protocol_id": 26
-      },
-      "minecraft:happy_villager": {
-        "protocol_id": 42
-      },
-      "minecraft:heart": {
-        "protocol_id": 44
-      },
-      "minecraft:infested": {
-        "protocol_id": 32
-      },
-      "minecraft:instant_effect": {
-        "protocol_id": 45
-      },
-      "minecraft:item": {
-        "protocol_id": 46
-      },
-      "minecraft:item_cobweb": {
-        "protocol_id": 50
-      },
-      "minecraft:item_slime": {
-        "protocol_id": 49
-      },
-      "minecraft:item_snowball": {
-        "protocol_id": 51
-      },
-      "minecraft:landing_honey": {
-        "protocol_id": 78
-      },
-      "minecraft:landing_lava": {
-        "protocol_id": 10
-      },
-      "minecraft:landing_obsidian_tear": {
-        "protocol_id": 87
-      },
-      "minecraft:large_smoke": {
-        "protocol_id": 52
-      },
-      "minecraft:lava": {
-        "protocol_id": 53
-      },
-      "minecraft:mycelium": {
-        "protocol_id": 54
-      },
-      "minecraft:nautilus": {
+      "minecraft:ash": {
         "protocol_id": 72
       },
-      "minecraft:note": {
-        "protocol_id": 55
+      "minecraft:block": {
+        "protocol_id": 2
       },
-      "minecraft:ominous_spawning": {
-        "protocol_id": 109
+      "minecraft:block_marker": {
+        "protocol_id": 3
       },
-      "minecraft:pale_oak_leaves": {
-        "protocol_id": 34
+      "minecraft:bubble": {
+        "protocol_id": 4
       },
-      "minecraft:poof": {
-        "protocol_id": 56
-      },
-      "minecraft:portal": {
-        "protocol_id": 57
-      },
-      "minecraft:raid_omen": {
-        "protocol_id": 110
-      },
-      "minecraft:rain": {
-        "protocol_id": 58
-      },
-      "minecraft:reverse_portal": {
-        "protocol_id": 88
-      },
-      "minecraft:scrape": {
-        "protocol_id": 101
-      },
-      "minecraft:sculk_charge": {
-        "protocol_id": 37
-      },
-      "minecraft:sculk_charge_pop": {
-        "protocol_id": 38
-      },
-      "minecraft:sculk_soul": {
-        "protocol_id": 36
-      },
-      "minecraft:shriek": {
-        "protocol_id": 102
-      },
-      "minecraft:small_flame": {
-        "protocol_id": 90
-      },
-      "minecraft:small_gust": {
-        "protocol_id": 24
-      },
-      "minecraft:smoke": {
-        "protocol_id": 59
-      },
-      "minecraft:sneeze": {
-        "protocol_id": 61
-      },
-      "minecraft:snowflake": {
-        "protocol_id": 91
-      },
-      "minecraft:sonic_boom": {
-        "protocol_id": 27
-      },
-      "minecraft:soul": {
-        "protocol_id": 40
-      },
-      "minecraft:soul_fire_flame": {
-        "protocol_id": 39
-      },
-      "minecraft:spit": {
+      "minecraft:bubble_column_up": {
         "protocol_id": 62
       },
-      "minecraft:splash": {
-        "protocol_id": 67
-      },
-      "minecraft:spore_blossom_air": {
-        "protocol_id": 84
-      },
-      "minecraft:squid_ink": {
-        "protocol_id": 63
-      },
-      "minecraft:sweep_attack": {
-        "protocol_id": 64
-      },
-      "minecraft:tinted_leaves": {
-        "protocol_id": 35
-      },
-      "minecraft:totem_of_undying": {
-        "protocol_id": 65
-      },
-      "minecraft:trail": {
-        "protocol_id": 48
-      },
-      "minecraft:trial_omen": {
-        "protocol_id": 111
-      },
-      "minecraft:trial_spawner_detection": {
-        "protocol_id": 105
-      },
-      "minecraft:trial_spawner_detection_ominous": {
-        "protocol_id": 106
-      },
-      "minecraft:underwater": {
-        "protocol_id": 66
-      },
-      "minecraft:vault_connection": {
-        "protocol_id": 107
-      },
-      "minecraft:vibration": {
-        "protocol_id": 47
-      },
-      "minecraft:warped_spore": {
-        "protocol_id": 83
-      },
-      "minecraft:wax_off": {
-        "protocol_id": 99
-      },
-      "minecraft:wax_on": {
-        "protocol_id": 98
-      },
-      "minecraft:white_ash": {
-        "protocol_id": 89
-      },
-      "minecraft:white_smoke": {
+      "minecraft:bubble_pop": {
         "protocol_id": 60
       },
-      "minecraft:witch": {
+      "minecraft:campfire_cosy_smoke": {
+        "protocol_id": 65
+      },
+      "minecraft:campfire_signal_smoke": {
+        "protocol_id": 66
+      },
+      "minecraft:cherry_leaves": {
+        "protocol_id": 29
+      },
+      "minecraft:cloud": {
+        "protocol_id": 5
+      },
+      "minecraft:composter": {
+        "protocol_id": 37
+      },
+      "minecraft:crimson_spore": {
+        "protocol_id": 73
+      },
+      "minecraft:crit": {
+        "protocol_id": 6
+      },
+      "minecraft:current_down": {
+        "protocol_id": 61
+      },
+      "minecraft:damage_indicator": {
+        "protocol_id": 7
+      },
+      "minecraft:dolphin": {
+        "protocol_id": 64
+      },
+      "minecraft:dragon_breath": {
+        "protocol_id": 8
+      },
+      "minecraft:dripping_dripstone_lava": {
+        "protocol_id": 83
+      },
+      "minecraft:dripping_dripstone_water": {
+        "protocol_id": 85
+      },
+      "minecraft:dripping_honey": {
+        "protocol_id": 67
+      },
+      "minecraft:dripping_lava": {
+        "protocol_id": 9
+      },
+      "minecraft:dripping_obsidian_tear": {
+        "protocol_id": 76
+      },
+      "minecraft:dripping_water": {
+        "protocol_id": 12
+      },
+      "minecraft:dust": {
+        "protocol_id": 14
+      },
+      "minecraft:dust_color_transition": {
+        "protocol_id": 15
+      },
+      "minecraft:effect": {
+        "protocol_id": 16
+      },
+      "minecraft:egg_crack": {
+        "protocol_id": 94
+      },
+      "minecraft:elder_guardian": {
+        "protocol_id": 17
+      },
+      "minecraft:electric_spark": {
+        "protocol_id": 91
+      },
+      "minecraft:enchant": {
+        "protocol_id": 19
+      },
+      "minecraft:enchanted_hit": {
+        "protocol_id": 18
+      },
+      "minecraft:end_rod": {
+        "protocol_id": 20
+      },
+      "minecraft:entity_effect": {
+        "protocol_id": 21
+      },
+      "minecraft:explosion": {
+        "protocol_id": 23
+      },
+      "minecraft:explosion_emitter": {
+        "protocol_id": 22
+      },
+      "minecraft:falling_dripstone_lava": {
+        "protocol_id": 84
+      },
+      "minecraft:falling_dripstone_water": {
+        "protocol_id": 86
+      },
+      "minecraft:falling_dust": {
+        "protocol_id": 25
+      },
+      "minecraft:falling_honey": {
         "protocol_id": 68
+      },
+      "minecraft:falling_lava": {
+        "protocol_id": 10
+      },
+      "minecraft:falling_nectar": {
+        "protocol_id": 70
+      },
+      "minecraft:falling_obsidian_tear": {
+        "protocol_id": 77
+      },
+      "minecraft:falling_spore_blossom": {
+        "protocol_id": 71
+      },
+      "minecraft:falling_water": {
+        "protocol_id": 13
+      },
+      "minecraft:firework": {
+        "protocol_id": 26
+      },
+      "minecraft:fishing": {
+        "protocol_id": 27
+      },
+      "minecraft:flame": {
+        "protocol_id": 28
+      },
+      "minecraft:flash": {
+        "protocol_id": 35
+      },
+      "minecraft:glow": {
+        "protocol_id": 88
+      },
+      "minecraft:glow_squid_ink": {
+        "protocol_id": 87
+      },
+      "minecraft:happy_villager": {
+        "protocol_id": 36
+      },
+      "minecraft:heart": {
+        "protocol_id": 38
+      },
+      "minecraft:instant_effect": {
+        "protocol_id": 39
+      },
+      "minecraft:item": {
+        "protocol_id": 40
+      },
+      "minecraft:item_slime": {
+        "protocol_id": 42
+      },
+      "minecraft:item_snowball": {
+        "protocol_id": 43
+      },
+      "minecraft:landing_honey": {
+        "protocol_id": 69
+      },
+      "minecraft:landing_lava": {
+        "protocol_id": 11
+      },
+      "minecraft:landing_obsidian_tear": {
+        "protocol_id": 78
+      },
+      "minecraft:large_smoke": {
+        "protocol_id": 44
+      },
+      "minecraft:lava": {
+        "protocol_id": 45
+      },
+      "minecraft:mycelium": {
+        "protocol_id": 46
+      },
+      "minecraft:nautilus": {
+        "protocol_id": 63
+      },
+      "minecraft:note": {
+        "protocol_id": 47
+      },
+      "minecraft:poof": {
+        "protocol_id": 48
+      },
+      "minecraft:portal": {
+        "protocol_id": 49
+      },
+      "minecraft:rain": {
+        "protocol_id": 50
+      },
+      "minecraft:reverse_portal": {
+        "protocol_id": 79
+      },
+      "minecraft:scrape": {
+        "protocol_id": 92
+      },
+      "minecraft:sculk_charge": {
+        "protocol_id": 31
+      },
+      "minecraft:sculk_charge_pop": {
+        "protocol_id": 32
+      },
+      "minecraft:sculk_soul": {
+        "protocol_id": 30
+      },
+      "minecraft:shriek": {
+        "protocol_id": 93
+      },
+      "minecraft:small_flame": {
+        "protocol_id": 81
+      },
+      "minecraft:smoke": {
+        "protocol_id": 51
+      },
+      "minecraft:sneeze": {
+        "protocol_id": 52
+      },
+      "minecraft:snowflake": {
+        "protocol_id": 82
+      },
+      "minecraft:sonic_boom": {
+        "protocol_id": 24
+      },
+      "minecraft:soul": {
+        "protocol_id": 34
+      },
+      "minecraft:soul_fire_flame": {
+        "protocol_id": 33
+      },
+      "minecraft:spit": {
+        "protocol_id": 53
+      },
+      "minecraft:splash": {
+        "protocol_id": 58
+      },
+      "minecraft:spore_blossom_air": {
+        "protocol_id": 75
+      },
+      "minecraft:squid_ink": {
+        "protocol_id": 54
+      },
+      "minecraft:sweep_attack": {
+        "protocol_id": 55
+      },
+      "minecraft:totem_of_undying": {
+        "protocol_id": 56
+      },
+      "minecraft:underwater": {
+        "protocol_id": 57
+      },
+      "minecraft:vibration": {
+        "protocol_id": 41
+      },
+      "minecraft:warped_spore": {
+        "protocol_id": 74
+      },
+      "minecraft:wax_off": {
+        "protocol_id": 90
+      },
+      "minecraft:wax_on": {
+        "protocol_id": 89
+      },
+      "minecraft:white_ash": {
+        "protocol_id": 80
+      },
+      "minecraft:witch": {
+        "protocol_id": 59
       }
     },
-    "protocol_id": 8
+    "protocol_id": 9
   },
   "minecraft:point_of_interest_type": {
     "entries": {
@@ -11894,7 +9739,7 @@
         "protocol_id": 12
       }
     },
-    "protocol_id": 24
+    "protocol_id": 26
   },
   "minecraft:pos_rule_test": {
     "entries": {
@@ -11908,7 +9753,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 14
+    "protocol_id": 16
   },
   "minecraft:position_source_type": {
     "entries": {
@@ -11919,225 +9764,153 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 19
+    "protocol_id": 21
   },
   "minecraft:potion": {
+    "default": "minecraft:empty",
     "entries": {
       "minecraft:awkward": {
-        "protocol_id": 3
+        "protocol_id": 4
+      },
+      "minecraft:empty": {
+        "protocol_id": 0
       },
       "minecraft:fire_resistance": {
-        "protocol_id": 11
+        "protocol_id": 12
       },
       "minecraft:harming": {
-        "protocol_id": 26
-      },
-      "minecraft:healing": {
-        "protocol_id": 24
-      },
-      "minecraft:infested": {
-        "protocol_id": 45
-      },
-      "minecraft:invisibility": {
-        "protocol_id": 6
-      },
-      "minecraft:leaping": {
-        "protocol_id": 8
-      },
-      "minecraft:long_fire_resistance": {
-        "protocol_id": 12
-      },
-      "minecraft:long_invisibility": {
-        "protocol_id": 7
-      },
-      "minecraft:long_leaping": {
-        "protocol_id": 9
-      },
-      "minecraft:long_night_vision": {
-        "protocol_id": 5
-      },
-      "minecraft:long_poison": {
-        "protocol_id": 29
-      },
-      "minecraft:long_regeneration": {
-        "protocol_id": 32
-      },
-      "minecraft:long_slow_falling": {
-        "protocol_id": 41
-      },
-      "minecraft:long_slowness": {
-        "protocol_id": 17
-      },
-      "minecraft:long_strength": {
-        "protocol_id": 35
-      },
-      "minecraft:long_swiftness": {
-        "protocol_id": 14
-      },
-      "minecraft:long_turtle_master": {
-        "protocol_id": 20
-      },
-      "minecraft:long_water_breathing": {
-        "protocol_id": 23
-      },
-      "minecraft:long_weakness": {
-        "protocol_id": 38
-      },
-      "minecraft:luck": {
-        "protocol_id": 39
-      },
-      "minecraft:mundane": {
-        "protocol_id": 1
-      },
-      "minecraft:night_vision": {
-        "protocol_id": 4
-      },
-      "minecraft:oozing": {
-        "protocol_id": 44
-      },
-      "minecraft:poison": {
-        "protocol_id": 28
-      },
-      "minecraft:regeneration": {
-        "protocol_id": 31
-      },
-      "minecraft:slow_falling": {
-        "protocol_id": 40
-      },
-      "minecraft:slowness": {
-        "protocol_id": 16
-      },
-      "minecraft:strength": {
-        "protocol_id": 34
-      },
-      "minecraft:strong_harming": {
         "protocol_id": 27
       },
-      "minecraft:strong_healing": {
+      "minecraft:healing": {
         "protocol_id": 25
       },
-      "minecraft:strong_leaping": {
-        "protocol_id": 10
-      },
-      "minecraft:strong_poison": {
-        "protocol_id": 30
-      },
-      "minecraft:strong_regeneration": {
-        "protocol_id": 33
-      },
-      "minecraft:strong_slowness": {
-        "protocol_id": 18
-      },
-      "minecraft:strong_strength": {
-        "protocol_id": 36
-      },
-      "minecraft:strong_swiftness": {
-        "protocol_id": 15
-      },
-      "minecraft:strong_turtle_master": {
-        "protocol_id": 21
-      },
-      "minecraft:swiftness": {
-        "protocol_id": 13
-      },
-      "minecraft:thick": {
-        "protocol_id": 2
-      },
-      "minecraft:turtle_master": {
-        "protocol_id": 19
-      },
-      "minecraft:water": {
-        "protocol_id": 0
-      },
-      "minecraft:water_breathing": {
-        "protocol_id": 22
-      },
-      "minecraft:weakness": {
-        "protocol_id": 37
-      },
-      "minecraft:weaving": {
-        "protocol_id": 43
-      },
-      "minecraft:wind_charged": {
-        "protocol_id": 42
-      }
-    },
-    "protocol_id": 7
-  },
-  "minecraft:recipe_book_category": {
-    "entries": {
-      "minecraft:blast_furnace_blocks": {
+      "minecraft:invisibility": {
         "protocol_id": 7
       },
-      "minecraft:blast_furnace_misc": {
-        "protocol_id": 8
-      },
-      "minecraft:campfire": {
-        "protocol_id": 12
-      },
-      "minecraft:crafting_building_blocks": {
-        "protocol_id": 0
-      },
-      "minecraft:crafting_equipment": {
-        "protocol_id": 2
-      },
-      "minecraft:crafting_misc": {
-        "protocol_id": 3
-      },
-      "minecraft:crafting_redstone": {
-        "protocol_id": 1
-      },
-      "minecraft:furnace_blocks": {
-        "protocol_id": 5
-      },
-      "minecraft:furnace_food": {
-        "protocol_id": 4
-      },
-      "minecraft:furnace_misc": {
-        "protocol_id": 6
-      },
-      "minecraft:smithing": {
-        "protocol_id": 11
-      },
-      "minecraft:smoker_food": {
+      "minecraft:leaping": {
         "protocol_id": 9
       },
-      "minecraft:stonecutter": {
+      "minecraft:long_fire_resistance": {
+        "protocol_id": 13
+      },
+      "minecraft:long_invisibility": {
+        "protocol_id": 8
+      },
+      "minecraft:long_leaping": {
         "protocol_id": 10
-      }
-    },
-    "protocol_id": 77
-  },
-  "minecraft:recipe_display": {
-    "entries": {
-      "minecraft:crafting_shaped": {
-        "protocol_id": 1
       },
-      "minecraft:crafting_shapeless": {
-        "protocol_id": 0
+      "minecraft:long_night_vision": {
+        "protocol_id": 6
       },
-      "minecraft:furnace": {
+      "minecraft:long_poison": {
+        "protocol_id": 30
+      },
+      "minecraft:long_regeneration": {
+        "protocol_id": 33
+      },
+      "minecraft:long_slow_falling": {
+        "protocol_id": 42
+      },
+      "minecraft:long_slowness": {
+        "protocol_id": 18
+      },
+      "minecraft:long_strength": {
+        "protocol_id": 36
+      },
+      "minecraft:long_swiftness": {
+        "protocol_id": 15
+      },
+      "minecraft:long_turtle_master": {
+        "protocol_id": 21
+      },
+      "minecraft:long_water_breathing": {
+        "protocol_id": 24
+      },
+      "minecraft:long_weakness": {
+        "protocol_id": 39
+      },
+      "minecraft:luck": {
+        "protocol_id": 40
+      },
+      "minecraft:mundane": {
         "protocol_id": 2
       },
-      "minecraft:smithing": {
-        "protocol_id": 4
+      "minecraft:night_vision": {
+        "protocol_id": 5
       },
-      "minecraft:stonecutter": {
+      "minecraft:poison": {
+        "protocol_id": 29
+      },
+      "minecraft:regeneration": {
+        "protocol_id": 32
+      },
+      "minecraft:slow_falling": {
+        "protocol_id": 41
+      },
+      "minecraft:slowness": {
+        "protocol_id": 17
+      },
+      "minecraft:strength": {
+        "protocol_id": 35
+      },
+      "minecraft:strong_harming": {
+        "protocol_id": 28
+      },
+      "minecraft:strong_healing": {
+        "protocol_id": 26
+      },
+      "minecraft:strong_leaping": {
+        "protocol_id": 11
+      },
+      "minecraft:strong_poison": {
+        "protocol_id": 31
+      },
+      "minecraft:strong_regeneration": {
+        "protocol_id": 34
+      },
+      "minecraft:strong_slowness": {
+        "protocol_id": 19
+      },
+      "minecraft:strong_strength": {
+        "protocol_id": 37
+      },
+      "minecraft:strong_swiftness": {
+        "protocol_id": 16
+      },
+      "minecraft:strong_turtle_master": {
+        "protocol_id": 22
+      },
+      "minecraft:swiftness": {
+        "protocol_id": 14
+      },
+      "minecraft:thick": {
         "protocol_id": 3
+      },
+      "minecraft:turtle_master": {
+        "protocol_id": 20
+      },
+      "minecraft:water": {
+        "protocol_id": 1
+      },
+      "minecraft:water_breathing": {
+        "protocol_id": 23
+      },
+      "minecraft:weakness": {
+        "protocol_id": 38
       }
     },
-    "protocol_id": 75
+    "protocol_id": 8
   },
   "minecraft:recipe_serializer": {
     "entries": {
       "minecraft:blasting": {
-        "protocol_id": 15
+        "protocol_id": 16
       },
       "minecraft:campfire_cooking": {
-        "protocol_id": 17
+        "protocol_id": 18
       },
       "minecraft:crafting_decorated_pot": {
-        "protocol_id": 21
+        "protocol_id": 22
       },
       "minecraft:crafting_shaped": {
         "protocol_id": 0
@@ -12170,34 +9943,37 @@
         "protocol_id": 5
       },
       "minecraft:crafting_special_repairitem": {
-        "protocol_id": 13
+        "protocol_id": 14
       },
       "minecraft:crafting_special_shielddecoration": {
         "protocol_id": 11
       },
+      "minecraft:crafting_special_shulkerboxcoloring": {
+        "protocol_id": 12
+      },
+      "minecraft:crafting_special_suspiciousstew": {
+        "protocol_id": 13
+      },
       "minecraft:crafting_special_tippedarrow": {
         "protocol_id": 9
       },
-      "minecraft:crafting_transmute": {
-        "protocol_id": 12
-      },
       "minecraft:smelting": {
-        "protocol_id": 14
+        "protocol_id": 15
       },
       "minecraft:smithing_transform": {
-        "protocol_id": 19
-      },
-      "minecraft:smithing_trim": {
         "protocol_id": 20
       },
+      "minecraft:smithing_trim": {
+        "protocol_id": 21
+      },
       "minecraft:smoking": {
-        "protocol_id": 16
+        "protocol_id": 17
       },
       "minecraft:stonecutting": {
-        "protocol_id": 18
+        "protocol_id": 19
       }
     },
-    "protocol_id": 17
+    "protocol_id": 19
   },
   "minecraft:recipe_type": {
     "entries": {
@@ -12223,7 +9999,7 @@
         "protocol_id": 5
       }
     },
-    "protocol_id": 16
+    "protocol_id": 18
   },
   "minecraft:rule_block_entity_modifier": {
     "entries": {
@@ -12240,7 +10016,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 13
+    "protocol_id": 15
   },
   "minecraft:rule_test": {
     "entries": {
@@ -12263,7 +10039,7 @@
         "protocol_id": 3
       }
     },
-    "protocol_id": 12
+    "protocol_id": 14
   },
   "minecraft:schedule": {
     "entries": {
@@ -12280,55 +10056,46 @@
         "protocol_id": 3
       }
     },
-    "protocol_id": 27
+    "protocol_id": 29
   },
   "minecraft:sensor_type": {
     "default": "minecraft:dummy",
     "entries": {
-      "minecraft:armadillo_scare_detected": {
-        "protocol_id": 10
-      },
-      "minecraft:armadillo_temptations": {
-        "protocol_id": 20
-      },
       "minecraft:axolotl_attackables": {
-        "protocol_id": 15
+        "protocol_id": 14
       },
       "minecraft:axolotl_temptations": {
-        "protocol_id": 16
-      },
-      "minecraft:breeze_attack_entity_sensor": {
-        "protocol_id": 25
+        "protocol_id": 15
       },
       "minecraft:camel_temptations": {
-        "protocol_id": 19
+        "protocol_id": 18
       },
       "minecraft:dummy": {
         "protocol_id": 0
       },
       "minecraft:frog_attackables": {
-        "protocol_id": 21
+        "protocol_id": 19
       },
       "minecraft:frog_temptations": {
-        "protocol_id": 18
+        "protocol_id": 17
       },
       "minecraft:goat_temptations": {
-        "protocol_id": 17
+        "protocol_id": 16
       },
       "minecraft:golem_detected": {
         "protocol_id": 9
       },
       "minecraft:hoglin_specific_sensor": {
-        "protocol_id": 13
+        "protocol_id": 12
       },
       "minecraft:hurt_by": {
         "protocol_id": 5
       },
       "minecraft:is_in_water": {
-        "protocol_id": 22
+        "protocol_id": 20
       },
       "minecraft:nearest_adult": {
-        "protocol_id": 14
+        "protocol_id": 13
       },
       "minecraft:nearest_bed": {
         "protocol_id": 4
@@ -12343,16 +10110,16 @@
         "protocol_id": 3
       },
       "minecraft:piglin_brute_specific_sensor": {
-        "protocol_id": 12
+        "protocol_id": 11
       },
       "minecraft:piglin_specific_sensor": {
-        "protocol_id": 11
+        "protocol_id": 10
       },
       "minecraft:secondary_pois": {
         "protocol_id": 8
       },
       "minecraft:sniffer_temptations": {
-        "protocol_id": 24
+        "protocol_id": 22
       },
       "minecraft:villager_babies": {
         "protocol_id": 7
@@ -12361,39 +10128,10 @@
         "protocol_id": 6
       },
       "minecraft:warden_entity_sensor": {
-        "protocol_id": 23
+        "protocol_id": 21
       }
     },
-    "protocol_id": 26
-  },
-  "minecraft:slot_display": {
-    "entries": {
-      "minecraft:any_fuel": {
-        "protocol_id": 1
-      },
-      "minecraft:composite": {
-        "protocol_id": 7
-      },
-      "minecraft:empty": {
-        "protocol_id": 0
-      },
-      "minecraft:item": {
-        "protocol_id": 2
-      },
-      "minecraft:item_stack": {
-        "protocol_id": 3
-      },
-      "minecraft:smithing_trim": {
-        "protocol_id": 5
-      },
-      "minecraft:tag": {
-        "protocol_id": 4
-      },
-      "minecraft:with_remainder": {
-        "protocol_id": 6
-      }
-    },
-    "protocol_id": 76
+    "protocol_id": 28
   },
   "minecraft:sound_event": {
     "entries": {
@@ -12539,2245 +10277,1864 @@
         "protocol_id": 53
       },
       "minecraft:block.azalea.break": {
-        "protocol_id": 95
+        "protocol_id": 80
       },
       "minecraft:block.azalea.fall": {
-        "protocol_id": 96
+        "protocol_id": 81
       },
       "minecraft:block.azalea.hit": {
-        "protocol_id": 97
+        "protocol_id": 82
       },
       "minecraft:block.azalea.place": {
-        "protocol_id": 98
+        "protocol_id": 83
       },
       "minecraft:block.azalea.step": {
-        "protocol_id": 99
+        "protocol_id": 84
       },
       "minecraft:block.azalea_leaves.break": {
-        "protocol_id": 100
+        "protocol_id": 85
       },
       "minecraft:block.azalea_leaves.fall": {
-        "protocol_id": 101
+        "protocol_id": 86
       },
       "minecraft:block.azalea_leaves.hit": {
-        "protocol_id": 102
+        "protocol_id": 87
       },
       "minecraft:block.azalea_leaves.place": {
-        "protocol_id": 103
+        "protocol_id": 88
       },
       "minecraft:block.azalea_leaves.step": {
-        "protocol_id": 104
+        "protocol_id": 89
       },
       "minecraft:block.bamboo.break": {
-        "protocol_id": 105
+        "protocol_id": 90
       },
       "minecraft:block.bamboo.fall": {
-        "protocol_id": 106
+        "protocol_id": 91
       },
       "minecraft:block.bamboo.hit": {
-        "protocol_id": 107
+        "protocol_id": 92
       },
       "minecraft:block.bamboo.place": {
-        "protocol_id": 108
+        "protocol_id": 93
       },
       "minecraft:block.bamboo.step": {
-        "protocol_id": 109
+        "protocol_id": 94
       },
       "minecraft:block.bamboo_sapling.break": {
-        "protocol_id": 110
+        "protocol_id": 95
       },
       "minecraft:block.bamboo_sapling.hit": {
-        "protocol_id": 111
+        "protocol_id": 96
       },
       "minecraft:block.bamboo_sapling.place": {
-        "protocol_id": 112
+        "protocol_id": 97
       },
       "minecraft:block.bamboo_wood.break": {
-        "protocol_id": 113
+        "protocol_id": 98
       },
       "minecraft:block.bamboo_wood.fall": {
-        "protocol_id": 114
+        "protocol_id": 99
       },
       "minecraft:block.bamboo_wood.hit": {
-        "protocol_id": 115
+        "protocol_id": 100
       },
       "minecraft:block.bamboo_wood.place": {
-        "protocol_id": 116
+        "protocol_id": 101
       },
       "minecraft:block.bamboo_wood.step": {
-        "protocol_id": 117
+        "protocol_id": 102
       },
       "minecraft:block.bamboo_wood_button.click_off": {
-        "protocol_id": 122
+        "protocol_id": 107
       },
       "minecraft:block.bamboo_wood_button.click_on": {
-        "protocol_id": 123
+        "protocol_id": 108
       },
       "minecraft:block.bamboo_wood_door.close": {
-        "protocol_id": 118
+        "protocol_id": 103
       },
       "minecraft:block.bamboo_wood_door.open": {
-        "protocol_id": 119
+        "protocol_id": 104
       },
       "minecraft:block.bamboo_wood_fence_gate.close": {
-        "protocol_id": 126
+        "protocol_id": 111
       },
       "minecraft:block.bamboo_wood_fence_gate.open": {
-        "protocol_id": 127
+        "protocol_id": 112
       },
       "minecraft:block.bamboo_wood_hanging_sign.break": {
-        "protocol_id": 697
+        "protocol_id": 605
       },
       "minecraft:block.bamboo_wood_hanging_sign.fall": {
-        "protocol_id": 698
+        "protocol_id": 606
       },
       "minecraft:block.bamboo_wood_hanging_sign.hit": {
-        "protocol_id": 699
+        "protocol_id": 607
       },
       "minecraft:block.bamboo_wood_hanging_sign.place": {
-        "protocol_id": 700
+        "protocol_id": 608
       },
       "minecraft:block.bamboo_wood_hanging_sign.step": {
-        "protocol_id": 696
+        "protocol_id": 604
       },
       "minecraft:block.bamboo_wood_pressure_plate.click_off": {
-        "protocol_id": 124
+        "protocol_id": 109
       },
       "minecraft:block.bamboo_wood_pressure_plate.click_on": {
-        "protocol_id": 125
+        "protocol_id": 110
       },
       "minecraft:block.bamboo_wood_trapdoor.close": {
-        "protocol_id": 120
+        "protocol_id": 105
       },
       "minecraft:block.bamboo_wood_trapdoor.open": {
-        "protocol_id": 121
+        "protocol_id": 106
       },
       "minecraft:block.barrel.close": {
-        "protocol_id": 128
+        "protocol_id": 113
       },
       "minecraft:block.barrel.open": {
-        "protocol_id": 129
+        "protocol_id": 114
       },
       "minecraft:block.basalt.break": {
-        "protocol_id": 130
+        "protocol_id": 115
       },
       "minecraft:block.basalt.fall": {
-        "protocol_id": 134
+        "protocol_id": 119
       },
       "minecraft:block.basalt.hit": {
-        "protocol_id": 133
+        "protocol_id": 118
       },
       "minecraft:block.basalt.place": {
-        "protocol_id": 132
+        "protocol_id": 117
       },
       "minecraft:block.basalt.step": {
-        "protocol_id": 131
+        "protocol_id": 116
       },
       "minecraft:block.beacon.activate": {
-        "protocol_id": 140
+        "protocol_id": 125
       },
       "minecraft:block.beacon.ambient": {
-        "protocol_id": 141
+        "protocol_id": 126
       },
       "minecraft:block.beacon.deactivate": {
-        "protocol_id": 142
+        "protocol_id": 127
       },
       "minecraft:block.beacon.power_select": {
-        "protocol_id": 143
+        "protocol_id": 128
       },
       "minecraft:block.beehive.drip": {
-        "protocol_id": 150
+        "protocol_id": 135
       },
       "minecraft:block.beehive.enter": {
-        "protocol_id": 151
+        "protocol_id": 136
       },
       "minecraft:block.beehive.exit": {
-        "protocol_id": 152
+        "protocol_id": 137
       },
       "minecraft:block.beehive.shear": {
-        "protocol_id": 153
+        "protocol_id": 138
       },
       "minecraft:block.beehive.work": {
-        "protocol_id": 154
+        "protocol_id": 139
       },
       "minecraft:block.bell.resonate": {
-        "protocol_id": 156
+        "protocol_id": 141
       },
       "minecraft:block.bell.use": {
-        "protocol_id": 155
+        "protocol_id": 140
       },
       "minecraft:block.big_dripleaf.break": {
-        "protocol_id": 157
+        "protocol_id": 142
       },
       "minecraft:block.big_dripleaf.fall": {
-        "protocol_id": 158
+        "protocol_id": 143
       },
       "minecraft:block.big_dripleaf.hit": {
-        "protocol_id": 159
+        "protocol_id": 144
       },
       "minecraft:block.big_dripleaf.place": {
-        "protocol_id": 160
+        "protocol_id": 145
       },
       "minecraft:block.big_dripleaf.step": {
-        "protocol_id": 161
+        "protocol_id": 146
       },
       "minecraft:block.big_dripleaf.tilt_down": {
-        "protocol_id": 467
+        "protocol_id": 384
       },
       "minecraft:block.big_dripleaf.tilt_up": {
-        "protocol_id": 468
+        "protocol_id": 385
       },
       "minecraft:block.blastfurnace.fire_crackle": {
-        "protocol_id": 182
+        "protocol_id": 162
       },
       "minecraft:block.bone_block.break": {
-        "protocol_id": 174
+        "protocol_id": 154
       },
       "minecraft:block.bone_block.fall": {
-        "protocol_id": 175
+        "protocol_id": 155
       },
       "minecraft:block.bone_block.hit": {
-        "protocol_id": 176
+        "protocol_id": 156
       },
       "minecraft:block.bone_block.place": {
-        "protocol_id": 177
+        "protocol_id": 157
       },
       "minecraft:block.bone_block.step": {
-        "protocol_id": 178
+        "protocol_id": 158
       },
       "minecraft:block.brewing_stand.brew": {
-        "protocol_id": 199
+        "protocol_id": 166
       },
       "minecraft:block.bubble_column.bubble_pop": {
-        "protocol_id": 205
+        "protocol_id": 172
       },
       "minecraft:block.bubble_column.upwards_ambient": {
-        "protocol_id": 206
+        "protocol_id": 173
       },
       "minecraft:block.bubble_column.upwards_inside": {
-        "protocol_id": 207
+        "protocol_id": 174
       },
       "minecraft:block.bubble_column.whirlpool_ambient": {
-        "protocol_id": 208
+        "protocol_id": 175
       },
       "minecraft:block.bubble_column.whirlpool_inside": {
-        "protocol_id": 209
-      },
-      "minecraft:block.cactus_flower.break": {
-        "protocol_id": 227
-      },
-      "minecraft:block.cactus_flower.place": {
-        "protocol_id": 228
+        "protocol_id": 176
       },
       "minecraft:block.cake.add_candle": {
-        "protocol_id": 229
+        "protocol_id": 192
       },
       "minecraft:block.calcite.break": {
-        "protocol_id": 230
+        "protocol_id": 193
       },
       "minecraft:block.calcite.fall": {
-        "protocol_id": 234
+        "protocol_id": 197
       },
       "minecraft:block.calcite.hit": {
-        "protocol_id": 233
+        "protocol_id": 196
       },
       "minecraft:block.calcite.place": {
-        "protocol_id": 232
+        "protocol_id": 195
       },
       "minecraft:block.calcite.step": {
-        "protocol_id": 231
+        "protocol_id": 194
       },
       "minecraft:block.campfire.crackle": {
-        "protocol_id": 246
+        "protocol_id": 209
       },
       "minecraft:block.candle.ambient": {
-        "protocol_id": 247
+        "protocol_id": 210
       },
       "minecraft:block.candle.break": {
-        "protocol_id": 248
+        "protocol_id": 211
       },
       "minecraft:block.candle.extinguish": {
-        "protocol_id": 249
+        "protocol_id": 212
       },
       "minecraft:block.candle.fall": {
-        "protocol_id": 250
+        "protocol_id": 213
       },
       "minecraft:block.candle.hit": {
-        "protocol_id": 251
+        "protocol_id": 214
       },
       "minecraft:block.candle.place": {
-        "protocol_id": 252
+        "protocol_id": 215
       },
       "minecraft:block.candle.step": {
-        "protocol_id": 253
+        "protocol_id": 216
       },
       "minecraft:block.cave_vines.break": {
-        "protocol_id": 263
+        "protocol_id": 226
       },
       "minecraft:block.cave_vines.fall": {
-        "protocol_id": 264
+        "protocol_id": 227
       },
       "minecraft:block.cave_vines.hit": {
-        "protocol_id": 265
+        "protocol_id": 228
       },
       "minecraft:block.cave_vines.pick_berries": {
-        "protocol_id": 268
+        "protocol_id": 231
       },
       "minecraft:block.cave_vines.place": {
-        "protocol_id": 266
+        "protocol_id": 229
       },
       "minecraft:block.cave_vines.step": {
-        "protocol_id": 267
+        "protocol_id": 230
       },
       "minecraft:block.chain.break": {
-        "protocol_id": 269
+        "protocol_id": 232
       },
       "minecraft:block.chain.fall": {
-        "protocol_id": 270
+        "protocol_id": 233
       },
       "minecraft:block.chain.hit": {
-        "protocol_id": 271
+        "protocol_id": 234
       },
       "minecraft:block.chain.place": {
-        "protocol_id": 272
+        "protocol_id": 235
       },
       "minecraft:block.chain.step": {
-        "protocol_id": 273
+        "protocol_id": 236
       },
       "minecraft:block.cherry_leaves.break": {
-        "protocol_id": 284
+        "protocol_id": 247
       },
       "minecraft:block.cherry_leaves.fall": {
-        "protocol_id": 285
+        "protocol_id": 248
       },
       "minecraft:block.cherry_leaves.hit": {
-        "protocol_id": 286
+        "protocol_id": 249
       },
       "minecraft:block.cherry_leaves.place": {
-        "protocol_id": 287
+        "protocol_id": 250
       },
       "minecraft:block.cherry_leaves.step": {
-        "protocol_id": 288
+        "protocol_id": 251
       },
       "minecraft:block.cherry_sapling.break": {
-        "protocol_id": 279
+        "protocol_id": 242
       },
       "minecraft:block.cherry_sapling.fall": {
-        "protocol_id": 280
+        "protocol_id": 243
       },
       "minecraft:block.cherry_sapling.hit": {
-        "protocol_id": 281
+        "protocol_id": 244
       },
       "minecraft:block.cherry_sapling.place": {
-        "protocol_id": 282
+        "protocol_id": 245
       },
       "minecraft:block.cherry_sapling.step": {
-        "protocol_id": 283
+        "protocol_id": 246
       },
       "minecraft:block.cherry_wood.break": {
-        "protocol_id": 274
+        "protocol_id": 237
       },
       "minecraft:block.cherry_wood.fall": {
-        "protocol_id": 275
+        "protocol_id": 238
       },
       "minecraft:block.cherry_wood.hit": {
-        "protocol_id": 276
+        "protocol_id": 239
       },
       "minecraft:block.cherry_wood.place": {
-        "protocol_id": 277
+        "protocol_id": 240
       },
       "minecraft:block.cherry_wood.step": {
-        "protocol_id": 278
+        "protocol_id": 241
       },
       "minecraft:block.cherry_wood_button.click_off": {
-        "protocol_id": 298
+        "protocol_id": 261
       },
       "minecraft:block.cherry_wood_button.click_on": {
-        "protocol_id": 299
+        "protocol_id": 262
       },
       "minecraft:block.cherry_wood_door.close": {
-        "protocol_id": 294
+        "protocol_id": 257
       },
       "minecraft:block.cherry_wood_door.open": {
-        "protocol_id": 295
+        "protocol_id": 258
       },
       "minecraft:block.cherry_wood_fence_gate.close": {
-        "protocol_id": 302
+        "protocol_id": 265
       },
       "minecraft:block.cherry_wood_fence_gate.open": {
-        "protocol_id": 303
+        "protocol_id": 266
       },
       "minecraft:block.cherry_wood_hanging_sign.break": {
-        "protocol_id": 290
+        "protocol_id": 253
       },
       "minecraft:block.cherry_wood_hanging_sign.fall": {
-        "protocol_id": 291
+        "protocol_id": 254
       },
       "minecraft:block.cherry_wood_hanging_sign.hit": {
-        "protocol_id": 292
+        "protocol_id": 255
       },
       "minecraft:block.cherry_wood_hanging_sign.place": {
-        "protocol_id": 293
+        "protocol_id": 256
       },
       "minecraft:block.cherry_wood_hanging_sign.step": {
-        "protocol_id": 289
+        "protocol_id": 252
       },
       "minecraft:block.cherry_wood_pressure_plate.click_off": {
-        "protocol_id": 300
+        "protocol_id": 263
       },
       "minecraft:block.cherry_wood_pressure_plate.click_on": {
-        "protocol_id": 301
+        "protocol_id": 264
       },
       "minecraft:block.cherry_wood_trapdoor.close": {
-        "protocol_id": 296
+        "protocol_id": 259
       },
       "minecraft:block.cherry_wood_trapdoor.open": {
-        "protocol_id": 297
+        "protocol_id": 260
       },
       "minecraft:block.chest.close": {
-        "protocol_id": 304
+        "protocol_id": 267
       },
       "minecraft:block.chest.locked": {
-        "protocol_id": 305
+        "protocol_id": 268
       },
       "minecraft:block.chest.open": {
-        "protocol_id": 306
+        "protocol_id": 269
       },
       "minecraft:block.chiseled_bookshelf.break": {
-        "protocol_id": 312
+        "protocol_id": 275
       },
       "minecraft:block.chiseled_bookshelf.fall": {
-        "protocol_id": 313
+        "protocol_id": 276
       },
       "minecraft:block.chiseled_bookshelf.hit": {
-        "protocol_id": 314
+        "protocol_id": 277
       },
       "minecraft:block.chiseled_bookshelf.insert": {
-        "protocol_id": 315
+        "protocol_id": 278
       },
       "minecraft:block.chiseled_bookshelf.insert.enchanted": {
-        "protocol_id": 316
+        "protocol_id": 279
       },
       "minecraft:block.chiseled_bookshelf.pickup": {
-        "protocol_id": 318
+        "protocol_id": 281
       },
       "minecraft:block.chiseled_bookshelf.pickup.enchanted": {
-        "protocol_id": 319
+        "protocol_id": 282
       },
       "minecraft:block.chiseled_bookshelf.place": {
-        "protocol_id": 320
+        "protocol_id": 283
       },
       "minecraft:block.chiseled_bookshelf.step": {
-        "protocol_id": 317
+        "protocol_id": 280
       },
       "minecraft:block.chorus_flower.death": {
-        "protocol_id": 321
+        "protocol_id": 284
       },
       "minecraft:block.chorus_flower.grow": {
-        "protocol_id": 322
-      },
-      "minecraft:block.cobweb.break": {
-        "protocol_id": 324
-      },
-      "minecraft:block.cobweb.fall": {
-        "protocol_id": 328
-      },
-      "minecraft:block.cobweb.hit": {
-        "protocol_id": 327
-      },
-      "minecraft:block.cobweb.place": {
-        "protocol_id": 326
-      },
-      "minecraft:block.cobweb.step": {
-        "protocol_id": 325
+        "protocol_id": 285
       },
       "minecraft:block.comparator.click": {
-        "protocol_id": 333
+        "protocol_id": 291
       },
       "minecraft:block.composter.empty": {
-        "protocol_id": 334
+        "protocol_id": 292
       },
       "minecraft:block.composter.fill": {
-        "protocol_id": 335
+        "protocol_id": 293
       },
       "minecraft:block.composter.fill_success": {
-        "protocol_id": 336
+        "protocol_id": 294
       },
       "minecraft:block.composter.ready": {
-        "protocol_id": 337
+        "protocol_id": 295
       },
       "minecraft:block.conduit.activate": {
-        "protocol_id": 338
+        "protocol_id": 296
       },
       "minecraft:block.conduit.ambient": {
-        "protocol_id": 339
+        "protocol_id": 297
       },
       "minecraft:block.conduit.ambient.short": {
-        "protocol_id": 340
+        "protocol_id": 298
       },
       "minecraft:block.conduit.attack.target": {
-        "protocol_id": 341
+        "protocol_id": 299
       },
       "minecraft:block.conduit.deactivate": {
-        "protocol_id": 342
+        "protocol_id": 300
       },
       "minecraft:block.copper.break": {
-        "protocol_id": 350
+        "protocol_id": 301
       },
       "minecraft:block.copper.fall": {
-        "protocol_id": 354
+        "protocol_id": 305
       },
       "minecraft:block.copper.hit": {
-        "protocol_id": 353
+        "protocol_id": 304
       },
       "minecraft:block.copper.place": {
-        "protocol_id": 352
+        "protocol_id": 303
       },
       "minecraft:block.copper.step": {
-        "protocol_id": 351
-      },
-      "minecraft:block.copper_bulb.break": {
-        "protocol_id": 343
-      },
-      "minecraft:block.copper_bulb.fall": {
-        "protocol_id": 347
-      },
-      "minecraft:block.copper_bulb.hit": {
-        "protocol_id": 346
-      },
-      "minecraft:block.copper_bulb.place": {
-        "protocol_id": 345
-      },
-      "minecraft:block.copper_bulb.step": {
-        "protocol_id": 344
-      },
-      "minecraft:block.copper_bulb.turn_off": {
-        "protocol_id": 349
-      },
-      "minecraft:block.copper_bulb.turn_on": {
-        "protocol_id": 348
-      },
-      "minecraft:block.copper_door.close": {
-        "protocol_id": 355
-      },
-      "minecraft:block.copper_door.open": {
-        "protocol_id": 356
-      },
-      "minecraft:block.copper_grate.break": {
-        "protocol_id": 357
-      },
-      "minecraft:block.copper_grate.fall": {
-        "protocol_id": 361
-      },
-      "minecraft:block.copper_grate.hit": {
-        "protocol_id": 360
-      },
-      "minecraft:block.copper_grate.place": {
-        "protocol_id": 359
-      },
-      "minecraft:block.copper_grate.step": {
-        "protocol_id": 358
-      },
-      "minecraft:block.copper_trapdoor.close": {
-        "protocol_id": 362
-      },
-      "minecraft:block.copper_trapdoor.open": {
-        "protocol_id": 363
+        "protocol_id": 302
       },
       "minecraft:block.coral_block.break": {
-        "protocol_id": 364
+        "protocol_id": 306
       },
       "minecraft:block.coral_block.fall": {
-        "protocol_id": 365
+        "protocol_id": 307
       },
       "minecraft:block.coral_block.hit": {
-        "protocol_id": 366
+        "protocol_id": 308
       },
       "minecraft:block.coral_block.place": {
-        "protocol_id": 367
+        "protocol_id": 309
       },
       "minecraft:block.coral_block.step": {
-        "protocol_id": 368
-      },
-      "minecraft:block.crafter.craft": {
-        "protocol_id": 374
-      },
-      "minecraft:block.crafter.fail": {
-        "protocol_id": 375
-      },
-      "minecraft:block.creaking_heart.break": {
-        "protocol_id": 387
-      },
-      "minecraft:block.creaking_heart.fall": {
-        "protocol_id": 388
-      },
-      "minecraft:block.creaking_heart.hit": {
-        "protocol_id": 389
-      },
-      "minecraft:block.creaking_heart.hurt": {
-        "protocol_id": 390
-      },
-      "minecraft:block.creaking_heart.idle": {
-        "protocol_id": 393
-      },
-      "minecraft:block.creaking_heart.place": {
-        "protocol_id": 391
-      },
-      "minecraft:block.creaking_heart.spawn": {
-        "protocol_id": 394
-      },
-      "minecraft:block.creaking_heart.step": {
-        "protocol_id": 392
+        "protocol_id": 310
       },
       "minecraft:block.crop.break": {
-        "protocol_id": 398
-      },
-      "minecraft:block.deadbush.idle": {
-        "protocol_id": 408
+        "protocol_id": 319
       },
       "minecraft:block.decorated_pot.break": {
-        "protocol_id": 409
+        "protocol_id": 329
       },
       "minecraft:block.decorated_pot.fall": {
-        "protocol_id": 410
+        "protocol_id": 330
       },
       "minecraft:block.decorated_pot.hit": {
-        "protocol_id": 411
-      },
-      "minecraft:block.decorated_pot.insert": {
-        "protocol_id": 412
-      },
-      "minecraft:block.decorated_pot.insert_fail": {
-        "protocol_id": 413
+        "protocol_id": 331
       },
       "minecraft:block.decorated_pot.place": {
-        "protocol_id": 415
+        "protocol_id": 333
       },
       "minecraft:block.decorated_pot.shatter": {
-        "protocol_id": 416
+        "protocol_id": 334
       },
       "minecraft:block.decorated_pot.step": {
-        "protocol_id": 414
+        "protocol_id": 332
       },
       "minecraft:block.deepslate.break": {
-        "protocol_id": 422
+        "protocol_id": 340
       },
       "minecraft:block.deepslate.fall": {
-        "protocol_id": 423
+        "protocol_id": 341
       },
       "minecraft:block.deepslate.hit": {
-        "protocol_id": 424
+        "protocol_id": 342
       },
       "minecraft:block.deepslate.place": {
-        "protocol_id": 425
+        "protocol_id": 343
       },
       "minecraft:block.deepslate.step": {
-        "protocol_id": 426
+        "protocol_id": 344
       },
       "minecraft:block.deepslate_bricks.break": {
-        "protocol_id": 417
+        "protocol_id": 335
       },
       "minecraft:block.deepslate_bricks.fall": {
-        "protocol_id": 418
+        "protocol_id": 336
       },
       "minecraft:block.deepslate_bricks.hit": {
-        "protocol_id": 419
+        "protocol_id": 337
       },
       "minecraft:block.deepslate_bricks.place": {
-        "protocol_id": 420
+        "protocol_id": 338
       },
       "minecraft:block.deepslate_bricks.step": {
-        "protocol_id": 421
+        "protocol_id": 339
       },
       "minecraft:block.deepslate_tiles.break": {
-        "protocol_id": 427
+        "protocol_id": 345
       },
       "minecraft:block.deepslate_tiles.fall": {
-        "protocol_id": 428
+        "protocol_id": 346
       },
       "minecraft:block.deepslate_tiles.hit": {
-        "protocol_id": 429
+        "protocol_id": 347
       },
       "minecraft:block.deepslate_tiles.place": {
-        "protocol_id": 430
+        "protocol_id": 348
       },
       "minecraft:block.deepslate_tiles.step": {
-        "protocol_id": 431
+        "protocol_id": 349
       },
       "minecraft:block.dispenser.dispense": {
-        "protocol_id": 432
+        "protocol_id": 350
       },
       "minecraft:block.dispenser.fail": {
-        "protocol_id": 433
+        "protocol_id": 351
       },
       "minecraft:block.dispenser.launch": {
-        "protocol_id": 434
+        "protocol_id": 352
       },
       "minecraft:block.dripstone_block.break": {
-        "protocol_id": 452
+        "protocol_id": 369
       },
       "minecraft:block.dripstone_block.fall": {
-        "protocol_id": 456
+        "protocol_id": 373
       },
       "minecraft:block.dripstone_block.hit": {
-        "protocol_id": 455
+        "protocol_id": 372
       },
       "minecraft:block.dripstone_block.place": {
-        "protocol_id": 454
+        "protocol_id": 371
       },
       "minecraft:block.dripstone_block.step": {
-        "protocol_id": 453
+        "protocol_id": 370
       },
       "minecraft:block.enchantment_table.use": {
-        "protocol_id": 489
+        "protocol_id": 406
       },
       "minecraft:block.end_gateway.spawn": {
-        "protocol_id": 512
+        "protocol_id": 429
       },
       "minecraft:block.end_portal.spawn": {
-        "protocol_id": 514
+        "protocol_id": 431
       },
       "minecraft:block.end_portal_frame.fill": {
-        "protocol_id": 513
+        "protocol_id": 430
       },
       "minecraft:block.ender_chest.close": {
-        "protocol_id": 490
+        "protocol_id": 407
       },
       "minecraft:block.ender_chest.open": {
-        "protocol_id": 491
-      },
-      "minecraft:block.eyeblossom.close": {
-        "protocol_id": 529
-      },
-      "minecraft:block.eyeblossom.close_long": {
-        "protocol_id": 528
-      },
-      "minecraft:block.eyeblossom.idle": {
-        "protocol_id": 530
-      },
-      "minecraft:block.eyeblossom.open": {
-        "protocol_id": 527
-      },
-      "minecraft:block.eyeblossom.open_long": {
-        "protocol_id": 526
+        "protocol_id": 408
       },
       "minecraft:block.fence_gate.close": {
-        "protocol_id": 531
+        "protocol_id": 443
       },
       "minecraft:block.fence_gate.open": {
-        "protocol_id": 532
+        "protocol_id": 444
       },
       "minecraft:block.fire.ambient": {
-        "protocol_id": 543
+        "protocol_id": 454
       },
       "minecraft:block.fire.extinguish": {
-        "protocol_id": 544
-      },
-      "minecraft:block.firefly_bush.idle": {
-        "protocol_id": 534
+        "protocol_id": 455
       },
       "minecraft:block.flowering_azalea.break": {
-        "protocol_id": 550
-      },
-      "minecraft:block.flowering_azalea.fall": {
-        "protocol_id": 551
-      },
-      "minecraft:block.flowering_azalea.hit": {
-        "protocol_id": 552
-      },
-      "minecraft:block.flowering_azalea.place": {
-        "protocol_id": 553
-      },
-      "minecraft:block.flowering_azalea.step": {
-        "protocol_id": 554
-      },
-      "minecraft:block.froglight.break": {
-        "protocol_id": 576
-      },
-      "minecraft:block.froglight.fall": {
-        "protocol_id": 577
-      },
-      "minecraft:block.froglight.hit": {
-        "protocol_id": 578
-      },
-      "minecraft:block.froglight.place": {
-        "protocol_id": 579
-      },
-      "minecraft:block.froglight.step": {
-        "protocol_id": 580
-      },
-      "minecraft:block.frogspawn.break": {
-        "protocol_id": 582
-      },
-      "minecraft:block.frogspawn.fall": {
-        "protocol_id": 583
-      },
-      "minecraft:block.frogspawn.hatch": {
-        "protocol_id": 584
-      },
-      "minecraft:block.frogspawn.hit": {
-        "protocol_id": 585
-      },
-      "minecraft:block.frogspawn.place": {
-        "protocol_id": 586
-      },
-      "minecraft:block.frogspawn.step": {
-        "protocol_id": 581
-      },
-      "minecraft:block.fungus.break": {
-        "protocol_id": 999
-      },
-      "minecraft:block.fungus.fall": {
-        "protocol_id": 1003
-      },
-      "minecraft:block.fungus.hit": {
-        "protocol_id": 1002
-      },
-      "minecraft:block.fungus.place": {
-        "protocol_id": 1001
-      },
-      "minecraft:block.fungus.step": {
-        "protocol_id": 1000
-      },
-      "minecraft:block.furnace.fire_crackle": {
-        "protocol_id": 600
-      },
-      "minecraft:block.gilded_blackstone.break": {
-        "protocol_id": 618
-      },
-      "minecraft:block.gilded_blackstone.fall": {
-        "protocol_id": 619
-      },
-      "minecraft:block.gilded_blackstone.hit": {
-        "protocol_id": 620
-      },
-      "minecraft:block.gilded_blackstone.place": {
-        "protocol_id": 621
-      },
-      "minecraft:block.gilded_blackstone.step": {
-        "protocol_id": 622
-      },
-      "minecraft:block.glass.break": {
-        "protocol_id": 623
-      },
-      "minecraft:block.glass.fall": {
-        "protocol_id": 624
-      },
-      "minecraft:block.glass.hit": {
-        "protocol_id": 625
-      },
-      "minecraft:block.glass.place": {
-        "protocol_id": 626
-      },
-      "minecraft:block.glass.step": {
-        "protocol_id": 627
-      },
-      "minecraft:block.grass.break": {
-        "protocol_id": 656
-      },
-      "minecraft:block.grass.fall": {
-        "protocol_id": 657
-      },
-      "minecraft:block.grass.hit": {
-        "protocol_id": 658
-      },
-      "minecraft:block.grass.place": {
-        "protocol_id": 659
-      },
-      "minecraft:block.grass.step": {
-        "protocol_id": 660
-      },
-      "minecraft:block.gravel.break": {
-        "protocol_id": 661
-      },
-      "minecraft:block.gravel.fall": {
-        "protocol_id": 662
-      },
-      "minecraft:block.gravel.hit": {
-        "protocol_id": 663
-      },
-      "minecraft:block.gravel.place": {
-        "protocol_id": 664
-      },
-      "minecraft:block.gravel.step": {
-        "protocol_id": 665
-      },
-      "minecraft:block.grindstone.use": {
-        "protocol_id": 666
-      },
-      "minecraft:block.growing_plant.crop": {
-        "protocol_id": 667
-      },
-      "minecraft:block.hanging_roots.break": {
-        "protocol_id": 676
-      },
-      "minecraft:block.hanging_roots.fall": {
-        "protocol_id": 677
-      },
-      "minecraft:block.hanging_roots.hit": {
-        "protocol_id": 678
-      },
-      "minecraft:block.hanging_roots.place": {
-        "protocol_id": 679
-      },
-      "minecraft:block.hanging_roots.step": {
-        "protocol_id": 680
-      },
-      "minecraft:block.hanging_sign.break": {
-        "protocol_id": 682
-      },
-      "minecraft:block.hanging_sign.fall": {
-        "protocol_id": 683
-      },
-      "minecraft:block.hanging_sign.hit": {
-        "protocol_id": 684
-      },
-      "minecraft:block.hanging_sign.place": {
-        "protocol_id": 685
-      },
-      "minecraft:block.hanging_sign.step": {
-        "protocol_id": 681
-      },
-      "minecraft:block.hanging_sign.waxed_interact_fail": {
-        "protocol_id": 1570
-      },
-      "minecraft:block.heavy_core.break": {
-        "protocol_id": 686
-      },
-      "minecraft:block.heavy_core.fall": {
-        "protocol_id": 687
-      },
-      "minecraft:block.heavy_core.hit": {
-        "protocol_id": 688
-      },
-      "minecraft:block.heavy_core.place": {
-        "protocol_id": 689
-      },
-      "minecraft:block.heavy_core.step": {
-        "protocol_id": 690
-      },
-      "minecraft:block.honey_block.break": {
-        "protocol_id": 726
-      },
-      "minecraft:block.honey_block.fall": {
-        "protocol_id": 727
-      },
-      "minecraft:block.honey_block.hit": {
-        "protocol_id": 728
-      },
-      "minecraft:block.honey_block.place": {
-        "protocol_id": 729
-      },
-      "minecraft:block.honey_block.slide": {
-        "protocol_id": 730
-      },
-      "minecraft:block.honey_block.step": {
-        "protocol_id": 731
-      },
-      "minecraft:block.iron.break": {
-        "protocol_id": 774
-      },
-      "minecraft:block.iron.fall": {
-        "protocol_id": 778
-      },
-      "minecraft:block.iron.hit": {
-        "protocol_id": 777
-      },
-      "minecraft:block.iron.place": {
-        "protocol_id": 776
-      },
-      "minecraft:block.iron.step": {
-        "protocol_id": 775
-      },
-      "minecraft:block.iron_door.close": {
-        "protocol_id": 779
-      },
-      "minecraft:block.iron_door.open": {
-        "protocol_id": 780
-      },
-      "minecraft:block.iron_trapdoor.close": {
-        "protocol_id": 787
-      },
-      "minecraft:block.iron_trapdoor.open": {
-        "protocol_id": 788
-      },
-      "minecraft:block.ladder.break": {
-        "protocol_id": 796
-      },
-      "minecraft:block.ladder.fall": {
-        "protocol_id": 797
-      },
-      "minecraft:block.ladder.hit": {
-        "protocol_id": 798
-      },
-      "minecraft:block.ladder.place": {
-        "protocol_id": 799
-      },
-      "minecraft:block.ladder.step": {
-        "protocol_id": 800
-      },
-      "minecraft:block.lantern.break": {
-        "protocol_id": 801
-      },
-      "minecraft:block.lantern.fall": {
-        "protocol_id": 802
-      },
-      "minecraft:block.lantern.hit": {
-        "protocol_id": 803
-      },
-      "minecraft:block.lantern.place": {
-        "protocol_id": 804
-      },
-      "minecraft:block.lantern.step": {
-        "protocol_id": 805
-      },
-      "minecraft:block.large_amethyst_bud.break": {
-        "protocol_id": 806
-      },
-      "minecraft:block.large_amethyst_bud.place": {
-        "protocol_id": 807
-      },
-      "minecraft:block.lava.ambient": {
-        "protocol_id": 808
-      },
-      "minecraft:block.lava.extinguish": {
-        "protocol_id": 809
-      },
-      "minecraft:block.lava.pop": {
-        "protocol_id": 810
-      },
-      "minecraft:block.leaf_litter.break": {
-        "protocol_id": 811
-      },
-      "minecraft:block.leaf_litter.fall": {
-        "protocol_id": 815
-      },
-      "minecraft:block.leaf_litter.hit": {
-        "protocol_id": 814
-      },
-      "minecraft:block.leaf_litter.place": {
-        "protocol_id": 813
-      },
-      "minecraft:block.leaf_litter.step": {
-        "protocol_id": 812
-      },
-      "minecraft:block.lever.click": {
-        "protocol_id": 818
-      },
-      "minecraft:block.lily_pad.place": {
-        "protocol_id": 1539
-      },
-      "minecraft:block.lodestone.break": {
-        "protocol_id": 832
-      },
-      "minecraft:block.lodestone.fall": {
-        "protocol_id": 836
-      },
-      "minecraft:block.lodestone.hit": {
-        "protocol_id": 835
-      },
-      "minecraft:block.lodestone.place": {
-        "protocol_id": 834
-      },
-      "minecraft:block.lodestone.step": {
-        "protocol_id": 833
-      },
-      "minecraft:block.mangrove_roots.break": {
-        "protocol_id": 847
-      },
-      "minecraft:block.mangrove_roots.fall": {
-        "protocol_id": 848
-      },
-      "minecraft:block.mangrove_roots.hit": {
-        "protocol_id": 849
-      },
-      "minecraft:block.mangrove_roots.place": {
-        "protocol_id": 850
-      },
-      "minecraft:block.mangrove_roots.step": {
-        "protocol_id": 851
-      },
-      "minecraft:block.medium_amethyst_bud.break": {
-        "protocol_id": 852
-      },
-      "minecraft:block.medium_amethyst_bud.place": {
-        "protocol_id": 853
-      },
-      "minecraft:block.metal.break": {
-        "protocol_id": 854
-      },
-      "minecraft:block.metal.fall": {
-        "protocol_id": 855
-      },
-      "minecraft:block.metal.hit": {
-        "protocol_id": 856
-      },
-      "minecraft:block.metal.place": {
-        "protocol_id": 857
-      },
-      "minecraft:block.metal.step": {
-        "protocol_id": 860
-      },
-      "minecraft:block.metal_pressure_plate.click_off": {
-        "protocol_id": 858
-      },
-      "minecraft:block.metal_pressure_plate.click_on": {
-        "protocol_id": 859
-      },
-      "minecraft:block.moss.break": {
-        "protocol_id": 879
-      },
-      "minecraft:block.moss.fall": {
-        "protocol_id": 880
-      },
-      "minecraft:block.moss.hit": {
-        "protocol_id": 881
-      },
-      "minecraft:block.moss.place": {
-        "protocol_id": 882
-      },
-      "minecraft:block.moss.step": {
-        "protocol_id": 883
-      },
-      "minecraft:block.moss_carpet.break": {
-        "protocol_id": 869
-      },
-      "minecraft:block.moss_carpet.fall": {
-        "protocol_id": 870
-      },
-      "minecraft:block.moss_carpet.hit": {
-        "protocol_id": 871
-      },
-      "minecraft:block.moss_carpet.place": {
-        "protocol_id": 872
-      },
-      "minecraft:block.moss_carpet.step": {
-        "protocol_id": 873
-      },
-      "minecraft:block.mud.break": {
-        "protocol_id": 884
-      },
-      "minecraft:block.mud.fall": {
-        "protocol_id": 885
-      },
-      "minecraft:block.mud.hit": {
-        "protocol_id": 886
-      },
-      "minecraft:block.mud.place": {
-        "protocol_id": 887
-      },
-      "minecraft:block.mud.step": {
-        "protocol_id": 888
-      },
-      "minecraft:block.mud_bricks.break": {
-        "protocol_id": 889
-      },
-      "minecraft:block.mud_bricks.fall": {
-        "protocol_id": 890
-      },
-      "minecraft:block.mud_bricks.hit": {
-        "protocol_id": 891
-      },
-      "minecraft:block.mud_bricks.place": {
-        "protocol_id": 892
-      },
-      "minecraft:block.mud_bricks.step": {
-        "protocol_id": 893
-      },
-      "minecraft:block.muddy_mangrove_roots.break": {
-        "protocol_id": 894
-      },
-      "minecraft:block.muddy_mangrove_roots.fall": {
-        "protocol_id": 895
-      },
-      "minecraft:block.muddy_mangrove_roots.hit": {
-        "protocol_id": 896
-      },
-      "minecraft:block.muddy_mangrove_roots.place": {
-        "protocol_id": 897
-      },
-      "minecraft:block.muddy_mangrove_roots.step": {
-        "protocol_id": 898
-      },
-      "minecraft:block.nether_bricks.break": {
-        "protocol_id": 956
-      },
-      "minecraft:block.nether_bricks.fall": {
-        "protocol_id": 960
-      },
-      "minecraft:block.nether_bricks.hit": {
-        "protocol_id": 959
-      },
-      "minecraft:block.nether_bricks.place": {
-        "protocol_id": 958
-      },
-      "minecraft:block.nether_bricks.step": {
-        "protocol_id": 957
-      },
-      "minecraft:block.nether_gold_ore.break": {
-        "protocol_id": 1201
-      },
-      "minecraft:block.nether_gold_ore.fall": {
-        "protocol_id": 1202
-      },
-      "minecraft:block.nether_gold_ore.hit": {
-        "protocol_id": 1203
-      },
-      "minecraft:block.nether_gold_ore.place": {
-        "protocol_id": 1204
-      },
-      "minecraft:block.nether_gold_ore.step": {
-        "protocol_id": 1205
-      },
-      "minecraft:block.nether_ore.break": {
-        "protocol_id": 1206
-      },
-      "minecraft:block.nether_ore.fall": {
-        "protocol_id": 1207
-      },
-      "minecraft:block.nether_ore.hit": {
-        "protocol_id": 1208
-      },
-      "minecraft:block.nether_ore.place": {
-        "protocol_id": 1209
-      },
-      "minecraft:block.nether_ore.step": {
-        "protocol_id": 1210
-      },
-      "minecraft:block.nether_sprouts.break": {
-        "protocol_id": 994
-      },
-      "minecraft:block.nether_sprouts.fall": {
-        "protocol_id": 998
-      },
-      "minecraft:block.nether_sprouts.hit": {
-        "protocol_id": 997
-      },
-      "minecraft:block.nether_sprouts.place": {
-        "protocol_id": 996
-      },
-      "minecraft:block.nether_sprouts.step": {
-        "protocol_id": 995
-      },
-      "minecraft:block.nether_wart.break": {
-        "protocol_id": 961
-      },
-      "minecraft:block.nether_wood.break": {
-        "protocol_id": 963
-      },
-      "minecraft:block.nether_wood.fall": {
-        "protocol_id": 964
-      },
-      "minecraft:block.nether_wood.hit": {
-        "protocol_id": 965
-      },
-      "minecraft:block.nether_wood.place": {
-        "protocol_id": 966
-      },
-      "minecraft:block.nether_wood.step": {
-        "protocol_id": 967
-      },
-      "minecraft:block.nether_wood_button.click_off": {
-        "protocol_id": 972
-      },
-      "minecraft:block.nether_wood_button.click_on": {
-        "protocol_id": 973
-      },
-      "minecraft:block.nether_wood_door.close": {
-        "protocol_id": 968
-      },
-      "minecraft:block.nether_wood_door.open": {
-        "protocol_id": 969
-      },
-      "minecraft:block.nether_wood_fence_gate.close": {
-        "protocol_id": 976
-      },
-      "minecraft:block.nether_wood_fence_gate.open": {
-        "protocol_id": 977
-      },
-      "minecraft:block.nether_wood_hanging_sign.break": {
-        "protocol_id": 692
-      },
-      "minecraft:block.nether_wood_hanging_sign.fall": {
-        "protocol_id": 693
-      },
-      "minecraft:block.nether_wood_hanging_sign.hit": {
-        "protocol_id": 694
-      },
-      "minecraft:block.nether_wood_hanging_sign.place": {
-        "protocol_id": 695
-      },
-      "minecraft:block.nether_wood_hanging_sign.step": {
-        "protocol_id": 691
-      },
-      "minecraft:block.nether_wood_pressure_plate.click_off": {
-        "protocol_id": 974
-      },
-      "minecraft:block.nether_wood_pressure_plate.click_on": {
-        "protocol_id": 975
-      },
-      "minecraft:block.nether_wood_trapdoor.close": {
-        "protocol_id": 970
-      },
-      "minecraft:block.nether_wood_trapdoor.open": {
-        "protocol_id": 971
-      },
-      "minecraft:block.netherite_block.break": {
-        "protocol_id": 1014
-      },
-      "minecraft:block.netherite_block.fall": {
-        "protocol_id": 1018
-      },
-      "minecraft:block.netherite_block.hit": {
-        "protocol_id": 1017
-      },
-      "minecraft:block.netherite_block.place": {
-        "protocol_id": 1016
-      },
-      "minecraft:block.netherite_block.step": {
-        "protocol_id": 1015
-      },
-      "minecraft:block.netherrack.break": {
-        "protocol_id": 1019
-      },
-      "minecraft:block.netherrack.fall": {
-        "protocol_id": 1023
-      },
-      "minecraft:block.netherrack.hit": {
-        "protocol_id": 1022
-      },
-      "minecraft:block.netherrack.place": {
-        "protocol_id": 1021
-      },
-      "minecraft:block.netherrack.step": {
-        "protocol_id": 1020
-      },
-      "minecraft:block.note_block.banjo": {
-        "protocol_id": 1039
-      },
-      "minecraft:block.note_block.basedrum": {
-        "protocol_id": 1024
-      },
-      "minecraft:block.note_block.bass": {
-        "protocol_id": 1025
-      },
-      "minecraft:block.note_block.bell": {
-        "protocol_id": 1026
-      },
-      "minecraft:block.note_block.bit": {
-        "protocol_id": 1038
-      },
-      "minecraft:block.note_block.chime": {
-        "protocol_id": 1027
-      },
-      "minecraft:block.note_block.cow_bell": {
-        "protocol_id": 1036
-      },
-      "minecraft:block.note_block.didgeridoo": {
-        "protocol_id": 1037
-      },
-      "minecraft:block.note_block.flute": {
-        "protocol_id": 1028
-      },
-      "minecraft:block.note_block.guitar": {
-        "protocol_id": 1029
-      },
-      "minecraft:block.note_block.harp": {
-        "protocol_id": 1030
-      },
-      "minecraft:block.note_block.hat": {
-        "protocol_id": 1031
-      },
-      "minecraft:block.note_block.imitate.creeper": {
-        "protocol_id": 1042
-      },
-      "minecraft:block.note_block.imitate.ender_dragon": {
-        "protocol_id": 1043
-      },
-      "minecraft:block.note_block.imitate.piglin": {
-        "protocol_id": 1045
-      },
-      "minecraft:block.note_block.imitate.skeleton": {
-        "protocol_id": 1041
-      },
-      "minecraft:block.note_block.imitate.wither_skeleton": {
-        "protocol_id": 1044
-      },
-      "minecraft:block.note_block.imitate.zombie": {
-        "protocol_id": 1040
-      },
-      "minecraft:block.note_block.iron_xylophone": {
-        "protocol_id": 1035
-      },
-      "minecraft:block.note_block.pling": {
-        "protocol_id": 1032
-      },
-      "minecraft:block.note_block.snare": {
-        "protocol_id": 1033
-      },
-      "minecraft:block.note_block.xylophone": {
-        "protocol_id": 1034
-      },
-      "minecraft:block.nylium.break": {
-        "protocol_id": 989
-      },
-      "minecraft:block.nylium.fall": {
-        "protocol_id": 993
-      },
-      "minecraft:block.nylium.hit": {
-        "protocol_id": 992
-      },
-      "minecraft:block.nylium.place": {
-        "protocol_id": 991
-      },
-      "minecraft:block.nylium.step": {
-        "protocol_id": 990
-      },
-      "minecraft:block.packed_mud.break": {
-        "protocol_id": 979
-      },
-      "minecraft:block.packed_mud.fall": {
-        "protocol_id": 980
-      },
-      "minecraft:block.packed_mud.hit": {
-        "protocol_id": 981
-      },
-      "minecraft:block.packed_mud.place": {
-        "protocol_id": 982
-      },
-      "minecraft:block.packed_mud.step": {
-        "protocol_id": 983
-      },
-      "minecraft:block.pale_hanging_moss.idle": {
-        "protocol_id": 1052
-      },
-      "minecraft:block.pink_petals.break": {
-        "protocol_id": 874
-      },
-      "minecraft:block.pink_petals.fall": {
-        "protocol_id": 875
-      },
-      "minecraft:block.pink_petals.hit": {
-        "protocol_id": 876
-      },
-      "minecraft:block.pink_petals.place": {
-        "protocol_id": 877
-      },
-      "minecraft:block.pink_petals.step": {
-        "protocol_id": 878
-      },
-      "minecraft:block.piston.contract": {
-        "protocol_id": 1137
-      },
-      "minecraft:block.piston.extend": {
-        "protocol_id": 1138
-      },
-      "minecraft:block.pointed_dripstone.break": {
-        "protocol_id": 457
-      },
-      "minecraft:block.pointed_dripstone.drip_lava": {
-        "protocol_id": 463
-      },
-      "minecraft:block.pointed_dripstone.drip_lava_into_cauldron": {
-        "protocol_id": 465
-      },
-      "minecraft:block.pointed_dripstone.drip_water": {
-        "protocol_id": 464
-      },
-      "minecraft:block.pointed_dripstone.drip_water_into_cauldron": {
-        "protocol_id": 466
-      },
-      "minecraft:block.pointed_dripstone.fall": {
         "protocol_id": 461
       },
-      "minecraft:block.pointed_dripstone.hit": {
-        "protocol_id": 460
-      },
-      "minecraft:block.pointed_dripstone.land": {
+      "minecraft:block.flowering_azalea.fall": {
         "protocol_id": 462
       },
-      "minecraft:block.pointed_dripstone.place": {
-        "protocol_id": 459
+      "minecraft:block.flowering_azalea.hit": {
+        "protocol_id": 463
       },
-      "minecraft:block.pointed_dripstone.step": {
-        "protocol_id": 458
+      "minecraft:block.flowering_azalea.place": {
+        "protocol_id": 464
       },
-      "minecraft:block.polished_deepslate.break": {
-        "protocol_id": 1166
+      "minecraft:block.flowering_azalea.step": {
+        "protocol_id": 465
       },
-      "minecraft:block.polished_deepslate.fall": {
-        "protocol_id": 1167
+      "minecraft:block.froglight.break": {
+        "protocol_id": 487
       },
-      "minecraft:block.polished_deepslate.hit": {
-        "protocol_id": 1168
+      "minecraft:block.froglight.fall": {
+        "protocol_id": 488
       },
-      "minecraft:block.polished_deepslate.place": {
-        "protocol_id": 1169
+      "minecraft:block.froglight.hit": {
+        "protocol_id": 489
       },
-      "minecraft:block.polished_deepslate.step": {
-        "protocol_id": 1170
+      "minecraft:block.froglight.place": {
+        "protocol_id": 490
       },
-      "minecraft:block.polished_tuff.break": {
-        "protocol_id": 1466
+      "minecraft:block.froglight.step": {
+        "protocol_id": 491
       },
-      "minecraft:block.polished_tuff.fall": {
-        "protocol_id": 1467
+      "minecraft:block.frogspawn.break": {
+        "protocol_id": 493
       },
-      "minecraft:block.polished_tuff.hit": {
-        "protocol_id": 1468
+      "minecraft:block.frogspawn.fall": {
+        "protocol_id": 494
       },
-      "minecraft:block.polished_tuff.place": {
-        "protocol_id": 1469
+      "minecraft:block.frogspawn.hatch": {
+        "protocol_id": 495
       },
-      "minecraft:block.polished_tuff.step": {
-        "protocol_id": 1470
+      "minecraft:block.frogspawn.hit": {
+        "protocol_id": 496
       },
-      "minecraft:block.portal.ambient": {
-        "protocol_id": 1171
+      "minecraft:block.frogspawn.place": {
+        "protocol_id": 497
       },
-      "minecraft:block.portal.travel": {
-        "protocol_id": 1172
+      "minecraft:block.frogspawn.step": {
+        "protocol_id": 492
       },
-      "minecraft:block.portal.trigger": {
-        "protocol_id": 1173
+      "minecraft:block.fungus.break": {
+        "protocol_id": 874
       },
-      "minecraft:block.powder_snow.break": {
-        "protocol_id": 1174
+      "minecraft:block.fungus.fall": {
+        "protocol_id": 878
       },
-      "minecraft:block.powder_snow.fall": {
-        "protocol_id": 1175
+      "minecraft:block.fungus.hit": {
+        "protocol_id": 877
       },
-      "minecraft:block.powder_snow.hit": {
-        "protocol_id": 1176
+      "minecraft:block.fungus.place": {
+        "protocol_id": 876
       },
-      "minecraft:block.powder_snow.place": {
-        "protocol_id": 1177
+      "minecraft:block.fungus.step": {
+        "protocol_id": 875
       },
-      "minecraft:block.powder_snow.step": {
-        "protocol_id": 1178
+      "minecraft:block.furnace.fire_crackle": {
+        "protocol_id": 511
       },
-      "minecraft:block.pumpkin.carve": {
-        "protocol_id": 1186
+      "minecraft:block.gilded_blackstone.break": {
+        "protocol_id": 529
       },
-      "minecraft:block.redstone_torch.burnout": {
-        "protocol_id": 1211
+      "minecraft:block.gilded_blackstone.fall": {
+        "protocol_id": 530
       },
-      "minecraft:block.resin.break": {
-        "protocol_id": 1344
+      "minecraft:block.gilded_blackstone.hit": {
+        "protocol_id": 531
       },
-      "minecraft:block.resin.fall": {
-        "protocol_id": 1345
+      "minecraft:block.gilded_blackstone.place": {
+        "protocol_id": 532
       },
-      "minecraft:block.resin.place": {
-        "protocol_id": 1346
+      "minecraft:block.gilded_blackstone.step": {
+        "protocol_id": 533
       },
-      "minecraft:block.resin.step": {
-        "protocol_id": 1347
+      "minecraft:block.glass.break": {
+        "protocol_id": 534
       },
-      "minecraft:block.resin_bricks.break": {
-        "protocol_id": 1348
+      "minecraft:block.glass.fall": {
+        "protocol_id": 535
       },
-      "minecraft:block.resin_bricks.fall": {
-        "protocol_id": 1349
+      "minecraft:block.glass.hit": {
+        "protocol_id": 536
       },
-      "minecraft:block.resin_bricks.hit": {
-        "protocol_id": 1350
+      "minecraft:block.glass.place": {
+        "protocol_id": 537
       },
-      "minecraft:block.resin_bricks.place": {
-        "protocol_id": 1351
+      "minecraft:block.glass.step": {
+        "protocol_id": 538
       },
-      "minecraft:block.resin_bricks.step": {
-        "protocol_id": 1352
-      },
-      "minecraft:block.respawn_anchor.ambient": {
-        "protocol_id": 1212
-      },
-      "minecraft:block.respawn_anchor.charge": {
-        "protocol_id": 1213
-      },
-      "minecraft:block.respawn_anchor.deplete": {
-        "protocol_id": 1214
-      },
-      "minecraft:block.respawn_anchor.set_spawn": {
-        "protocol_id": 1215
-      },
-      "minecraft:block.rooted_dirt.break": {
-        "protocol_id": 1216
-      },
-      "minecraft:block.rooted_dirt.fall": {
-        "protocol_id": 1217
-      },
-      "minecraft:block.rooted_dirt.hit": {
-        "protocol_id": 1218
-      },
-      "minecraft:block.rooted_dirt.place": {
-        "protocol_id": 1219
-      },
-      "minecraft:block.rooted_dirt.step": {
-        "protocol_id": 1220
-      },
-      "minecraft:block.roots.break": {
-        "protocol_id": 595
-      },
-      "minecraft:block.roots.fall": {
-        "protocol_id": 599
-      },
-      "minecraft:block.roots.hit": {
-        "protocol_id": 598
-      },
-      "minecraft:block.roots.place": {
-        "protocol_id": 597
-      },
-      "minecraft:block.roots.step": {
-        "protocol_id": 596
-      },
-      "minecraft:block.sand.break": {
-        "protocol_id": 1225
-      },
-      "minecraft:block.sand.fall": {
-        "protocol_id": 1226
-      },
-      "minecraft:block.sand.hit": {
-        "protocol_id": 1227
-      },
-      "minecraft:block.sand.idle": {
-        "protocol_id": 1230
-      },
-      "minecraft:block.sand.place": {
-        "protocol_id": 1228
-      },
-      "minecraft:block.sand.step": {
-        "protocol_id": 1229
-      },
-      "minecraft:block.sand.wind": {
-        "protocol_id": 1231
-      },
-      "minecraft:block.scaffolding.break": {
-        "protocol_id": 1232
-      },
-      "minecraft:block.scaffolding.fall": {
-        "protocol_id": 1233
-      },
-      "minecraft:block.scaffolding.hit": {
-        "protocol_id": 1234
-      },
-      "minecraft:block.scaffolding.place": {
-        "protocol_id": 1235
-      },
-      "minecraft:block.scaffolding.step": {
-        "protocol_id": 1236
-      },
-      "minecraft:block.sculk.break": {
-        "protocol_id": 1239
-      },
-      "minecraft:block.sculk.charge": {
-        "protocol_id": 1238
-      },
-      "minecraft:block.sculk.fall": {
-        "protocol_id": 1240
-      },
-      "minecraft:block.sculk.hit": {
-        "protocol_id": 1241
-      },
-      "minecraft:block.sculk.place": {
-        "protocol_id": 1242
-      },
-      "minecraft:block.sculk.spread": {
-        "protocol_id": 1237
-      },
-      "minecraft:block.sculk.step": {
-        "protocol_id": 1243
-      },
-      "minecraft:block.sculk_catalyst.bloom": {
-        "protocol_id": 1244
-      },
-      "minecraft:block.sculk_catalyst.break": {
-        "protocol_id": 1245
-      },
-      "minecraft:block.sculk_catalyst.fall": {
-        "protocol_id": 1246
-      },
-      "minecraft:block.sculk_catalyst.hit": {
-        "protocol_id": 1247
-      },
-      "minecraft:block.sculk_catalyst.place": {
-        "protocol_id": 1248
-      },
-      "minecraft:block.sculk_catalyst.step": {
-        "protocol_id": 1249
-      },
-      "minecraft:block.sculk_sensor.break": {
-        "protocol_id": 1252
-      },
-      "minecraft:block.sculk_sensor.clicking": {
-        "protocol_id": 1250
-      },
-      "minecraft:block.sculk_sensor.clicking_stop": {
-        "protocol_id": 1251
-      },
-      "minecraft:block.sculk_sensor.fall": {
-        "protocol_id": 1253
-      },
-      "minecraft:block.sculk_sensor.hit": {
-        "protocol_id": 1254
-      },
-      "minecraft:block.sculk_sensor.place": {
-        "protocol_id": 1255
-      },
-      "minecraft:block.sculk_sensor.step": {
-        "protocol_id": 1256
-      },
-      "minecraft:block.sculk_shrieker.break": {
-        "protocol_id": 1257
-      },
-      "minecraft:block.sculk_shrieker.fall": {
-        "protocol_id": 1258
-      },
-      "minecraft:block.sculk_shrieker.hit": {
-        "protocol_id": 1259
-      },
-      "minecraft:block.sculk_shrieker.place": {
-        "protocol_id": 1260
-      },
-      "minecraft:block.sculk_shrieker.shriek": {
-        "protocol_id": 1261
-      },
-      "minecraft:block.sculk_shrieker.step": {
-        "protocol_id": 1262
-      },
-      "minecraft:block.sculk_vein.break": {
-        "protocol_id": 1263
-      },
-      "minecraft:block.sculk_vein.fall": {
-        "protocol_id": 1264
-      },
-      "minecraft:block.sculk_vein.hit": {
-        "protocol_id": 1265
-      },
-      "minecraft:block.sculk_vein.place": {
-        "protocol_id": 1266
-      },
-      "minecraft:block.sculk_vein.step": {
-        "protocol_id": 1267
-      },
-      "minecraft:block.shroomlight.break": {
-        "protocol_id": 1275
-      },
-      "minecraft:block.shroomlight.fall": {
-        "protocol_id": 1279
-      },
-      "minecraft:block.shroomlight.hit": {
-        "protocol_id": 1278
-      },
-      "minecraft:block.shroomlight.place": {
-        "protocol_id": 1277
-      },
-      "minecraft:block.shroomlight.step": {
-        "protocol_id": 1276
-      },
-      "minecraft:block.shulker_box.close": {
-        "protocol_id": 1282
-      },
-      "minecraft:block.shulker_box.open": {
-        "protocol_id": 1283
-      },
-      "minecraft:block.sign.waxed_interact_fail": {
-        "protocol_id": 1571
-      },
-      "minecraft:block.slime_block.break": {
-        "protocol_id": 1316
-      },
-      "minecraft:block.slime_block.fall": {
-        "protocol_id": 1317
-      },
-      "minecraft:block.slime_block.hit": {
-        "protocol_id": 1318
-      },
-      "minecraft:block.slime_block.place": {
-        "protocol_id": 1319
-      },
-      "minecraft:block.slime_block.step": {
-        "protocol_id": 1320
-      },
-      "minecraft:block.small_amethyst_bud.break": {
-        "protocol_id": 1321
-      },
-      "minecraft:block.small_amethyst_bud.place": {
-        "protocol_id": 1322
-      },
-      "minecraft:block.small_dripleaf.break": {
-        "protocol_id": 1323
-      },
-      "minecraft:block.small_dripleaf.fall": {
-        "protocol_id": 1324
-      },
-      "minecraft:block.small_dripleaf.hit": {
-        "protocol_id": 1325
-      },
-      "minecraft:block.small_dripleaf.place": {
-        "protocol_id": 1326
-      },
-      "minecraft:block.small_dripleaf.step": {
-        "protocol_id": 1327
-      },
-      "minecraft:block.smithing_table.use": {
-        "protocol_id": 1371
-      },
-      "minecraft:block.smoker.smoke": {
-        "protocol_id": 1372
-      },
-      "minecraft:block.sniffer_egg.crack": {
-        "protocol_id": 1386
-      },
-      "minecraft:block.sniffer_egg.hatch": {
-        "protocol_id": 1387
-      },
-      "minecraft:block.sniffer_egg.plop": {
-        "protocol_id": 1385
-      },
-      "minecraft:block.snow.break": {
-        "protocol_id": 1389
-      },
-      "minecraft:block.snow.fall": {
-        "protocol_id": 1390
-      },
-      "minecraft:block.snow.hit": {
-        "protocol_id": 1396
-      },
-      "minecraft:block.snow.place": {
-        "protocol_id": 1397
-      },
-      "minecraft:block.snow.step": {
-        "protocol_id": 1398
-      },
-      "minecraft:block.soul_sand.break": {
-        "protocol_id": 1328
-      },
-      "minecraft:block.soul_sand.fall": {
-        "protocol_id": 1332
-      },
-      "minecraft:block.soul_sand.hit": {
-        "protocol_id": 1331
-      },
-      "minecraft:block.soul_sand.place": {
-        "protocol_id": 1330
-      },
-      "minecraft:block.soul_sand.step": {
-        "protocol_id": 1329
-      },
-      "minecraft:block.soul_soil.break": {
-        "protocol_id": 1333
-      },
-      "minecraft:block.soul_soil.fall": {
-        "protocol_id": 1337
-      },
-      "minecraft:block.soul_soil.hit": {
-        "protocol_id": 1336
-      },
-      "minecraft:block.soul_soil.place": {
-        "protocol_id": 1335
-      },
-      "minecraft:block.soul_soil.step": {
-        "protocol_id": 1334
-      },
-      "minecraft:block.spawner.break": {
-        "protocol_id": 1339
-      },
-      "minecraft:block.spawner.fall": {
-        "protocol_id": 1340
-      },
-      "minecraft:block.spawner.hit": {
-        "protocol_id": 1341
-      },
-      "minecraft:block.spawner.place": {
-        "protocol_id": 1342
-      },
-      "minecraft:block.spawner.step": {
-        "protocol_id": 1343
-      },
-      "minecraft:block.sponge.absorb": {
-        "protocol_id": 1410
-      },
-      "minecraft:block.sponge.break": {
-        "protocol_id": 1405
-      },
-      "minecraft:block.sponge.fall": {
-        "protocol_id": 1406
-      },
-      "minecraft:block.sponge.hit": {
-        "protocol_id": 1407
-      },
-      "minecraft:block.sponge.place": {
-        "protocol_id": 1408
-      },
-      "minecraft:block.sponge.step": {
-        "protocol_id": 1409
-      },
-      "minecraft:block.spore_blossom.break": {
-        "protocol_id": 1353
-      },
-      "minecraft:block.spore_blossom.fall": {
-        "protocol_id": 1354
-      },
-      "minecraft:block.spore_blossom.hit": {
-        "protocol_id": 1355
-      },
-      "minecraft:block.spore_blossom.place": {
-        "protocol_id": 1356
-      },
-      "minecraft:block.spore_blossom.step": {
-        "protocol_id": 1357
-      },
-      "minecraft:block.stem.break": {
-        "protocol_id": 984
-      },
-      "minecraft:block.stem.fall": {
-        "protocol_id": 988
-      },
-      "minecraft:block.stem.hit": {
-        "protocol_id": 987
-      },
-      "minecraft:block.stem.place": {
-        "protocol_id": 986
-      },
-      "minecraft:block.stem.step": {
-        "protocol_id": 985
-      },
-      "minecraft:block.stone.break": {
-        "protocol_id": 1417
-      },
-      "minecraft:block.stone.fall": {
-        "protocol_id": 1420
-      },
-      "minecraft:block.stone.hit": {
-        "protocol_id": 1421
-      },
-      "minecraft:block.stone.place": {
-        "protocol_id": 1422
-      },
-      "minecraft:block.stone.step": {
-        "protocol_id": 1425
-      },
-      "minecraft:block.stone_button.click_off": {
-        "protocol_id": 1418
-      },
-      "minecraft:block.stone_button.click_on": {
-        "protocol_id": 1419
-      },
-      "minecraft:block.stone_pressure_plate.click_off": {
-        "protocol_id": 1423
-      },
-      "minecraft:block.stone_pressure_plate.click_on": {
-        "protocol_id": 1424
-      },
-      "minecraft:block.suspicious_gravel.break": {
-        "protocol_id": 571
-      },
-      "minecraft:block.suspicious_gravel.fall": {
-        "protocol_id": 575
-      },
-      "minecraft:block.suspicious_gravel.hit": {
-        "protocol_id": 574
-      },
-      "minecraft:block.suspicious_gravel.place": {
-        "protocol_id": 573
-      },
-      "minecraft:block.suspicious_gravel.step": {
-        "protocol_id": 572
-      },
-      "minecraft:block.suspicious_sand.break": {
-        "protocol_id": 566
-      },
-      "minecraft:block.suspicious_sand.fall": {
-        "protocol_id": 570
-      },
-      "minecraft:block.suspicious_sand.hit": {
+      "minecraft:block.grass.break": {
         "protocol_id": 569
       },
-      "minecraft:block.suspicious_sand.place": {
-        "protocol_id": 568
+      "minecraft:block.grass.fall": {
+        "protocol_id": 570
       },
-      "minecraft:block.suspicious_sand.step": {
-        "protocol_id": 567
+      "minecraft:block.grass.hit": {
+        "protocol_id": 571
       },
-      "minecraft:block.sweet_berry_bush.break": {
-        "protocol_id": 1430
+      "minecraft:block.grass.place": {
+        "protocol_id": 572
       },
-      "minecraft:block.sweet_berry_bush.pick_berries": {
-        "protocol_id": 1432
+      "minecraft:block.grass.step": {
+        "protocol_id": 573
       },
-      "minecraft:block.sweet_berry_bush.place": {
-        "protocol_id": 1431
+      "minecraft:block.gravel.break": {
+        "protocol_id": 574
       },
-      "minecraft:block.trial_spawner.about_to_spawn_item": {
-        "protocol_id": 707
+      "minecraft:block.gravel.fall": {
+        "protocol_id": 575
       },
-      "minecraft:block.trial_spawner.ambient": {
-        "protocol_id": 712
+      "minecraft:block.gravel.hit": {
+        "protocol_id": 576
       },
-      "minecraft:block.trial_spawner.ambient_ominous": {
-        "protocol_id": 713
+      "minecraft:block.gravel.place": {
+        "protocol_id": 577
       },
-      "minecraft:block.trial_spawner.break": {
-        "protocol_id": 701
+      "minecraft:block.gravel.step": {
+        "protocol_id": 578
       },
-      "minecraft:block.trial_spawner.close_shutter": {
-        "protocol_id": 715
+      "minecraft:block.grindstone.use": {
+        "protocol_id": 579
       },
-      "minecraft:block.trial_spawner.detect_player": {
-        "protocol_id": 710
+      "minecraft:block.growing_plant.crop": {
+        "protocol_id": 580
       },
-      "minecraft:block.trial_spawner.eject_item": {
-        "protocol_id": 716
+      "minecraft:block.hanging_roots.break": {
+        "protocol_id": 589
       },
-      "minecraft:block.trial_spawner.fall": {
-        "protocol_id": 705
+      "minecraft:block.hanging_roots.fall": {
+        "protocol_id": 590
       },
-      "minecraft:block.trial_spawner.hit": {
-        "protocol_id": 704
+      "minecraft:block.hanging_roots.hit": {
+        "protocol_id": 591
       },
-      "minecraft:block.trial_spawner.ominous_activate": {
-        "protocol_id": 711
+      "minecraft:block.hanging_roots.place": {
+        "protocol_id": 592
       },
-      "minecraft:block.trial_spawner.open_shutter": {
+      "minecraft:block.hanging_roots.step": {
+        "protocol_id": 593
+      },
+      "minecraft:block.hanging_sign.break": {
+        "protocol_id": 595
+      },
+      "minecraft:block.hanging_sign.fall": {
+        "protocol_id": 596
+      },
+      "minecraft:block.hanging_sign.hit": {
+        "protocol_id": 597
+      },
+      "minecraft:block.hanging_sign.place": {
+        "protocol_id": 598
+      },
+      "minecraft:block.hanging_sign.step": {
+        "protocol_id": 594
+      },
+      "minecraft:block.honey_block.break": {
+        "protocol_id": 618
+      },
+      "minecraft:block.honey_block.fall": {
+        "protocol_id": 619
+      },
+      "minecraft:block.honey_block.hit": {
+        "protocol_id": 620
+      },
+      "minecraft:block.honey_block.place": {
+        "protocol_id": 621
+      },
+      "minecraft:block.honey_block.slide": {
+        "protocol_id": 622
+      },
+      "minecraft:block.honey_block.step": {
+        "protocol_id": 623
+      },
+      "minecraft:block.iron_door.close": {
+        "protocol_id": 666
+      },
+      "minecraft:block.iron_door.open": {
+        "protocol_id": 667
+      },
+      "minecraft:block.iron_trapdoor.close": {
+        "protocol_id": 674
+      },
+      "minecraft:block.iron_trapdoor.open": {
+        "protocol_id": 675
+      },
+      "minecraft:block.ladder.break": {
+        "protocol_id": 683
+      },
+      "minecraft:block.ladder.fall": {
+        "protocol_id": 684
+      },
+      "minecraft:block.ladder.hit": {
+        "protocol_id": 685
+      },
+      "minecraft:block.ladder.place": {
+        "protocol_id": 686
+      },
+      "minecraft:block.ladder.step": {
+        "protocol_id": 687
+      },
+      "minecraft:block.lantern.break": {
+        "protocol_id": 688
+      },
+      "minecraft:block.lantern.fall": {
+        "protocol_id": 689
+      },
+      "minecraft:block.lantern.hit": {
+        "protocol_id": 690
+      },
+      "minecraft:block.lantern.place": {
+        "protocol_id": 691
+      },
+      "minecraft:block.lantern.step": {
+        "protocol_id": 692
+      },
+      "minecraft:block.large_amethyst_bud.break": {
+        "protocol_id": 693
+      },
+      "minecraft:block.large_amethyst_bud.place": {
+        "protocol_id": 694
+      },
+      "minecraft:block.lava.ambient": {
+        "protocol_id": 695
+      },
+      "minecraft:block.lava.extinguish": {
+        "protocol_id": 696
+      },
+      "minecraft:block.lava.pop": {
+        "protocol_id": 697
+      },
+      "minecraft:block.lever.click": {
+        "protocol_id": 700
+      },
+      "minecraft:block.lily_pad.place": {
+        "protocol_id": 1362
+      },
+      "minecraft:block.lodestone.break": {
         "protocol_id": 714
       },
-      "minecraft:block.trial_spawner.place": {
-        "protocol_id": 703
+      "minecraft:block.lodestone.fall": {
+        "protocol_id": 718
       },
-      "minecraft:block.trial_spawner.spawn_item": {
-        "protocol_id": 708
+      "minecraft:block.lodestone.hit": {
+        "protocol_id": 717
       },
-      "minecraft:block.trial_spawner.spawn_item_begin": {
-        "protocol_id": 709
+      "minecraft:block.lodestone.place": {
+        "protocol_id": 716
       },
-      "minecraft:block.trial_spawner.spawn_mob": {
-        "protocol_id": 706
+      "minecraft:block.lodestone.step": {
+        "protocol_id": 715
       },
-      "minecraft:block.trial_spawner.step": {
-        "protocol_id": 702
+      "minecraft:block.mangrove_roots.break": {
+        "protocol_id": 726
       },
-      "minecraft:block.tripwire.attach": {
-        "protocol_id": 1448
+      "minecraft:block.mangrove_roots.fall": {
+        "protocol_id": 727
       },
-      "minecraft:block.tripwire.click_off": {
-        "protocol_id": 1449
+      "minecraft:block.mangrove_roots.hit": {
+        "protocol_id": 728
       },
-      "minecraft:block.tripwire.click_on": {
-        "protocol_id": 1450
+      "minecraft:block.mangrove_roots.place": {
+        "protocol_id": 729
       },
-      "minecraft:block.tripwire.detach": {
-        "protocol_id": 1451
+      "minecraft:block.mangrove_roots.step": {
+        "protocol_id": 730
       },
-      "minecraft:block.tuff.break": {
-        "protocol_id": 1456
+      "minecraft:block.medium_amethyst_bud.break": {
+        "protocol_id": 731
       },
-      "minecraft:block.tuff.fall": {
-        "protocol_id": 1460
+      "minecraft:block.medium_amethyst_bud.place": {
+        "protocol_id": 732
       },
-      "minecraft:block.tuff.hit": {
-        "protocol_id": 1459
+      "minecraft:block.metal.break": {
+        "protocol_id": 733
       },
-      "minecraft:block.tuff.place": {
-        "protocol_id": 1458
+      "minecraft:block.metal.fall": {
+        "protocol_id": 734
       },
-      "minecraft:block.tuff.step": {
-        "protocol_id": 1457
+      "minecraft:block.metal.hit": {
+        "protocol_id": 735
       },
-      "minecraft:block.tuff_bricks.break": {
-        "protocol_id": 1461
+      "minecraft:block.metal.place": {
+        "protocol_id": 736
       },
-      "minecraft:block.tuff_bricks.fall": {
-        "protocol_id": 1462
+      "minecraft:block.metal.step": {
+        "protocol_id": 739
       },
-      "minecraft:block.tuff_bricks.hit": {
-        "protocol_id": 1463
+      "minecraft:block.metal_pressure_plate.click_off": {
+        "protocol_id": 737
       },
-      "minecraft:block.tuff_bricks.place": {
-        "protocol_id": 1464
+      "minecraft:block.metal_pressure_plate.click_on": {
+        "protocol_id": 738
       },
-      "minecraft:block.tuff_bricks.step": {
-        "protocol_id": 1465
+      "minecraft:block.moss.break": {
+        "protocol_id": 758
       },
-      "minecraft:block.vault.activate": {
-        "protocol_id": 1492
+      "minecraft:block.moss.fall": {
+        "protocol_id": 759
       },
-      "minecraft:block.vault.ambient": {
-        "protocol_id": 1493
+      "minecraft:block.moss.hit": {
+        "protocol_id": 760
       },
-      "minecraft:block.vault.break": {
-        "protocol_id": 1494
+      "minecraft:block.moss.place": {
+        "protocol_id": 761
       },
-      "minecraft:block.vault.close_shutter": {
-        "protocol_id": 1495
+      "minecraft:block.moss.step": {
+        "protocol_id": 762
       },
-      "minecraft:block.vault.deactivate": {
-        "protocol_id": 1496
+      "minecraft:block.moss_carpet.break": {
+        "protocol_id": 748
       },
-      "minecraft:block.vault.eject_item": {
-        "protocol_id": 1497
+      "minecraft:block.moss_carpet.fall": {
+        "protocol_id": 749
       },
-      "minecraft:block.vault.fall": {
-        "protocol_id": 1499
+      "minecraft:block.moss_carpet.hit": {
+        "protocol_id": 750
       },
-      "minecraft:block.vault.hit": {
-        "protocol_id": 1500
+      "minecraft:block.moss_carpet.place": {
+        "protocol_id": 751
       },
-      "minecraft:block.vault.insert_item": {
-        "protocol_id": 1501
+      "minecraft:block.moss_carpet.step": {
+        "protocol_id": 752
       },
-      "minecraft:block.vault.insert_item_fail": {
-        "protocol_id": 1502
+      "minecraft:block.mud.break": {
+        "protocol_id": 763
       },
-      "minecraft:block.vault.open_shutter": {
-        "protocol_id": 1503
+      "minecraft:block.mud.fall": {
+        "protocol_id": 764
       },
-      "minecraft:block.vault.place": {
-        "protocol_id": 1504
+      "minecraft:block.mud.hit": {
+        "protocol_id": 765
       },
-      "minecraft:block.vault.reject_rewarded_player": {
-        "protocol_id": 1498
+      "minecraft:block.mud.place": {
+        "protocol_id": 766
       },
-      "minecraft:block.vault.step": {
-        "protocol_id": 1505
+      "minecraft:block.mud.step": {
+        "protocol_id": 767
       },
-      "minecraft:block.vine.break": {
-        "protocol_id": 1534
+      "minecraft:block.mud_bricks.break": {
+        "protocol_id": 768
       },
-      "minecraft:block.vine.fall": {
-        "protocol_id": 1535
+      "minecraft:block.mud_bricks.fall": {
+        "protocol_id": 769
       },
-      "minecraft:block.vine.hit": {
-        "protocol_id": 1536
+      "minecraft:block.mud_bricks.hit": {
+        "protocol_id": 770
       },
-      "minecraft:block.vine.place": {
-        "protocol_id": 1537
+      "minecraft:block.mud_bricks.place": {
+        "protocol_id": 771
       },
-      "minecraft:block.vine.step": {
-        "protocol_id": 1538
+      "minecraft:block.mud_bricks.step": {
+        "protocol_id": 772
       },
-      "minecraft:block.wart_block.break": {
-        "protocol_id": 1009
+      "minecraft:block.muddy_mangrove_roots.break": {
+        "protocol_id": 773
       },
-      "minecraft:block.wart_block.fall": {
-        "protocol_id": 1013
+      "minecraft:block.muddy_mangrove_roots.fall": {
+        "protocol_id": 774
       },
-      "minecraft:block.wart_block.hit": {
-        "protocol_id": 1012
+      "minecraft:block.muddy_mangrove_roots.hit": {
+        "protocol_id": 775
       },
-      "minecraft:block.wart_block.place": {
-        "protocol_id": 1011
+      "minecraft:block.muddy_mangrove_roots.place": {
+        "protocol_id": 776
       },
-      "minecraft:block.wart_block.step": {
-        "protocol_id": 1010
+      "minecraft:block.muddy_mangrove_roots.step": {
+        "protocol_id": 777
       },
-      "minecraft:block.water.ambient": {
-        "protocol_id": 1572
+      "minecraft:block.nether_bricks.break": {
+        "protocol_id": 831
       },
-      "minecraft:block.weeping_vines.break": {
-        "protocol_id": 1004
+      "minecraft:block.nether_bricks.fall": {
+        "protocol_id": 835
       },
-      "minecraft:block.weeping_vines.fall": {
-        "protocol_id": 1008
+      "minecraft:block.nether_bricks.hit": {
+        "protocol_id": 834
       },
-      "minecraft:block.weeping_vines.hit": {
+      "minecraft:block.nether_bricks.place": {
+        "protocol_id": 833
+      },
+      "minecraft:block.nether_bricks.step": {
+        "protocol_id": 832
+      },
+      "minecraft:block.nether_gold_ore.break": {
+        "protocol_id": 1070
+      },
+      "minecraft:block.nether_gold_ore.fall": {
+        "protocol_id": 1071
+      },
+      "minecraft:block.nether_gold_ore.hit": {
+        "protocol_id": 1072
+      },
+      "minecraft:block.nether_gold_ore.place": {
+        "protocol_id": 1073
+      },
+      "minecraft:block.nether_gold_ore.step": {
+        "protocol_id": 1074
+      },
+      "minecraft:block.nether_ore.break": {
+        "protocol_id": 1075
+      },
+      "minecraft:block.nether_ore.fall": {
+        "protocol_id": 1076
+      },
+      "minecraft:block.nether_ore.hit": {
+        "protocol_id": 1077
+      },
+      "minecraft:block.nether_ore.place": {
+        "protocol_id": 1078
+      },
+      "minecraft:block.nether_ore.step": {
+        "protocol_id": 1079
+      },
+      "minecraft:block.nether_sprouts.break": {
+        "protocol_id": 869
+      },
+      "minecraft:block.nether_sprouts.fall": {
+        "protocol_id": 873
+      },
+      "minecraft:block.nether_sprouts.hit": {
+        "protocol_id": 872
+      },
+      "minecraft:block.nether_sprouts.place": {
+        "protocol_id": 871
+      },
+      "minecraft:block.nether_sprouts.step": {
+        "protocol_id": 870
+      },
+      "minecraft:block.nether_wart.break": {
+        "protocol_id": 836
+      },
+      "minecraft:block.nether_wood.break": {
+        "protocol_id": 838
+      },
+      "minecraft:block.nether_wood.fall": {
+        "protocol_id": 839
+      },
+      "minecraft:block.nether_wood.hit": {
+        "protocol_id": 840
+      },
+      "minecraft:block.nether_wood.place": {
+        "protocol_id": 841
+      },
+      "minecraft:block.nether_wood.step": {
+        "protocol_id": 842
+      },
+      "minecraft:block.nether_wood_button.click_off": {
+        "protocol_id": 847
+      },
+      "minecraft:block.nether_wood_button.click_on": {
+        "protocol_id": 848
+      },
+      "minecraft:block.nether_wood_door.close": {
+        "protocol_id": 843
+      },
+      "minecraft:block.nether_wood_door.open": {
+        "protocol_id": 844
+      },
+      "minecraft:block.nether_wood_fence_gate.close": {
+        "protocol_id": 851
+      },
+      "minecraft:block.nether_wood_fence_gate.open": {
+        "protocol_id": 852
+      },
+      "minecraft:block.nether_wood_hanging_sign.break": {
+        "protocol_id": 600
+      },
+      "minecraft:block.nether_wood_hanging_sign.fall": {
+        "protocol_id": 601
+      },
+      "minecraft:block.nether_wood_hanging_sign.hit": {
+        "protocol_id": 602
+      },
+      "minecraft:block.nether_wood_hanging_sign.place": {
+        "protocol_id": 603
+      },
+      "minecraft:block.nether_wood_hanging_sign.step": {
+        "protocol_id": 599
+      },
+      "minecraft:block.nether_wood_pressure_plate.click_off": {
+        "protocol_id": 849
+      },
+      "minecraft:block.nether_wood_pressure_plate.click_on": {
+        "protocol_id": 850
+      },
+      "minecraft:block.nether_wood_trapdoor.close": {
+        "protocol_id": 845
+      },
+      "minecraft:block.nether_wood_trapdoor.open": {
+        "protocol_id": 846
+      },
+      "minecraft:block.netherite_block.break": {
+        "protocol_id": 889
+      },
+      "minecraft:block.netherite_block.fall": {
+        "protocol_id": 893
+      },
+      "minecraft:block.netherite_block.hit": {
+        "protocol_id": 892
+      },
+      "minecraft:block.netherite_block.place": {
+        "protocol_id": 891
+      },
+      "minecraft:block.netherite_block.step": {
+        "protocol_id": 890
+      },
+      "minecraft:block.netherrack.break": {
+        "protocol_id": 894
+      },
+      "minecraft:block.netherrack.fall": {
+        "protocol_id": 898
+      },
+      "minecraft:block.netherrack.hit": {
+        "protocol_id": 897
+      },
+      "minecraft:block.netherrack.place": {
+        "protocol_id": 896
+      },
+      "minecraft:block.netherrack.step": {
+        "protocol_id": 895
+      },
+      "minecraft:block.note_block.banjo": {
+        "protocol_id": 914
+      },
+      "minecraft:block.note_block.basedrum": {
+        "protocol_id": 899
+      },
+      "minecraft:block.note_block.bass": {
+        "protocol_id": 900
+      },
+      "minecraft:block.note_block.bell": {
+        "protocol_id": 901
+      },
+      "minecraft:block.note_block.bit": {
+        "protocol_id": 913
+      },
+      "minecraft:block.note_block.chime": {
+        "protocol_id": 902
+      },
+      "minecraft:block.note_block.cow_bell": {
+        "protocol_id": 911
+      },
+      "minecraft:block.note_block.didgeridoo": {
+        "protocol_id": 912
+      },
+      "minecraft:block.note_block.flute": {
+        "protocol_id": 903
+      },
+      "minecraft:block.note_block.guitar": {
+        "protocol_id": 904
+      },
+      "minecraft:block.note_block.harp": {
+        "protocol_id": 905
+      },
+      "minecraft:block.note_block.hat": {
+        "protocol_id": 906
+      },
+      "minecraft:block.note_block.imitate.creeper": {
+        "protocol_id": 917
+      },
+      "minecraft:block.note_block.imitate.ender_dragon": {
+        "protocol_id": 918
+      },
+      "minecraft:block.note_block.imitate.piglin": {
+        "protocol_id": 920
+      },
+      "minecraft:block.note_block.imitate.skeleton": {
+        "protocol_id": 916
+      },
+      "minecraft:block.note_block.imitate.wither_skeleton": {
+        "protocol_id": 919
+      },
+      "minecraft:block.note_block.imitate.zombie": {
+        "protocol_id": 915
+      },
+      "minecraft:block.note_block.iron_xylophone": {
+        "protocol_id": 910
+      },
+      "minecraft:block.note_block.pling": {
+        "protocol_id": 907
+      },
+      "minecraft:block.note_block.snare": {
+        "protocol_id": 908
+      },
+      "minecraft:block.note_block.xylophone": {
+        "protocol_id": 909
+      },
+      "minecraft:block.nylium.break": {
+        "protocol_id": 864
+      },
+      "minecraft:block.nylium.fall": {
+        "protocol_id": 868
+      },
+      "minecraft:block.nylium.hit": {
+        "protocol_id": 867
+      },
+      "minecraft:block.nylium.place": {
+        "protocol_id": 866
+      },
+      "minecraft:block.nylium.step": {
+        "protocol_id": 865
+      },
+      "minecraft:block.packed_mud.break": {
+        "protocol_id": 854
+      },
+      "minecraft:block.packed_mud.fall": {
+        "protocol_id": 855
+      },
+      "minecraft:block.packed_mud.hit": {
+        "protocol_id": 856
+      },
+      "minecraft:block.packed_mud.place": {
+        "protocol_id": 857
+      },
+      "minecraft:block.packed_mud.step": {
+        "protocol_id": 858
+      },
+      "minecraft:block.pink_petals.break": {
+        "protocol_id": 753
+      },
+      "minecraft:block.pink_petals.fall": {
+        "protocol_id": 754
+      },
+      "minecraft:block.pink_petals.hit": {
+        "protocol_id": 755
+      },
+      "minecraft:block.pink_petals.place": {
+        "protocol_id": 756
+      },
+      "minecraft:block.pink_petals.step": {
+        "protocol_id": 757
+      },
+      "minecraft:block.piston.contract": {
         "protocol_id": 1007
       },
+      "minecraft:block.piston.extend": {
+        "protocol_id": 1008
+      },
+      "minecraft:block.pointed_dripstone.break": {
+        "protocol_id": 374
+      },
+      "minecraft:block.pointed_dripstone.drip_lava": {
+        "protocol_id": 380
+      },
+      "minecraft:block.pointed_dripstone.drip_lava_into_cauldron": {
+        "protocol_id": 382
+      },
+      "minecraft:block.pointed_dripstone.drip_water": {
+        "protocol_id": 381
+      },
+      "minecraft:block.pointed_dripstone.drip_water_into_cauldron": {
+        "protocol_id": 383
+      },
+      "minecraft:block.pointed_dripstone.fall": {
+        "protocol_id": 378
+      },
+      "minecraft:block.pointed_dripstone.hit": {
+        "protocol_id": 377
+      },
+      "minecraft:block.pointed_dripstone.land": {
+        "protocol_id": 379
+      },
+      "minecraft:block.pointed_dripstone.place": {
+        "protocol_id": 376
+      },
+      "minecraft:block.pointed_dripstone.step": {
+        "protocol_id": 375
+      },
+      "minecraft:block.polished_deepslate.break": {
+        "protocol_id": 1035
+      },
+      "minecraft:block.polished_deepslate.fall": {
+        "protocol_id": 1036
+      },
+      "minecraft:block.polished_deepslate.hit": {
+        "protocol_id": 1037
+      },
+      "minecraft:block.polished_deepslate.place": {
+        "protocol_id": 1038
+      },
+      "minecraft:block.polished_deepslate.step": {
+        "protocol_id": 1039
+      },
+      "minecraft:block.portal.ambient": {
+        "protocol_id": 1040
+      },
+      "minecraft:block.portal.travel": {
+        "protocol_id": 1041
+      },
+      "minecraft:block.portal.trigger": {
+        "protocol_id": 1042
+      },
+      "minecraft:block.powder_snow.break": {
+        "protocol_id": 1043
+      },
+      "minecraft:block.powder_snow.fall": {
+        "protocol_id": 1044
+      },
+      "minecraft:block.powder_snow.hit": {
+        "protocol_id": 1045
+      },
+      "minecraft:block.powder_snow.place": {
+        "protocol_id": 1046
+      },
+      "minecraft:block.powder_snow.step": {
+        "protocol_id": 1047
+      },
+      "minecraft:block.pumpkin.carve": {
+        "protocol_id": 1055
+      },
+      "minecraft:block.redstone_torch.burnout": {
+        "protocol_id": 1080
+      },
+      "minecraft:block.respawn_anchor.ambient": {
+        "protocol_id": 1081
+      },
+      "minecraft:block.respawn_anchor.charge": {
+        "protocol_id": 1082
+      },
+      "minecraft:block.respawn_anchor.deplete": {
+        "protocol_id": 1083
+      },
+      "minecraft:block.respawn_anchor.set_spawn": {
+        "protocol_id": 1084
+      },
+      "minecraft:block.rooted_dirt.break": {
+        "protocol_id": 1085
+      },
+      "minecraft:block.rooted_dirt.fall": {
+        "protocol_id": 1086
+      },
+      "minecraft:block.rooted_dirt.hit": {
+        "protocol_id": 1087
+      },
+      "minecraft:block.rooted_dirt.place": {
+        "protocol_id": 1088
+      },
+      "minecraft:block.rooted_dirt.step": {
+        "protocol_id": 1089
+      },
+      "minecraft:block.roots.break": {
+        "protocol_id": 506
+      },
+      "minecraft:block.roots.fall": {
+        "protocol_id": 510
+      },
+      "minecraft:block.roots.hit": {
+        "protocol_id": 509
+      },
+      "minecraft:block.roots.place": {
+        "protocol_id": 508
+      },
+      "minecraft:block.roots.step": {
+        "protocol_id": 507
+      },
+      "minecraft:block.sand.break": {
+        "protocol_id": 1094
+      },
+      "minecraft:block.sand.fall": {
+        "protocol_id": 1095
+      },
+      "minecraft:block.sand.hit": {
+        "protocol_id": 1096
+      },
+      "minecraft:block.sand.place": {
+        "protocol_id": 1097
+      },
+      "minecraft:block.sand.step": {
+        "protocol_id": 1098
+      },
+      "minecraft:block.scaffolding.break": {
+        "protocol_id": 1099
+      },
+      "minecraft:block.scaffolding.fall": {
+        "protocol_id": 1100
+      },
+      "minecraft:block.scaffolding.hit": {
+        "protocol_id": 1101
+      },
+      "minecraft:block.scaffolding.place": {
+        "protocol_id": 1102
+      },
+      "minecraft:block.scaffolding.step": {
+        "protocol_id": 1103
+      },
+      "minecraft:block.sculk.break": {
+        "protocol_id": 1106
+      },
+      "minecraft:block.sculk.charge": {
+        "protocol_id": 1105
+      },
+      "minecraft:block.sculk.fall": {
+        "protocol_id": 1107
+      },
+      "minecraft:block.sculk.hit": {
+        "protocol_id": 1108
+      },
+      "minecraft:block.sculk.place": {
+        "protocol_id": 1109
+      },
+      "minecraft:block.sculk.spread": {
+        "protocol_id": 1104
+      },
+      "minecraft:block.sculk.step": {
+        "protocol_id": 1110
+      },
+      "minecraft:block.sculk_catalyst.bloom": {
+        "protocol_id": 1111
+      },
+      "minecraft:block.sculk_catalyst.break": {
+        "protocol_id": 1112
+      },
+      "minecraft:block.sculk_catalyst.fall": {
+        "protocol_id": 1113
+      },
+      "minecraft:block.sculk_catalyst.hit": {
+        "protocol_id": 1114
+      },
+      "minecraft:block.sculk_catalyst.place": {
+        "protocol_id": 1115
+      },
+      "minecraft:block.sculk_catalyst.step": {
+        "protocol_id": 1116
+      },
+      "minecraft:block.sculk_sensor.break": {
+        "protocol_id": 1119
+      },
+      "minecraft:block.sculk_sensor.clicking": {
+        "protocol_id": 1117
+      },
+      "minecraft:block.sculk_sensor.clicking_stop": {
+        "protocol_id": 1118
+      },
+      "minecraft:block.sculk_sensor.fall": {
+        "protocol_id": 1120
+      },
+      "minecraft:block.sculk_sensor.hit": {
+        "protocol_id": 1121
+      },
+      "minecraft:block.sculk_sensor.place": {
+        "protocol_id": 1122
+      },
+      "minecraft:block.sculk_sensor.step": {
+        "protocol_id": 1123
+      },
+      "minecraft:block.sculk_shrieker.break": {
+        "protocol_id": 1124
+      },
+      "minecraft:block.sculk_shrieker.fall": {
+        "protocol_id": 1125
+      },
+      "minecraft:block.sculk_shrieker.hit": {
+        "protocol_id": 1126
+      },
+      "minecraft:block.sculk_shrieker.place": {
+        "protocol_id": 1127
+      },
+      "minecraft:block.sculk_shrieker.shriek": {
+        "protocol_id": 1128
+      },
+      "minecraft:block.sculk_shrieker.step": {
+        "protocol_id": 1129
+      },
+      "minecraft:block.sculk_vein.break": {
+        "protocol_id": 1130
+      },
+      "minecraft:block.sculk_vein.fall": {
+        "protocol_id": 1131
+      },
+      "minecraft:block.sculk_vein.hit": {
+        "protocol_id": 1132
+      },
+      "minecraft:block.sculk_vein.place": {
+        "protocol_id": 1133
+      },
+      "minecraft:block.sculk_vein.step": {
+        "protocol_id": 1134
+      },
+      "minecraft:block.shroomlight.break": {
+        "protocol_id": 1142
+      },
+      "minecraft:block.shroomlight.fall": {
+        "protocol_id": 1146
+      },
+      "minecraft:block.shroomlight.hit": {
+        "protocol_id": 1145
+      },
+      "minecraft:block.shroomlight.place": {
+        "protocol_id": 1144
+      },
+      "minecraft:block.shroomlight.step": {
+        "protocol_id": 1143
+      },
+      "minecraft:block.shulker_box.close": {
+        "protocol_id": 1149
+      },
+      "minecraft:block.shulker_box.open": {
+        "protocol_id": 1150
+      },
+      "minecraft:block.sign.waxed_interact_fail": {
+        "protocol_id": 1393
+      },
+      "minecraft:block.slime_block.break": {
+        "protocol_id": 1183
+      },
+      "minecraft:block.slime_block.fall": {
+        "protocol_id": 1184
+      },
+      "minecraft:block.slime_block.hit": {
+        "protocol_id": 1185
+      },
+      "minecraft:block.slime_block.place": {
+        "protocol_id": 1186
+      },
+      "minecraft:block.slime_block.step": {
+        "protocol_id": 1187
+      },
+      "minecraft:block.small_amethyst_bud.break": {
+        "protocol_id": 1188
+      },
+      "minecraft:block.small_amethyst_bud.place": {
+        "protocol_id": 1189
+      },
+      "minecraft:block.small_dripleaf.break": {
+        "protocol_id": 1190
+      },
+      "minecraft:block.small_dripleaf.fall": {
+        "protocol_id": 1191
+      },
+      "minecraft:block.small_dripleaf.hit": {
+        "protocol_id": 1192
+      },
+      "minecraft:block.small_dripleaf.place": {
+        "protocol_id": 1193
+      },
+      "minecraft:block.small_dripleaf.step": {
+        "protocol_id": 1194
+      },
+      "minecraft:block.smithing_table.use": {
+        "protocol_id": 1224
+      },
+      "minecraft:block.smoker.smoke": {
+        "protocol_id": 1225
+      },
+      "minecraft:block.sniffer_egg.crack": {
+        "protocol_id": 1239
+      },
+      "minecraft:block.sniffer_egg.hatch": {
+        "protocol_id": 1240
+      },
+      "minecraft:block.sniffer_egg.plop": {
+        "protocol_id": 1238
+      },
+      "minecraft:block.snow.break": {
+        "protocol_id": 1242
+      },
+      "minecraft:block.snow.fall": {
+        "protocol_id": 1243
+      },
+      "minecraft:block.snow.hit": {
+        "protocol_id": 1249
+      },
+      "minecraft:block.snow.place": {
+        "protocol_id": 1250
+      },
+      "minecraft:block.snow.step": {
+        "protocol_id": 1251
+      },
+      "minecraft:block.soul_sand.break": {
+        "protocol_id": 1195
+      },
+      "minecraft:block.soul_sand.fall": {
+        "protocol_id": 1199
+      },
+      "minecraft:block.soul_sand.hit": {
+        "protocol_id": 1198
+      },
+      "minecraft:block.soul_sand.place": {
+        "protocol_id": 1197
+      },
+      "minecraft:block.soul_sand.step": {
+        "protocol_id": 1196
+      },
+      "minecraft:block.soul_soil.break": {
+        "protocol_id": 1200
+      },
+      "minecraft:block.soul_soil.fall": {
+        "protocol_id": 1204
+      },
+      "minecraft:block.soul_soil.hit": {
+        "protocol_id": 1203
+      },
+      "minecraft:block.soul_soil.place": {
+        "protocol_id": 1202
+      },
+      "minecraft:block.soul_soil.step": {
+        "protocol_id": 1201
+      },
+      "minecraft:block.spore_blossom.break": {
+        "protocol_id": 1206
+      },
+      "minecraft:block.spore_blossom.fall": {
+        "protocol_id": 1207
+      },
+      "minecraft:block.spore_blossom.hit": {
+        "protocol_id": 1208
+      },
+      "minecraft:block.spore_blossom.place": {
+        "protocol_id": 1209
+      },
+      "minecraft:block.spore_blossom.step": {
+        "protocol_id": 1210
+      },
+      "minecraft:block.stem.break": {
+        "protocol_id": 859
+      },
+      "minecraft:block.stem.fall": {
+        "protocol_id": 863
+      },
+      "minecraft:block.stem.hit": {
+        "protocol_id": 862
+      },
+      "minecraft:block.stem.place": {
+        "protocol_id": 861
+      },
+      "minecraft:block.stem.step": {
+        "protocol_id": 860
+      },
+      "minecraft:block.stone.break": {
+        "protocol_id": 1264
+      },
+      "minecraft:block.stone.fall": {
+        "protocol_id": 1267
+      },
+      "minecraft:block.stone.hit": {
+        "protocol_id": 1268
+      },
+      "minecraft:block.stone.place": {
+        "protocol_id": 1269
+      },
+      "minecraft:block.stone.step": {
+        "protocol_id": 1272
+      },
+      "minecraft:block.stone_button.click_off": {
+        "protocol_id": 1265
+      },
+      "minecraft:block.stone_button.click_on": {
+        "protocol_id": 1266
+      },
+      "minecraft:block.stone_pressure_plate.click_off": {
+        "protocol_id": 1270
+      },
+      "minecraft:block.stone_pressure_plate.click_on": {
+        "protocol_id": 1271
+      },
+      "minecraft:block.suspicious_gravel.break": {
+        "protocol_id": 482
+      },
+      "minecraft:block.suspicious_gravel.fall": {
+        "protocol_id": 486
+      },
+      "minecraft:block.suspicious_gravel.hit": {
+        "protocol_id": 485
+      },
+      "minecraft:block.suspicious_gravel.place": {
+        "protocol_id": 484
+      },
+      "minecraft:block.suspicious_gravel.step": {
+        "protocol_id": 483
+      },
+      "minecraft:block.suspicious_sand.break": {
+        "protocol_id": 477
+      },
+      "minecraft:block.suspicious_sand.fall": {
+        "protocol_id": 481
+      },
+      "minecraft:block.suspicious_sand.hit": {
+        "protocol_id": 480
+      },
+      "minecraft:block.suspicious_sand.place": {
+        "protocol_id": 479
+      },
+      "minecraft:block.suspicious_sand.step": {
+        "protocol_id": 478
+      },
+      "minecraft:block.sweet_berry_bush.break": {
+        "protocol_id": 1277
+      },
+      "minecraft:block.sweet_berry_bush.pick_berries": {
+        "protocol_id": 1279
+      },
+      "minecraft:block.sweet_berry_bush.place": {
+        "protocol_id": 1278
+      },
+      "minecraft:block.tripwire.attach": {
+        "protocol_id": 1295
+      },
+      "minecraft:block.tripwire.click_off": {
+        "protocol_id": 1296
+      },
+      "minecraft:block.tripwire.click_on": {
+        "protocol_id": 1297
+      },
+      "minecraft:block.tripwire.detach": {
+        "protocol_id": 1298
+      },
+      "minecraft:block.tuff.break": {
+        "protocol_id": 1303
+      },
+      "minecraft:block.tuff.fall": {
+        "protocol_id": 1307
+      },
+      "minecraft:block.tuff.hit": {
+        "protocol_id": 1306
+      },
+      "minecraft:block.tuff.place": {
+        "protocol_id": 1305
+      },
+      "minecraft:block.tuff.step": {
+        "protocol_id": 1304
+      },
+      "minecraft:block.vine.break": {
+        "protocol_id": 1357
+      },
+      "minecraft:block.vine.fall": {
+        "protocol_id": 1358
+      },
+      "minecraft:block.vine.hit": {
+        "protocol_id": 1359
+      },
+      "minecraft:block.vine.place": {
+        "protocol_id": 1360
+      },
+      "minecraft:block.vine.step": {
+        "protocol_id": 1361
+      },
+      "minecraft:block.wart_block.break": {
+        "protocol_id": 884
+      },
+      "minecraft:block.wart_block.fall": {
+        "protocol_id": 888
+      },
+      "minecraft:block.wart_block.hit": {
+        "protocol_id": 887
+      },
+      "minecraft:block.wart_block.place": {
+        "protocol_id": 886
+      },
+      "minecraft:block.wart_block.step": {
+        "protocol_id": 885
+      },
+      "minecraft:block.water.ambient": {
+        "protocol_id": 1394
+      },
+      "minecraft:block.weeping_vines.break": {
+        "protocol_id": 879
+      },
+      "minecraft:block.weeping_vines.fall": {
+        "protocol_id": 883
+      },
+      "minecraft:block.weeping_vines.hit": {
+        "protocol_id": 882
+      },
       "minecraft:block.weeping_vines.place": {
-        "protocol_id": 1006
+        "protocol_id": 881
       },
       "minecraft:block.weeping_vines.step": {
-        "protocol_id": 1005
+        "protocol_id": 880
       },
       "minecraft:block.wet_grass.break": {
-        "protocol_id": 1575
+        "protocol_id": 1397
       },
       "minecraft:block.wet_grass.fall": {
-        "protocol_id": 1576
+        "protocol_id": 1398
       },
       "minecraft:block.wet_grass.hit": {
-        "protocol_id": 1577
+        "protocol_id": 1399
       },
       "minecraft:block.wet_grass.place": {
-        "protocol_id": 1578
+        "protocol_id": 1400
       },
       "minecraft:block.wet_grass.step": {
-        "protocol_id": 1579
-      },
-      "minecraft:block.wet_sponge.break": {
-        "protocol_id": 1580
-      },
-      "minecraft:block.wet_sponge.dries": {
-        "protocol_id": 1581
-      },
-      "minecraft:block.wet_sponge.fall": {
-        "protocol_id": 1582
-      },
-      "minecraft:block.wet_sponge.hit": {
-        "protocol_id": 1583
-      },
-      "minecraft:block.wet_sponge.place": {
-        "protocol_id": 1584
-      },
-      "minecraft:block.wet_sponge.step": {
-        "protocol_id": 1585
+        "protocol_id": 1401
       },
       "minecraft:block.wood.break": {
-        "protocol_id": 1660
+        "protocol_id": 1435
       },
       "minecraft:block.wood.fall": {
-        "protocol_id": 1661
+        "protocol_id": 1436
       },
       "minecraft:block.wood.hit": {
-        "protocol_id": 1662
+        "protocol_id": 1437
       },
       "minecraft:block.wood.place": {
-        "protocol_id": 1663
+        "protocol_id": 1438
       },
       "minecraft:block.wood.step": {
-        "protocol_id": 1664
+        "protocol_id": 1439
       },
       "minecraft:block.wooden_button.click_off": {
-        "protocol_id": 1656
+        "protocol_id": 1431
       },
       "minecraft:block.wooden_button.click_on": {
-        "protocol_id": 1657
+        "protocol_id": 1432
       },
       "minecraft:block.wooden_door.close": {
-        "protocol_id": 1652
+        "protocol_id": 1427
       },
       "minecraft:block.wooden_door.open": {
-        "protocol_id": 1653
+        "protocol_id": 1428
       },
       "minecraft:block.wooden_pressure_plate.click_off": {
-        "protocol_id": 1658
+        "protocol_id": 1433
       },
       "minecraft:block.wooden_pressure_plate.click_on": {
-        "protocol_id": 1659
+        "protocol_id": 1434
       },
       "minecraft:block.wooden_trapdoor.close": {
-        "protocol_id": 1654
+        "protocol_id": 1429
       },
       "minecraft:block.wooden_trapdoor.open": {
-        "protocol_id": 1655
+        "protocol_id": 1430
       },
       "minecraft:block.wool.break": {
-        "protocol_id": 1665
+        "protocol_id": 1440
       },
       "minecraft:block.wool.fall": {
-        "protocol_id": 1666
+        "protocol_id": 1441
       },
       "minecraft:block.wool.hit": {
-        "protocol_id": 1667
+        "protocol_id": 1442
       },
       "minecraft:block.wool.place": {
-        "protocol_id": 1668
+        "protocol_id": 1443
       },
       "minecraft:block.wool.step": {
-        "protocol_id": 1669
+        "protocol_id": 1444
       },
       "minecraft:enchant.thorns.hit": {
-        "protocol_id": 1437
+        "protocol_id": 1284
       },
       "minecraft:entity.allay.ambient_with_item": {
         "protocol_id": 0
@@ -14800,2725 +12157,2408 @@
       "minecraft:entity.allay.item_thrown": {
         "protocol_id": 6
       },
-      "minecraft:entity.armadillo.ambient": {
-        "protocol_id": 57
-      },
-      "minecraft:entity.armadillo.brush": {
-        "protocol_id": 66
-      },
-      "minecraft:entity.armadillo.death": {
-        "protocol_id": 59
-      },
-      "minecraft:entity.armadillo.eat": {
-        "protocol_id": 54
-      },
-      "minecraft:entity.armadillo.hurt": {
-        "protocol_id": 55
-      },
-      "minecraft:entity.armadillo.hurt_reduced": {
-        "protocol_id": 56
-      },
-      "minecraft:entity.armadillo.land": {
-        "protocol_id": 61
-      },
-      "minecraft:entity.armadillo.peek": {
-        "protocol_id": 64
-      },
-      "minecraft:entity.armadillo.roll": {
-        "protocol_id": 60
-      },
-      "minecraft:entity.armadillo.scute_drop": {
-        "protocol_id": 62
-      },
-      "minecraft:entity.armadillo.step": {
-        "protocol_id": 58
-      },
-      "minecraft:entity.armadillo.unroll_finish": {
+      "minecraft:entity.armor_stand.break": {
         "protocol_id": 63
       },
-      "minecraft:entity.armadillo.unroll_start": {
-        "protocol_id": 65
-      },
-      "minecraft:entity.armor_stand.break": {
-        "protocol_id": 78
-      },
       "minecraft:entity.armor_stand.fall": {
-        "protocol_id": 79
+        "protocol_id": 64
       },
       "minecraft:entity.armor_stand.hit": {
-        "protocol_id": 80
+        "protocol_id": 65
       },
       "minecraft:entity.armor_stand.place": {
-        "protocol_id": 81
+        "protocol_id": 66
       },
       "minecraft:entity.arrow.hit": {
-        "protocol_id": 82
-      },
-      "minecraft:entity.arrow.hit_player": {
-        "protocol_id": 83
-      },
-      "minecraft:entity.arrow.shoot": {
-        "protocol_id": 84
-      },
-      "minecraft:entity.axolotl.attack": {
-        "protocol_id": 88
-      },
-      "minecraft:entity.axolotl.death": {
-        "protocol_id": 89
-      },
-      "minecraft:entity.axolotl.hurt": {
-        "protocol_id": 90
-      },
-      "minecraft:entity.axolotl.idle_air": {
-        "protocol_id": 91
-      },
-      "minecraft:entity.axolotl.idle_water": {
-        "protocol_id": 92
-      },
-      "minecraft:entity.axolotl.splash": {
-        "protocol_id": 93
-      },
-      "minecraft:entity.axolotl.swim": {
-        "protocol_id": 94
-      },
-      "minecraft:entity.bat.ambient": {
-        "protocol_id": 135
-      },
-      "minecraft:entity.bat.death": {
-        "protocol_id": 136
-      },
-      "minecraft:entity.bat.hurt": {
-        "protocol_id": 137
-      },
-      "minecraft:entity.bat.loop": {
-        "protocol_id": 138
-      },
-      "minecraft:entity.bat.takeoff": {
-        "protocol_id": 139
-      },
-      "minecraft:entity.bee.death": {
-        "protocol_id": 144
-      },
-      "minecraft:entity.bee.hurt": {
-        "protocol_id": 145
-      },
-      "minecraft:entity.bee.loop": {
-        "protocol_id": 147
-      },
-      "minecraft:entity.bee.loop_aggressive": {
-        "protocol_id": 146
-      },
-      "minecraft:entity.bee.pollinate": {
-        "protocol_id": 149
-      },
-      "minecraft:entity.bee.sting": {
-        "protocol_id": 148
-      },
-      "minecraft:entity.blaze.ambient": {
-        "protocol_id": 162
-      },
-      "minecraft:entity.blaze.burn": {
-        "protocol_id": 163
-      },
-      "minecraft:entity.blaze.death": {
-        "protocol_id": 164
-      },
-      "minecraft:entity.blaze.hurt": {
-        "protocol_id": 165
-      },
-      "minecraft:entity.blaze.shoot": {
-        "protocol_id": 166
-      },
-      "minecraft:entity.boat.paddle_land": {
-        "protocol_id": 167
-      },
-      "minecraft:entity.boat.paddle_water": {
-        "protocol_id": 168
-      },
-      "minecraft:entity.bogged.ambient": {
-        "protocol_id": 169
-      },
-      "minecraft:entity.bogged.death": {
-        "protocol_id": 170
-      },
-      "minecraft:entity.bogged.hurt": {
-        "protocol_id": 171
-      },
-      "minecraft:entity.bogged.shear": {
-        "protocol_id": 172
-      },
-      "minecraft:entity.bogged.step": {
-        "protocol_id": 173
-      },
-      "minecraft:entity.breeze.charge": {
-        "protocol_id": 186
-      },
-      "minecraft:entity.breeze.death": {
-        "protocol_id": 195
-      },
-      "minecraft:entity.breeze.deflect": {
-        "protocol_id": 187
-      },
-      "minecraft:entity.breeze.hurt": {
-        "protocol_id": 196
-      },
-      "minecraft:entity.breeze.idle_air": {
-        "protocol_id": 190
-      },
-      "minecraft:entity.breeze.idle_ground": {
-        "protocol_id": 189
-      },
-      "minecraft:entity.breeze.inhale": {
-        "protocol_id": 188
-      },
-      "minecraft:entity.breeze.jump": {
-        "protocol_id": 192
-      },
-      "minecraft:entity.breeze.land": {
-        "protocol_id": 193
-      },
-      "minecraft:entity.breeze.shoot": {
-        "protocol_id": 191
-      },
-      "minecraft:entity.breeze.slide": {
-        "protocol_id": 194
-      },
-      "minecraft:entity.breeze.whirl": {
-        "protocol_id": 197
-      },
-      "minecraft:entity.breeze.wind_burst": {
-        "protocol_id": 198
-      },
-      "minecraft:entity.camel.ambient": {
-        "protocol_id": 235
-      },
-      "minecraft:entity.camel.dash": {
-        "protocol_id": 236
-      },
-      "minecraft:entity.camel.dash_ready": {
-        "protocol_id": 237
-      },
-      "minecraft:entity.camel.death": {
-        "protocol_id": 238
-      },
-      "minecraft:entity.camel.eat": {
-        "protocol_id": 239
-      },
-      "minecraft:entity.camel.hurt": {
-        "protocol_id": 240
-      },
-      "minecraft:entity.camel.saddle": {
-        "protocol_id": 241
-      },
-      "minecraft:entity.camel.sit": {
-        "protocol_id": 242
-      },
-      "minecraft:entity.camel.stand": {
-        "protocol_id": 243
-      },
-      "minecraft:entity.camel.step": {
-        "protocol_id": 244
-      },
-      "minecraft:entity.camel.step_sand": {
-        "protocol_id": 245
-      },
-      "minecraft:entity.cat.ambient": {
-        "protocol_id": 254
-      },
-      "minecraft:entity.cat.beg_for_food": {
-        "protocol_id": 259
-      },
-      "minecraft:entity.cat.death": {
-        "protocol_id": 256
-      },
-      "minecraft:entity.cat.eat": {
-        "protocol_id": 257
-      },
-      "minecraft:entity.cat.hiss": {
-        "protocol_id": 258
-      },
-      "minecraft:entity.cat.hurt": {
-        "protocol_id": 260
-      },
-      "minecraft:entity.cat.purr": {
-        "protocol_id": 261
-      },
-      "minecraft:entity.cat.purreow": {
-        "protocol_id": 262
-      },
-      "minecraft:entity.cat.stray_ambient": {
-        "protocol_id": 255
-      },
-      "minecraft:entity.chicken.ambient": {
-        "protocol_id": 307
-      },
-      "minecraft:entity.chicken.death": {
-        "protocol_id": 308
-      },
-      "minecraft:entity.chicken.egg": {
-        "protocol_id": 309
-      },
-      "minecraft:entity.chicken.hurt": {
-        "protocol_id": 310
-      },
-      "minecraft:entity.chicken.step": {
-        "protocol_id": 311
-      },
-      "minecraft:entity.cod.ambient": {
-        "protocol_id": 329
-      },
-      "minecraft:entity.cod.death": {
-        "protocol_id": 330
-      },
-      "minecraft:entity.cod.flop": {
-        "protocol_id": 331
-      },
-      "minecraft:entity.cod.hurt": {
-        "protocol_id": 332
-      },
-      "minecraft:entity.cow.ambient": {
-        "protocol_id": 369
-      },
-      "minecraft:entity.cow.death": {
-        "protocol_id": 370
-      },
-      "minecraft:entity.cow.hurt": {
-        "protocol_id": 371
-      },
-      "minecraft:entity.cow.milk": {
-        "protocol_id": 372
-      },
-      "minecraft:entity.cow.step": {
-        "protocol_id": 373
-      },
-      "minecraft:entity.creaking.activate": {
-        "protocol_id": 377
-      },
-      "minecraft:entity.creaking.ambient": {
-        "protocol_id": 376
-      },
-      "minecraft:entity.creaking.attack": {
-        "protocol_id": 379
-      },
-      "minecraft:entity.creaking.deactivate": {
-        "protocol_id": 378
-      },
-      "minecraft:entity.creaking.death": {
-        "protocol_id": 380
-      },
-      "minecraft:entity.creaking.freeze": {
-        "protocol_id": 382
-      },
-      "minecraft:entity.creaking.spawn": {
-        "protocol_id": 384
-      },
-      "minecraft:entity.creaking.step": {
-        "protocol_id": 381
-      },
-      "minecraft:entity.creaking.sway": {
-        "protocol_id": 385
-      },
-      "minecraft:entity.creaking.twitch": {
-        "protocol_id": 386
-      },
-      "minecraft:entity.creaking.unfreeze": {
-        "protocol_id": 383
-      },
-      "minecraft:entity.creeper.death": {
-        "protocol_id": 395
-      },
-      "minecraft:entity.creeper.hurt": {
-        "protocol_id": 396
-      },
-      "minecraft:entity.creeper.primed": {
-        "protocol_id": 397
-      },
-      "minecraft:entity.dolphin.ambient": {
-        "protocol_id": 435
-      },
-      "minecraft:entity.dolphin.ambient_water": {
-        "protocol_id": 436
-      },
-      "minecraft:entity.dolphin.attack": {
-        "protocol_id": 437
-      },
-      "minecraft:entity.dolphin.death": {
-        "protocol_id": 438
-      },
-      "minecraft:entity.dolphin.eat": {
-        "protocol_id": 439
-      },
-      "minecraft:entity.dolphin.hurt": {
-        "protocol_id": 440
-      },
-      "minecraft:entity.dolphin.jump": {
-        "protocol_id": 441
-      },
-      "minecraft:entity.dolphin.play": {
-        "protocol_id": 442
-      },
-      "minecraft:entity.dolphin.splash": {
-        "protocol_id": 443
-      },
-      "minecraft:entity.dolphin.swim": {
-        "protocol_id": 444
-      },
-      "minecraft:entity.donkey.ambient": {
-        "protocol_id": 445
-      },
-      "minecraft:entity.donkey.angry": {
-        "protocol_id": 446
-      },
-      "minecraft:entity.donkey.chest": {
-        "protocol_id": 447
-      },
-      "minecraft:entity.donkey.death": {
-        "protocol_id": 448
-      },
-      "minecraft:entity.donkey.eat": {
-        "protocol_id": 449
-      },
-      "minecraft:entity.donkey.hurt": {
-        "protocol_id": 450
-      },
-      "minecraft:entity.donkey.jump": {
-        "protocol_id": 451
-      },
-      "minecraft:entity.dragon_fireball.explode": {
-        "protocol_id": 494
-      },
-      "minecraft:entity.drowned.ambient": {
-        "protocol_id": 469
-      },
-      "minecraft:entity.drowned.ambient_water": {
-        "protocol_id": 470
-      },
-      "minecraft:entity.drowned.death": {
-        "protocol_id": 471
-      },
-      "minecraft:entity.drowned.death_water": {
-        "protocol_id": 472
-      },
-      "minecraft:entity.drowned.hurt": {
-        "protocol_id": 473
-      },
-      "minecraft:entity.drowned.hurt_water": {
-        "protocol_id": 474
-      },
-      "minecraft:entity.drowned.shoot": {
-        "protocol_id": 475
-      },
-      "minecraft:entity.drowned.step": {
-        "protocol_id": 476
-      },
-      "minecraft:entity.drowned.swim": {
-        "protocol_id": 477
-      },
-      "minecraft:entity.egg.throw": {
-        "protocol_id": 479
-      },
-      "minecraft:entity.elder_guardian.ambient": {
-        "protocol_id": 480
-      },
-      "minecraft:entity.elder_guardian.ambient_land": {
-        "protocol_id": 481
-      },
-      "minecraft:entity.elder_guardian.curse": {
-        "protocol_id": 482
-      },
-      "minecraft:entity.elder_guardian.death": {
-        "protocol_id": 483
-      },
-      "minecraft:entity.elder_guardian.death_land": {
-        "protocol_id": 484
-      },
-      "minecraft:entity.elder_guardian.flop": {
-        "protocol_id": 485
-      },
-      "minecraft:entity.elder_guardian.hurt": {
-        "protocol_id": 486
-      },
-      "minecraft:entity.elder_guardian.hurt_land": {
-        "protocol_id": 487
-      },
-      "minecraft:entity.ender_dragon.ambient": {
-        "protocol_id": 492
-      },
-      "minecraft:entity.ender_dragon.death": {
-        "protocol_id": 493
-      },
-      "minecraft:entity.ender_dragon.flap": {
-        "protocol_id": 495
-      },
-      "minecraft:entity.ender_dragon.growl": {
-        "protocol_id": 496
-      },
-      "minecraft:entity.ender_dragon.hurt": {
-        "protocol_id": 497
-      },
-      "minecraft:entity.ender_dragon.shoot": {
-        "protocol_id": 498
-      },
-      "minecraft:entity.ender_eye.death": {
-        "protocol_id": 499
-      },
-      "minecraft:entity.ender_eye.launch": {
-        "protocol_id": 500
-      },
-      "minecraft:entity.ender_pearl.throw": {
-        "protocol_id": 511
-      },
-      "minecraft:entity.enderman.ambient": {
-        "protocol_id": 501
-      },
-      "minecraft:entity.enderman.death": {
-        "protocol_id": 502
-      },
-      "minecraft:entity.enderman.hurt": {
-        "protocol_id": 503
-      },
-      "minecraft:entity.enderman.scream": {
-        "protocol_id": 504
-      },
-      "minecraft:entity.enderman.stare": {
-        "protocol_id": 505
-      },
-      "minecraft:entity.enderman.teleport": {
-        "protocol_id": 506
-      },
-      "minecraft:entity.endermite.ambient": {
-        "protocol_id": 507
-      },
-      "minecraft:entity.endermite.death": {
-        "protocol_id": 508
-      },
-      "minecraft:entity.endermite.hurt": {
-        "protocol_id": 509
-      },
-      "minecraft:entity.endermite.step": {
-        "protocol_id": 510
-      },
-      "minecraft:entity.evoker.ambient": {
-        "protocol_id": 515
-      },
-      "minecraft:entity.evoker.cast_spell": {
-        "protocol_id": 516
-      },
-      "minecraft:entity.evoker.celebrate": {
-        "protocol_id": 517
-      },
-      "minecraft:entity.evoker.death": {
-        "protocol_id": 518
-      },
-      "minecraft:entity.evoker.hurt": {
-        "protocol_id": 520
-      },
-      "minecraft:entity.evoker.prepare_attack": {
-        "protocol_id": 521
-      },
-      "minecraft:entity.evoker.prepare_summon": {
-        "protocol_id": 522
-      },
-      "minecraft:entity.evoker.prepare_wololo": {
-        "protocol_id": 523
-      },
-      "minecraft:entity.evoker_fangs.attack": {
-        "protocol_id": 519
-      },
-      "minecraft:entity.experience_bottle.throw": {
-        "protocol_id": 524
-      },
-      "minecraft:entity.experience_orb.pickup": {
-        "protocol_id": 525
-      },
-      "minecraft:entity.firework_rocket.blast": {
-        "protocol_id": 535
-      },
-      "minecraft:entity.firework_rocket.blast_far": {
-        "protocol_id": 536
-      },
-      "minecraft:entity.firework_rocket.large_blast": {
-        "protocol_id": 537
-      },
-      "minecraft:entity.firework_rocket.large_blast_far": {
-        "protocol_id": 538
-      },
-      "minecraft:entity.firework_rocket.launch": {
-        "protocol_id": 539
-      },
-      "minecraft:entity.firework_rocket.shoot": {
-        "protocol_id": 540
-      },
-      "minecraft:entity.firework_rocket.twinkle": {
-        "protocol_id": 541
-      },
-      "minecraft:entity.firework_rocket.twinkle_far": {
-        "protocol_id": 542
-      },
-      "minecraft:entity.fish.swim": {
-        "protocol_id": 545
-      },
-      "minecraft:entity.fishing_bobber.retrieve": {
-        "protocol_id": 546
-      },
-      "minecraft:entity.fishing_bobber.splash": {
-        "protocol_id": 547
-      },
-      "minecraft:entity.fishing_bobber.throw": {
-        "protocol_id": 548
-      },
-      "minecraft:entity.fox.aggro": {
-        "protocol_id": 555
-      },
-      "minecraft:entity.fox.ambient": {
-        "protocol_id": 556
-      },
-      "minecraft:entity.fox.bite": {
-        "protocol_id": 557
-      },
-      "minecraft:entity.fox.death": {
-        "protocol_id": 558
-      },
-      "minecraft:entity.fox.eat": {
-        "protocol_id": 559
-      },
-      "minecraft:entity.fox.hurt": {
-        "protocol_id": 560
-      },
-      "minecraft:entity.fox.screech": {
-        "protocol_id": 561
-      },
-      "minecraft:entity.fox.sleep": {
-        "protocol_id": 562
-      },
-      "minecraft:entity.fox.sniff": {
-        "protocol_id": 563
-      },
-      "minecraft:entity.fox.spit": {
-        "protocol_id": 564
-      },
-      "minecraft:entity.fox.teleport": {
-        "protocol_id": 565
-      },
-      "minecraft:entity.frog.ambient": {
-        "protocol_id": 587
-      },
-      "minecraft:entity.frog.death": {
-        "protocol_id": 588
-      },
-      "minecraft:entity.frog.eat": {
-        "protocol_id": 589
-      },
-      "minecraft:entity.frog.hurt": {
-        "protocol_id": 590
-      },
-      "minecraft:entity.frog.lay_spawn": {
-        "protocol_id": 591
-      },
-      "minecraft:entity.frog.long_jump": {
-        "protocol_id": 592
-      },
-      "minecraft:entity.frog.step": {
-        "protocol_id": 593
-      },
-      "minecraft:entity.frog.tongue": {
-        "protocol_id": 594
-      },
-      "minecraft:entity.generic.big_fall": {
-        "protocol_id": 601
-      },
-      "minecraft:entity.generic.burn": {
-        "protocol_id": 602
-      },
-      "minecraft:entity.generic.death": {
-        "protocol_id": 603
-      },
-      "minecraft:entity.generic.drink": {
-        "protocol_id": 604
-      },
-      "minecraft:entity.generic.eat": {
-        "protocol_id": 605
-      },
-      "minecraft:entity.generic.explode": {
-        "protocol_id": 606
-      },
-      "minecraft:entity.generic.extinguish_fire": {
-        "protocol_id": 607
-      },
-      "minecraft:entity.generic.hurt": {
-        "protocol_id": 608
-      },
-      "minecraft:entity.generic.small_fall": {
-        "protocol_id": 609
-      },
-      "minecraft:entity.generic.splash": {
-        "protocol_id": 610
-      },
-      "minecraft:entity.generic.swim": {
-        "protocol_id": 611
-      },
-      "minecraft:entity.ghast.ambient": {
-        "protocol_id": 612
-      },
-      "minecraft:entity.ghast.death": {
-        "protocol_id": 613
-      },
-      "minecraft:entity.ghast.hurt": {
-        "protocol_id": 614
-      },
-      "minecraft:entity.ghast.scream": {
-        "protocol_id": 615
-      },
-      "minecraft:entity.ghast.shoot": {
-        "protocol_id": 616
-      },
-      "minecraft:entity.ghast.warn": {
-        "protocol_id": 617
-      },
-      "minecraft:entity.glow_item_frame.add_item": {
-        "protocol_id": 629
-      },
-      "minecraft:entity.glow_item_frame.break": {
-        "protocol_id": 630
-      },
-      "minecraft:entity.glow_item_frame.place": {
-        "protocol_id": 631
-      },
-      "minecraft:entity.glow_item_frame.remove_item": {
-        "protocol_id": 632
-      },
-      "minecraft:entity.glow_item_frame.rotate_item": {
-        "protocol_id": 633
-      },
-      "minecraft:entity.glow_squid.ambient": {
-        "protocol_id": 634
-      },
-      "minecraft:entity.glow_squid.death": {
-        "protocol_id": 635
-      },
-      "minecraft:entity.glow_squid.hurt": {
-        "protocol_id": 636
-      },
-      "minecraft:entity.glow_squid.squirt": {
-        "protocol_id": 637
-      },
-      "minecraft:entity.goat.ambient": {
-        "protocol_id": 638
-      },
-      "minecraft:entity.goat.death": {
-        "protocol_id": 639
-      },
-      "minecraft:entity.goat.eat": {
-        "protocol_id": 640
-      },
-      "minecraft:entity.goat.horn_break": {
-        "protocol_id": 646
-      },
-      "minecraft:entity.goat.hurt": {
-        "protocol_id": 641
-      },
-      "minecraft:entity.goat.long_jump": {
-        "protocol_id": 642
-      },
-      "minecraft:entity.goat.milk": {
-        "protocol_id": 643
-      },
-      "minecraft:entity.goat.prepare_ram": {
-        "protocol_id": 644
-      },
-      "minecraft:entity.goat.ram_impact": {
-        "protocol_id": 645
-      },
-      "minecraft:entity.goat.screaming.ambient": {
-        "protocol_id": 647
-      },
-      "minecraft:entity.goat.screaming.death": {
-        "protocol_id": 648
-      },
-      "minecraft:entity.goat.screaming.eat": {
-        "protocol_id": 649
-      },
-      "minecraft:entity.goat.screaming.hurt": {
-        "protocol_id": 650
-      },
-      "minecraft:entity.goat.screaming.long_jump": {
-        "protocol_id": 651
-      },
-      "minecraft:entity.goat.screaming.milk": {
-        "protocol_id": 652
-      },
-      "minecraft:entity.goat.screaming.prepare_ram": {
-        "protocol_id": 653
-      },
-      "minecraft:entity.goat.screaming.ram_impact": {
-        "protocol_id": 654
-      },
-      "minecraft:entity.goat.step": {
-        "protocol_id": 655
-      },
-      "minecraft:entity.guardian.ambient": {
-        "protocol_id": 668
-      },
-      "minecraft:entity.guardian.ambient_land": {
-        "protocol_id": 669
-      },
-      "minecraft:entity.guardian.attack": {
-        "protocol_id": 670
-      },
-      "minecraft:entity.guardian.death": {
-        "protocol_id": 671
-      },
-      "minecraft:entity.guardian.death_land": {
-        "protocol_id": 672
-      },
-      "minecraft:entity.guardian.flop": {
-        "protocol_id": 673
-      },
-      "minecraft:entity.guardian.hurt": {
-        "protocol_id": 674
-      },
-      "minecraft:entity.guardian.hurt_land": {
-        "protocol_id": 675
-      },
-      "minecraft:entity.hoglin.ambient": {
-        "protocol_id": 718
-      },
-      "minecraft:entity.hoglin.angry": {
-        "protocol_id": 719
-      },
-      "minecraft:entity.hoglin.attack": {
-        "protocol_id": 720
-      },
-      "minecraft:entity.hoglin.converted_to_zombified": {
-        "protocol_id": 721
-      },
-      "minecraft:entity.hoglin.death": {
-        "protocol_id": 722
-      },
-      "minecraft:entity.hoglin.hurt": {
-        "protocol_id": 723
-      },
-      "minecraft:entity.hoglin.retreat": {
-        "protocol_id": 724
-      },
-      "minecraft:entity.hoglin.step": {
-        "protocol_id": 725
-      },
-      "minecraft:entity.horse.ambient": {
-        "protocol_id": 742
-      },
-      "minecraft:entity.horse.angry": {
-        "protocol_id": 743
-      },
-      "minecraft:entity.horse.armor": {
-        "protocol_id": 744
-      },
-      "minecraft:entity.horse.breathe": {
-        "protocol_id": 745
-      },
-      "minecraft:entity.horse.death": {
-        "protocol_id": 746
-      },
-      "minecraft:entity.horse.eat": {
-        "protocol_id": 747
-      },
-      "minecraft:entity.horse.gallop": {
-        "protocol_id": 748
-      },
-      "minecraft:entity.horse.hurt": {
-        "protocol_id": 749
-      },
-      "minecraft:entity.horse.jump": {
-        "protocol_id": 750
-      },
-      "minecraft:entity.horse.land": {
-        "protocol_id": 751
-      },
-      "minecraft:entity.horse.saddle": {
-        "protocol_id": 752
-      },
-      "minecraft:entity.horse.step": {
-        "protocol_id": 753
-      },
-      "minecraft:entity.horse.step_wood": {
-        "protocol_id": 754
-      },
-      "minecraft:entity.hostile.big_fall": {
-        "protocol_id": 755
-      },
-      "minecraft:entity.hostile.death": {
-        "protocol_id": 756
-      },
-      "minecraft:entity.hostile.hurt": {
-        "protocol_id": 757
-      },
-      "minecraft:entity.hostile.small_fall": {
-        "protocol_id": 758
-      },
-      "minecraft:entity.hostile.splash": {
-        "protocol_id": 759
-      },
-      "minecraft:entity.hostile.swim": {
-        "protocol_id": 760
-      },
-      "minecraft:entity.husk.ambient": {
-        "protocol_id": 761
-      },
-      "minecraft:entity.husk.converted_to_zombie": {
-        "protocol_id": 762
-      },
-      "minecraft:entity.husk.death": {
-        "protocol_id": 763
-      },
-      "minecraft:entity.husk.hurt": {
-        "protocol_id": 764
-      },
-      "minecraft:entity.husk.step": {
-        "protocol_id": 765
-      },
-      "minecraft:entity.illusioner.ambient": {
-        "protocol_id": 766
-      },
-      "minecraft:entity.illusioner.cast_spell": {
-        "protocol_id": 767
-      },
-      "minecraft:entity.illusioner.death": {
-        "protocol_id": 768
-      },
-      "minecraft:entity.illusioner.hurt": {
-        "protocol_id": 769
-      },
-      "minecraft:entity.illusioner.mirror_move": {
-        "protocol_id": 770
-      },
-      "minecraft:entity.illusioner.prepare_blindness": {
-        "protocol_id": 771
-      },
-      "minecraft:entity.illusioner.prepare_mirror": {
-        "protocol_id": 772
-      },
-      "minecraft:entity.iron_golem.attack": {
-        "protocol_id": 781
-      },
-      "minecraft:entity.iron_golem.damage": {
-        "protocol_id": 782
-      },
-      "minecraft:entity.iron_golem.death": {
-        "protocol_id": 783
-      },
-      "minecraft:entity.iron_golem.hurt": {
-        "protocol_id": 784
-      },
-      "minecraft:entity.iron_golem.repair": {
-        "protocol_id": 785
-      },
-      "minecraft:entity.iron_golem.step": {
-        "protocol_id": 786
-      },
-      "minecraft:entity.item.break": {
-        "protocol_id": 794
-      },
-      "minecraft:entity.item.pickup": {
-        "protocol_id": 795
-      },
-      "minecraft:entity.item_frame.add_item": {
-        "protocol_id": 789
-      },
-      "minecraft:entity.item_frame.break": {
-        "protocol_id": 790
-      },
-      "minecraft:entity.item_frame.place": {
-        "protocol_id": 791
-      },
-      "minecraft:entity.item_frame.remove_item": {
-        "protocol_id": 792
-      },
-      "minecraft:entity.item_frame.rotate_item": {
-        "protocol_id": 793
-      },
-      "minecraft:entity.leash_knot.break": {
-        "protocol_id": 816
-      },
-      "minecraft:entity.leash_knot.place": {
-        "protocol_id": 817
-      },
-      "minecraft:entity.lightning_bolt.impact": {
-        "protocol_id": 819
-      },
-      "minecraft:entity.lightning_bolt.thunder": {
-        "protocol_id": 820
-      },
-      "minecraft:entity.lingering_potion.throw": {
-        "protocol_id": 821
-      },
-      "minecraft:entity.llama.ambient": {
-        "protocol_id": 822
-      },
-      "minecraft:entity.llama.angry": {
-        "protocol_id": 823
-      },
-      "minecraft:entity.llama.chest": {
-        "protocol_id": 824
-      },
-      "minecraft:entity.llama.death": {
-        "protocol_id": 825
-      },
-      "minecraft:entity.llama.eat": {
-        "protocol_id": 826
-      },
-      "minecraft:entity.llama.hurt": {
-        "protocol_id": 827
-      },
-      "minecraft:entity.llama.spit": {
-        "protocol_id": 828
-      },
-      "minecraft:entity.llama.step": {
-        "protocol_id": 829
-      },
-      "minecraft:entity.llama.swag": {
-        "protocol_id": 830
-      },
-      "minecraft:entity.magma_cube.death": {
-        "protocol_id": 841
-      },
-      "minecraft:entity.magma_cube.death_small": {
-        "protocol_id": 831
-      },
-      "minecraft:entity.magma_cube.hurt": {
-        "protocol_id": 842
-      },
-      "minecraft:entity.magma_cube.hurt_small": {
-        "protocol_id": 843
-      },
-      "minecraft:entity.magma_cube.jump": {
-        "protocol_id": 844
-      },
-      "minecraft:entity.magma_cube.squish": {
-        "protocol_id": 845
-      },
-      "minecraft:entity.magma_cube.squish_small": {
-        "protocol_id": 846
-      },
-      "minecraft:entity.minecart.inside": {
-        "protocol_id": 862
-      },
-      "minecraft:entity.minecart.inside.underwater": {
-        "protocol_id": 861
-      },
-      "minecraft:entity.minecart.riding": {
-        "protocol_id": 863
-      },
-      "minecraft:entity.mooshroom.convert": {
-        "protocol_id": 864
-      },
-      "minecraft:entity.mooshroom.eat": {
-        "protocol_id": 865
-      },
-      "minecraft:entity.mooshroom.milk": {
-        "protocol_id": 866
-      },
-      "minecraft:entity.mooshroom.shear": {
-        "protocol_id": 868
-      },
-      "minecraft:entity.mooshroom.suspicious_milk": {
-        "protocol_id": 867
-      },
-      "minecraft:entity.mule.ambient": {
-        "protocol_id": 899
-      },
-      "minecraft:entity.mule.angry": {
-        "protocol_id": 900
-      },
-      "minecraft:entity.mule.chest": {
-        "protocol_id": 901
-      },
-      "minecraft:entity.mule.death": {
-        "protocol_id": 902
-      },
-      "minecraft:entity.mule.eat": {
-        "protocol_id": 903
-      },
-      "minecraft:entity.mule.hurt": {
-        "protocol_id": 904
-      },
-      "minecraft:entity.mule.jump": {
-        "protocol_id": 905
-      },
-      "minecraft:entity.ocelot.ambient": {
-        "protocol_id": 1047
-      },
-      "minecraft:entity.ocelot.death": {
-        "protocol_id": 1048
-      },
-      "minecraft:entity.ocelot.hurt": {
-        "protocol_id": 1046
-      },
-      "minecraft:entity.painting.break": {
-        "protocol_id": 1050
-      },
-      "minecraft:entity.painting.place": {
-        "protocol_id": 1051
-      },
-      "minecraft:entity.panda.aggressive_ambient": {
-        "protocol_id": 1060
-      },
-      "minecraft:entity.panda.ambient": {
-        "protocol_id": 1055
-      },
-      "minecraft:entity.panda.bite": {
-        "protocol_id": 1063
-      },
-      "minecraft:entity.panda.cant_breed": {
-        "protocol_id": 1059
-      },
-      "minecraft:entity.panda.death": {
-        "protocol_id": 1056
-      },
-      "minecraft:entity.panda.eat": {
-        "protocol_id": 1057
-      },
-      "minecraft:entity.panda.hurt": {
-        "protocol_id": 1062
-      },
-      "minecraft:entity.panda.pre_sneeze": {
-        "protocol_id": 1053
-      },
-      "minecraft:entity.panda.sneeze": {
-        "protocol_id": 1054
-      },
-      "minecraft:entity.panda.step": {
-        "protocol_id": 1058
-      },
-      "minecraft:entity.panda.worried_ambient": {
-        "protocol_id": 1061
-      },
-      "minecraft:entity.parrot.ambient": {
-        "protocol_id": 1064
-      },
-      "minecraft:entity.parrot.death": {
-        "protocol_id": 1065
-      },
-      "minecraft:entity.parrot.eat": {
-        "protocol_id": 1066
-      },
-      "minecraft:entity.parrot.fly": {
-        "protocol_id": 1067
-      },
-      "minecraft:entity.parrot.hurt": {
-        "protocol_id": 1068
-      },
-      "minecraft:entity.parrot.imitate.blaze": {
-        "protocol_id": 1069
-      },
-      "minecraft:entity.parrot.imitate.bogged": {
-        "protocol_id": 1070
-      },
-      "minecraft:entity.parrot.imitate.breeze": {
-        "protocol_id": 1071
-      },
-      "minecraft:entity.parrot.imitate.creaking": {
-        "protocol_id": 1072
-      },
-      "minecraft:entity.parrot.imitate.creeper": {
-        "protocol_id": 1073
-      },
-      "minecraft:entity.parrot.imitate.drowned": {
-        "protocol_id": 1074
-      },
-      "minecraft:entity.parrot.imitate.elder_guardian": {
-        "protocol_id": 1075
-      },
-      "minecraft:entity.parrot.imitate.ender_dragon": {
-        "protocol_id": 1076
-      },
-      "minecraft:entity.parrot.imitate.endermite": {
-        "protocol_id": 1077
-      },
-      "minecraft:entity.parrot.imitate.evoker": {
-        "protocol_id": 1078
-      },
-      "minecraft:entity.parrot.imitate.ghast": {
-        "protocol_id": 1079
-      },
-      "minecraft:entity.parrot.imitate.guardian": {
-        "protocol_id": 1080
-      },
-      "minecraft:entity.parrot.imitate.hoglin": {
-        "protocol_id": 1081
-      },
-      "minecraft:entity.parrot.imitate.husk": {
-        "protocol_id": 1082
-      },
-      "minecraft:entity.parrot.imitate.illusioner": {
-        "protocol_id": 1083
-      },
-      "minecraft:entity.parrot.imitate.magma_cube": {
-        "protocol_id": 1084
-      },
-      "minecraft:entity.parrot.imitate.phantom": {
-        "protocol_id": 1085
-      },
-      "minecraft:entity.parrot.imitate.piglin": {
-        "protocol_id": 1086
-      },
-      "minecraft:entity.parrot.imitate.piglin_brute": {
-        "protocol_id": 1087
-      },
-      "minecraft:entity.parrot.imitate.pillager": {
-        "protocol_id": 1088
-      },
-      "minecraft:entity.parrot.imitate.ravager": {
-        "protocol_id": 1089
-      },
-      "minecraft:entity.parrot.imitate.shulker": {
-        "protocol_id": 1090
-      },
-      "minecraft:entity.parrot.imitate.silverfish": {
-        "protocol_id": 1091
-      },
-      "minecraft:entity.parrot.imitate.skeleton": {
-        "protocol_id": 1092
-      },
-      "minecraft:entity.parrot.imitate.slime": {
-        "protocol_id": 1093
-      },
-      "minecraft:entity.parrot.imitate.spider": {
-        "protocol_id": 1094
-      },
-      "minecraft:entity.parrot.imitate.stray": {
-        "protocol_id": 1095
-      },
-      "minecraft:entity.parrot.imitate.vex": {
-        "protocol_id": 1096
-      },
-      "minecraft:entity.parrot.imitate.vindicator": {
-        "protocol_id": 1097
-      },
-      "minecraft:entity.parrot.imitate.warden": {
-        "protocol_id": 1098
-      },
-      "minecraft:entity.parrot.imitate.witch": {
-        "protocol_id": 1099
-      },
-      "minecraft:entity.parrot.imitate.wither": {
-        "protocol_id": 1100
-      },
-      "minecraft:entity.parrot.imitate.wither_skeleton": {
-        "protocol_id": 1101
-      },
-      "minecraft:entity.parrot.imitate.zoglin": {
-        "protocol_id": 1102
-      },
-      "minecraft:entity.parrot.imitate.zombie": {
-        "protocol_id": 1103
-      },
-      "minecraft:entity.parrot.imitate.zombie_villager": {
-        "protocol_id": 1104
-      },
-      "minecraft:entity.parrot.step": {
-        "protocol_id": 1105
-      },
-      "minecraft:entity.phantom.ambient": {
-        "protocol_id": 1106
-      },
-      "minecraft:entity.phantom.bite": {
-        "protocol_id": 1107
-      },
-      "minecraft:entity.phantom.death": {
-        "protocol_id": 1108
-      },
-      "minecraft:entity.phantom.flap": {
-        "protocol_id": 1109
-      },
-      "minecraft:entity.phantom.hurt": {
-        "protocol_id": 1110
-      },
-      "minecraft:entity.phantom.swoop": {
-        "protocol_id": 1111
-      },
-      "minecraft:entity.pig.ambient": {
-        "protocol_id": 1112
-      },
-      "minecraft:entity.pig.death": {
-        "protocol_id": 1113
-      },
-      "minecraft:entity.pig.hurt": {
-        "protocol_id": 1114
-      },
-      "minecraft:entity.pig.saddle": {
-        "protocol_id": 1115
-      },
-      "minecraft:entity.pig.step": {
-        "protocol_id": 1116
-      },
-      "minecraft:entity.piglin.admiring_item": {
-        "protocol_id": 1117
-      },
-      "minecraft:entity.piglin.ambient": {
-        "protocol_id": 1118
-      },
-      "minecraft:entity.piglin.angry": {
-        "protocol_id": 1119
-      },
-      "minecraft:entity.piglin.celebrate": {
-        "protocol_id": 1120
-      },
-      "minecraft:entity.piglin.converted_to_zombified": {
-        "protocol_id": 1126
-      },
-      "minecraft:entity.piglin.death": {
-        "protocol_id": 1121
-      },
-      "minecraft:entity.piglin.hurt": {
-        "protocol_id": 1123
-      },
-      "minecraft:entity.piglin.jealous": {
-        "protocol_id": 1122
-      },
-      "minecraft:entity.piglin.retreat": {
-        "protocol_id": 1124
-      },
-      "minecraft:entity.piglin.step": {
-        "protocol_id": 1125
-      },
-      "minecraft:entity.piglin_brute.ambient": {
-        "protocol_id": 1127
-      },
-      "minecraft:entity.piglin_brute.angry": {
-        "protocol_id": 1128
-      },
-      "minecraft:entity.piglin_brute.converted_to_zombified": {
-        "protocol_id": 1132
-      },
-      "minecraft:entity.piglin_brute.death": {
-        "protocol_id": 1129
-      },
-      "minecraft:entity.piglin_brute.hurt": {
-        "protocol_id": 1130
-      },
-      "minecraft:entity.piglin_brute.step": {
-        "protocol_id": 1131
-      },
-      "minecraft:entity.pillager.ambient": {
-        "protocol_id": 1133
-      },
-      "minecraft:entity.pillager.celebrate": {
-        "protocol_id": 1134
-      },
-      "minecraft:entity.pillager.death": {
-        "protocol_id": 1135
-      },
-      "minecraft:entity.pillager.hurt": {
-        "protocol_id": 1136
-      },
-      "minecraft:entity.player.attack.crit": {
-        "protocol_id": 1139
-      },
-      "minecraft:entity.player.attack.knockback": {
-        "protocol_id": 1140
-      },
-      "minecraft:entity.player.attack.nodamage": {
-        "protocol_id": 1141
-      },
-      "minecraft:entity.player.attack.strong": {
-        "protocol_id": 1142
-      },
-      "minecraft:entity.player.attack.sweep": {
-        "protocol_id": 1143
-      },
-      "minecraft:entity.player.attack.weak": {
-        "protocol_id": 1144
-      },
-      "minecraft:entity.player.big_fall": {
-        "protocol_id": 1145
-      },
-      "minecraft:entity.player.breath": {
-        "protocol_id": 1146
-      },
-      "minecraft:entity.player.burp": {
-        "protocol_id": 1147
-      },
-      "minecraft:entity.player.death": {
-        "protocol_id": 1148
-      },
-      "minecraft:entity.player.hurt": {
-        "protocol_id": 1149
-      },
-      "minecraft:entity.player.hurt_drown": {
-        "protocol_id": 1150
-      },
-      "minecraft:entity.player.hurt_freeze": {
-        "protocol_id": 1151
-      },
-      "minecraft:entity.player.hurt_on_fire": {
-        "protocol_id": 1152
-      },
-      "minecraft:entity.player.hurt_sweet_berry_bush": {
-        "protocol_id": 1153
-      },
-      "minecraft:entity.player.levelup": {
-        "protocol_id": 1154
-      },
-      "minecraft:entity.player.small_fall": {
-        "protocol_id": 1155
-      },
-      "minecraft:entity.player.splash": {
-        "protocol_id": 1156
-      },
-      "minecraft:entity.player.splash.high_speed": {
-        "protocol_id": 1157
-      },
-      "minecraft:entity.player.swim": {
-        "protocol_id": 1158
-      },
-      "minecraft:entity.player.teleport": {
-        "protocol_id": 1159
-      },
-      "minecraft:entity.polar_bear.ambient": {
-        "protocol_id": 1160
-      },
-      "minecraft:entity.polar_bear.ambient_baby": {
-        "protocol_id": 1161
-      },
-      "minecraft:entity.polar_bear.death": {
-        "protocol_id": 1162
-      },
-      "minecraft:entity.polar_bear.hurt": {
-        "protocol_id": 1163
-      },
-      "minecraft:entity.polar_bear.step": {
-        "protocol_id": 1164
-      },
-      "minecraft:entity.polar_bear.warning": {
-        "protocol_id": 1165
-      },
-      "minecraft:entity.puffer_fish.ambient": {
-        "protocol_id": 1179
-      },
-      "minecraft:entity.puffer_fish.blow_out": {
-        "protocol_id": 1180
-      },
-      "minecraft:entity.puffer_fish.blow_up": {
-        "protocol_id": 1181
-      },
-      "minecraft:entity.puffer_fish.death": {
-        "protocol_id": 1182
-      },
-      "minecraft:entity.puffer_fish.flop": {
-        "protocol_id": 1183
-      },
-      "minecraft:entity.puffer_fish.hurt": {
-        "protocol_id": 1184
-      },
-      "minecraft:entity.puffer_fish.sting": {
-        "protocol_id": 1185
-      },
-      "minecraft:entity.rabbit.ambient": {
-        "protocol_id": 1187
-      },
-      "minecraft:entity.rabbit.attack": {
-        "protocol_id": 1188
-      },
-      "minecraft:entity.rabbit.death": {
-        "protocol_id": 1189
-      },
-      "minecraft:entity.rabbit.hurt": {
-        "protocol_id": 1190
-      },
-      "minecraft:entity.rabbit.jump": {
-        "protocol_id": 1191
-      },
-      "minecraft:entity.ravager.ambient": {
-        "protocol_id": 1193
-      },
-      "minecraft:entity.ravager.attack": {
-        "protocol_id": 1194
-      },
-      "minecraft:entity.ravager.celebrate": {
-        "protocol_id": 1195
-      },
-      "minecraft:entity.ravager.death": {
-        "protocol_id": 1196
-      },
-      "minecraft:entity.ravager.hurt": {
-        "protocol_id": 1197
-      },
-      "minecraft:entity.ravager.roar": {
-        "protocol_id": 1200
-      },
-      "minecraft:entity.ravager.step": {
-        "protocol_id": 1198
-      },
-      "minecraft:entity.ravager.stunned": {
-        "protocol_id": 1199
-      },
-      "minecraft:entity.salmon.ambient": {
-        "protocol_id": 1221
-      },
-      "minecraft:entity.salmon.death": {
-        "protocol_id": 1222
-      },
-      "minecraft:entity.salmon.flop": {
-        "protocol_id": 1223
-      },
-      "minecraft:entity.salmon.hurt": {
-        "protocol_id": 1224
-      },
-      "minecraft:entity.sheep.ambient": {
-        "protocol_id": 1268
-      },
-      "minecraft:entity.sheep.death": {
-        "protocol_id": 1269
-      },
-      "minecraft:entity.sheep.hurt": {
-        "protocol_id": 1270
-      },
-      "minecraft:entity.sheep.shear": {
-        "protocol_id": 1271
-      },
-      "minecraft:entity.sheep.step": {
-        "protocol_id": 1272
-      },
-      "minecraft:entity.shulker.ambient": {
-        "protocol_id": 1281
-      },
-      "minecraft:entity.shulker.close": {
-        "protocol_id": 1286
-      },
-      "minecraft:entity.shulker.death": {
-        "protocol_id": 1287
-      },
-      "minecraft:entity.shulker.hurt": {
-        "protocol_id": 1288
-      },
-      "minecraft:entity.shulker.hurt_closed": {
-        "protocol_id": 1289
-      },
-      "minecraft:entity.shulker.open": {
-        "protocol_id": 1290
-      },
-      "minecraft:entity.shulker.shoot": {
-        "protocol_id": 1291
-      },
-      "minecraft:entity.shulker.teleport": {
-        "protocol_id": 1292
-      },
-      "minecraft:entity.shulker_bullet.hit": {
-        "protocol_id": 1284
-      },
-      "minecraft:entity.shulker_bullet.hurt": {
-        "protocol_id": 1285
-      },
-      "minecraft:entity.silverfish.ambient": {
-        "protocol_id": 1293
-      },
-      "minecraft:entity.silverfish.death": {
-        "protocol_id": 1294
-      },
-      "minecraft:entity.silverfish.hurt": {
-        "protocol_id": 1295
-      },
-      "minecraft:entity.silverfish.step": {
-        "protocol_id": 1296
-      },
-      "minecraft:entity.skeleton.ambient": {
-        "protocol_id": 1297
-      },
-      "minecraft:entity.skeleton.converted_to_stray": {
-        "protocol_id": 1298
-      },
-      "minecraft:entity.skeleton.death": {
-        "protocol_id": 1299
-      },
-      "minecraft:entity.skeleton.hurt": {
-        "protocol_id": 1308
-      },
-      "minecraft:entity.skeleton.shoot": {
-        "protocol_id": 1309
-      },
-      "minecraft:entity.skeleton.step": {
-        "protocol_id": 1310
-      },
-      "minecraft:entity.skeleton_horse.ambient": {
-        "protocol_id": 1300
-      },
-      "minecraft:entity.skeleton_horse.ambient_water": {
-        "protocol_id": 1304
-      },
-      "minecraft:entity.skeleton_horse.death": {
-        "protocol_id": 1301
-      },
-      "minecraft:entity.skeleton_horse.gallop_water": {
-        "protocol_id": 1305
-      },
-      "minecraft:entity.skeleton_horse.hurt": {
-        "protocol_id": 1302
-      },
-      "minecraft:entity.skeleton_horse.jump_water": {
-        "protocol_id": 1306
-      },
-      "minecraft:entity.skeleton_horse.step_water": {
-        "protocol_id": 1307
-      },
-      "minecraft:entity.skeleton_horse.swim": {
-        "protocol_id": 1303
-      },
-      "minecraft:entity.slime.attack": {
-        "protocol_id": 1311
-      },
-      "minecraft:entity.slime.death": {
-        "protocol_id": 1312
-      },
-      "minecraft:entity.slime.death_small": {
-        "protocol_id": 1367
-      },
-      "minecraft:entity.slime.hurt": {
-        "protocol_id": 1313
-      },
-      "minecraft:entity.slime.hurt_small": {
-        "protocol_id": 1368
-      },
-      "minecraft:entity.slime.jump": {
-        "protocol_id": 1314
-      },
-      "minecraft:entity.slime.jump_small": {
-        "protocol_id": 1369
-      },
-      "minecraft:entity.slime.squish": {
-        "protocol_id": 1315
-      },
-      "minecraft:entity.slime.squish_small": {
-        "protocol_id": 1370
-      },
-      "minecraft:entity.sniffer.death": {
-        "protocol_id": 1377
-      },
-      "minecraft:entity.sniffer.digging": {
-        "protocol_id": 1382
-      },
-      "minecraft:entity.sniffer.digging_stop": {
-        "protocol_id": 1383
-      },
-      "minecraft:entity.sniffer.drop_seed": {
-        "protocol_id": 1378
-      },
-      "minecraft:entity.sniffer.eat": {
-        "protocol_id": 1374
-      },
-      "minecraft:entity.sniffer.happy": {
-        "protocol_id": 1384
-      },
-      "minecraft:entity.sniffer.hurt": {
-        "protocol_id": 1376
-      },
-      "minecraft:entity.sniffer.idle": {
-        "protocol_id": 1375
-      },
-      "minecraft:entity.sniffer.scenting": {
-        "protocol_id": 1379
-      },
-      "minecraft:entity.sniffer.searching": {
-        "protocol_id": 1381
-      },
-      "minecraft:entity.sniffer.sniffing": {
-        "protocol_id": 1380
-      },
-      "minecraft:entity.sniffer.step": {
-        "protocol_id": 1373
-      },
-      "minecraft:entity.snow_golem.ambient": {
-        "protocol_id": 1391
-      },
-      "minecraft:entity.snow_golem.death": {
-        "protocol_id": 1392
-      },
-      "minecraft:entity.snow_golem.hurt": {
-        "protocol_id": 1393
-      },
-      "minecraft:entity.snow_golem.shear": {
-        "protocol_id": 1395
-      },
-      "minecraft:entity.snow_golem.shoot": {
-        "protocol_id": 1394
-      },
-      "minecraft:entity.snowball.throw": {
-        "protocol_id": 1388
-      },
-      "minecraft:entity.spider.ambient": {
-        "protocol_id": 1399
-      },
-      "minecraft:entity.spider.death": {
-        "protocol_id": 1400
-      },
-      "minecraft:entity.spider.hurt": {
-        "protocol_id": 1401
-      },
-      "minecraft:entity.spider.step": {
-        "protocol_id": 1402
-      },
-      "minecraft:entity.splash_potion.break": {
-        "protocol_id": 1403
-      },
-      "minecraft:entity.splash_potion.throw": {
-        "protocol_id": 1404
-      },
-      "minecraft:entity.squid.ambient": {
-        "protocol_id": 1413
-      },
-      "minecraft:entity.squid.death": {
-        "protocol_id": 1414
-      },
-      "minecraft:entity.squid.hurt": {
-        "protocol_id": 1415
-      },
-      "minecraft:entity.squid.squirt": {
-        "protocol_id": 1416
-      },
-      "minecraft:entity.stray.ambient": {
-        "protocol_id": 1426
-      },
-      "minecraft:entity.stray.death": {
-        "protocol_id": 1427
-      },
-      "minecraft:entity.stray.hurt": {
-        "protocol_id": 1428
-      },
-      "minecraft:entity.stray.step": {
-        "protocol_id": 1429
-      },
-      "minecraft:entity.strider.ambient": {
-        "protocol_id": 1358
-      },
-      "minecraft:entity.strider.death": {
-        "protocol_id": 1361
-      },
-      "minecraft:entity.strider.eat": {
-        "protocol_id": 1365
-      },
-      "minecraft:entity.strider.happy": {
-        "protocol_id": 1359
-      },
-      "minecraft:entity.strider.hurt": {
-        "protocol_id": 1362
-      },
-      "minecraft:entity.strider.retreat": {
-        "protocol_id": 1360
-      },
-      "minecraft:entity.strider.saddle": {
-        "protocol_id": 1366
-      },
-      "minecraft:entity.strider.step": {
-        "protocol_id": 1363
-      },
-      "minecraft:entity.strider.step_lava": {
-        "protocol_id": 1364
-      },
-      "minecraft:entity.tadpole.death": {
-        "protocol_id": 1433
-      },
-      "minecraft:entity.tadpole.flop": {
-        "protocol_id": 1434
-      },
-      "minecraft:entity.tadpole.grow_up": {
-        "protocol_id": 1435
-      },
-      "minecraft:entity.tadpole.hurt": {
-        "protocol_id": 1436
-      },
-      "minecraft:entity.tnt.primed": {
-        "protocol_id": 1438
-      },
-      "minecraft:entity.tropical_fish.ambient": {
-        "protocol_id": 1452
-      },
-      "minecraft:entity.tropical_fish.death": {
-        "protocol_id": 1453
-      },
-      "minecraft:entity.tropical_fish.flop": {
-        "protocol_id": 1454
-      },
-      "minecraft:entity.tropical_fish.hurt": {
-        "protocol_id": 1455
-      },
-      "minecraft:entity.turtle.ambient_land": {
-        "protocol_id": 1471
-      },
-      "minecraft:entity.turtle.death": {
-        "protocol_id": 1472
-      },
-      "minecraft:entity.turtle.death_baby": {
-        "protocol_id": 1473
-      },
-      "minecraft:entity.turtle.egg_break": {
-        "protocol_id": 1474
-      },
-      "minecraft:entity.turtle.egg_crack": {
-        "protocol_id": 1475
-      },
-      "minecraft:entity.turtle.egg_hatch": {
-        "protocol_id": 1476
-      },
-      "minecraft:entity.turtle.hurt": {
-        "protocol_id": 1477
-      },
-      "minecraft:entity.turtle.hurt_baby": {
-        "protocol_id": 1478
-      },
-      "minecraft:entity.turtle.lay_egg": {
-        "protocol_id": 1479
-      },
-      "minecraft:entity.turtle.shamble": {
-        "protocol_id": 1480
-      },
-      "minecraft:entity.turtle.shamble_baby": {
-        "protocol_id": 1481
-      },
-      "minecraft:entity.turtle.swim": {
-        "protocol_id": 1482
-      },
-      "minecraft:entity.vex.ambient": {
-        "protocol_id": 1506
-      },
-      "minecraft:entity.vex.charge": {
-        "protocol_id": 1507
-      },
-      "minecraft:entity.vex.death": {
-        "protocol_id": 1508
-      },
-      "minecraft:entity.vex.hurt": {
-        "protocol_id": 1509
-      },
-      "minecraft:entity.villager.ambient": {
-        "protocol_id": 1510
-      },
-      "minecraft:entity.villager.celebrate": {
-        "protocol_id": 1511
-      },
-      "minecraft:entity.villager.death": {
-        "protocol_id": 1512
-      },
-      "minecraft:entity.villager.hurt": {
-        "protocol_id": 1513
-      },
-      "minecraft:entity.villager.no": {
-        "protocol_id": 1514
-      },
-      "minecraft:entity.villager.trade": {
-        "protocol_id": 1515
-      },
-      "minecraft:entity.villager.work_armorer": {
-        "protocol_id": 1517
-      },
-      "minecraft:entity.villager.work_butcher": {
-        "protocol_id": 1518
-      },
-      "minecraft:entity.villager.work_cartographer": {
-        "protocol_id": 1519
-      },
-      "minecraft:entity.villager.work_cleric": {
-        "protocol_id": 1520
-      },
-      "minecraft:entity.villager.work_farmer": {
-        "protocol_id": 1521
-      },
-      "minecraft:entity.villager.work_fisherman": {
-        "protocol_id": 1522
-      },
-      "minecraft:entity.villager.work_fletcher": {
-        "protocol_id": 1523
-      },
-      "minecraft:entity.villager.work_leatherworker": {
-        "protocol_id": 1524
-      },
-      "minecraft:entity.villager.work_librarian": {
-        "protocol_id": 1525
-      },
-      "minecraft:entity.villager.work_mason": {
-        "protocol_id": 1526
-      },
-      "minecraft:entity.villager.work_shepherd": {
-        "protocol_id": 1527
-      },
-      "minecraft:entity.villager.work_toolsmith": {
-        "protocol_id": 1528
-      },
-      "minecraft:entity.villager.work_weaponsmith": {
-        "protocol_id": 1529
-      },
-      "minecraft:entity.villager.yes": {
-        "protocol_id": 1516
-      },
-      "minecraft:entity.vindicator.ambient": {
-        "protocol_id": 1530
-      },
-      "minecraft:entity.vindicator.celebrate": {
-        "protocol_id": 1531
-      },
-      "minecraft:entity.vindicator.death": {
-        "protocol_id": 1532
-      },
-      "minecraft:entity.vindicator.hurt": {
-        "protocol_id": 1533
-      },
-      "minecraft:entity.wandering_trader.ambient": {
-        "protocol_id": 1540
-      },
-      "minecraft:entity.wandering_trader.death": {
-        "protocol_id": 1541
-      },
-      "minecraft:entity.wandering_trader.disappeared": {
-        "protocol_id": 1542
-      },
-      "minecraft:entity.wandering_trader.drink_milk": {
-        "protocol_id": 1543
-      },
-      "minecraft:entity.wandering_trader.drink_potion": {
-        "protocol_id": 1544
-      },
-      "minecraft:entity.wandering_trader.hurt": {
-        "protocol_id": 1545
-      },
-      "minecraft:entity.wandering_trader.no": {
-        "protocol_id": 1546
-      },
-      "minecraft:entity.wandering_trader.reappeared": {
-        "protocol_id": 1547
-      },
-      "minecraft:entity.wandering_trader.trade": {
-        "protocol_id": 1548
-      },
-      "minecraft:entity.wandering_trader.yes": {
-        "protocol_id": 1549
-      },
-      "minecraft:entity.warden.agitated": {
-        "protocol_id": 1550
-      },
-      "minecraft:entity.warden.ambient": {
-        "protocol_id": 1551
-      },
-      "minecraft:entity.warden.angry": {
-        "protocol_id": 1552
-      },
-      "minecraft:entity.warden.attack_impact": {
-        "protocol_id": 1553
-      },
-      "minecraft:entity.warden.death": {
-        "protocol_id": 1554
-      },
-      "minecraft:entity.warden.dig": {
-        "protocol_id": 1555
-      },
-      "minecraft:entity.warden.emerge": {
-        "protocol_id": 1556
-      },
-      "minecraft:entity.warden.heartbeat": {
-        "protocol_id": 1557
-      },
-      "minecraft:entity.warden.hurt": {
-        "protocol_id": 1558
-      },
-      "minecraft:entity.warden.listening": {
-        "protocol_id": 1559
-      },
-      "minecraft:entity.warden.listening_angry": {
-        "protocol_id": 1560
-      },
-      "minecraft:entity.warden.nearby_close": {
-        "protocol_id": 1561
-      },
-      "minecraft:entity.warden.nearby_closer": {
-        "protocol_id": 1562
-      },
-      "minecraft:entity.warden.nearby_closest": {
-        "protocol_id": 1563
-      },
-      "minecraft:entity.warden.roar": {
-        "protocol_id": 1564
-      },
-      "minecraft:entity.warden.sniff": {
-        "protocol_id": 1565
-      },
-      "minecraft:entity.warden.sonic_boom": {
-        "protocol_id": 1566
-      },
-      "minecraft:entity.warden.sonic_charge": {
-        "protocol_id": 1567
-      },
-      "minecraft:entity.warden.step": {
-        "protocol_id": 1568
-      },
-      "minecraft:entity.warden.tendril_clicks": {
-        "protocol_id": 1569
-      },
-      "minecraft:entity.wind_charge.throw": {
-        "protocol_id": 1587
-      },
-      "minecraft:entity.wind_charge.wind_burst": {
-        "protocol_id": 1586
-      },
-      "minecraft:entity.witch.ambient": {
-        "protocol_id": 1588
-      },
-      "minecraft:entity.witch.celebrate": {
-        "protocol_id": 1589
-      },
-      "minecraft:entity.witch.death": {
-        "protocol_id": 1590
-      },
-      "minecraft:entity.witch.drink": {
-        "protocol_id": 1591
-      },
-      "minecraft:entity.witch.hurt": {
-        "protocol_id": 1592
-      },
-      "minecraft:entity.witch.throw": {
-        "protocol_id": 1593
-      },
-      "minecraft:entity.wither.ambient": {
-        "protocol_id": 1594
-      },
-      "minecraft:entity.wither.break_block": {
-        "protocol_id": 1595
-      },
-      "minecraft:entity.wither.death": {
-        "protocol_id": 1596
-      },
-      "minecraft:entity.wither.hurt": {
-        "protocol_id": 1597
-      },
-      "minecraft:entity.wither.shoot": {
-        "protocol_id": 1598
-      },
-      "minecraft:entity.wither.spawn": {
-        "protocol_id": 1603
-      },
-      "minecraft:entity.wither_skeleton.ambient": {
-        "protocol_id": 1599
-      },
-      "minecraft:entity.wither_skeleton.death": {
-        "protocol_id": 1600
-      },
-      "minecraft:entity.wither_skeleton.hurt": {
-        "protocol_id": 1601
-      },
-      "minecraft:entity.wither_skeleton.step": {
-        "protocol_id": 1602
-      },
-      "minecraft:entity.wolf.ambient": {
-        "protocol_id": 1610
-      },
-      "minecraft:entity.wolf.death": {
-        "protocol_id": 1611
-      },
-      "minecraft:entity.wolf.growl": {
-        "protocol_id": 1612
-      },
-      "minecraft:entity.wolf.hurt": {
-        "protocol_id": 1613
-      },
-      "minecraft:entity.wolf.pant": {
-        "protocol_id": 1614
-      },
-      "minecraft:entity.wolf.shake": {
-        "protocol_id": 1608
-      },
-      "minecraft:entity.wolf.step": {
-        "protocol_id": 1609
-      },
-      "minecraft:entity.wolf.whine": {
-        "protocol_id": 1615
-      },
-      "minecraft:entity.wolf_angry.ambient": {
-        "protocol_id": 1628
-      },
-      "minecraft:entity.wolf_angry.death": {
-        "protocol_id": 1629
-      },
-      "minecraft:entity.wolf_angry.growl": {
-        "protocol_id": 1630
-      },
-      "minecraft:entity.wolf_angry.hurt": {
-        "protocol_id": 1631
-      },
-      "minecraft:entity.wolf_angry.pant": {
-        "protocol_id": 1632
-      },
-      "minecraft:entity.wolf_angry.whine": {
-        "protocol_id": 1633
-      },
-      "minecraft:entity.wolf_big.ambient": {
-        "protocol_id": 1640
-      },
-      "minecraft:entity.wolf_big.death": {
-        "protocol_id": 1641
-      },
-      "minecraft:entity.wolf_big.growl": {
-        "protocol_id": 1642
-      },
-      "minecraft:entity.wolf_big.hurt": {
-        "protocol_id": 1643
-      },
-      "minecraft:entity.wolf_big.pant": {
-        "protocol_id": 1644
-      },
-      "minecraft:entity.wolf_big.whine": {
-        "protocol_id": 1645
-      },
-      "minecraft:entity.wolf_cute.ambient": {
-        "protocol_id": 1646
-      },
-      "minecraft:entity.wolf_cute.death": {
-        "protocol_id": 1647
-      },
-      "minecraft:entity.wolf_cute.growl": {
-        "protocol_id": 1648
-      },
-      "minecraft:entity.wolf_cute.hurt": {
-        "protocol_id": 1649
-      },
-      "minecraft:entity.wolf_cute.pant": {
-        "protocol_id": 1650
-      },
-      "minecraft:entity.wolf_cute.whine": {
-        "protocol_id": 1651
-      },
-      "minecraft:entity.wolf_grumpy.ambient": {
-        "protocol_id": 1634
-      },
-      "minecraft:entity.wolf_grumpy.death": {
-        "protocol_id": 1635
-      },
-      "minecraft:entity.wolf_grumpy.growl": {
-        "protocol_id": 1636
-      },
-      "minecraft:entity.wolf_grumpy.hurt": {
-        "protocol_id": 1637
-      },
-      "minecraft:entity.wolf_grumpy.pant": {
-        "protocol_id": 1638
-      },
-      "minecraft:entity.wolf_grumpy.whine": {
-        "protocol_id": 1639
-      },
-      "minecraft:entity.wolf_puglin.ambient": {
-        "protocol_id": 1616
-      },
-      "minecraft:entity.wolf_puglin.death": {
-        "protocol_id": 1617
-      },
-      "minecraft:entity.wolf_puglin.growl": {
-        "protocol_id": 1618
-      },
-      "minecraft:entity.wolf_puglin.hurt": {
-        "protocol_id": 1619
-      },
-      "minecraft:entity.wolf_puglin.pant": {
-        "protocol_id": 1620
-      },
-      "minecraft:entity.wolf_puglin.whine": {
-        "protocol_id": 1621
-      },
-      "minecraft:entity.wolf_sad.ambient": {
-        "protocol_id": 1622
-      },
-      "minecraft:entity.wolf_sad.death": {
-        "protocol_id": 1623
-      },
-      "minecraft:entity.wolf_sad.growl": {
-        "protocol_id": 1624
-      },
-      "minecraft:entity.wolf_sad.hurt": {
-        "protocol_id": 1625
-      },
-      "minecraft:entity.wolf_sad.pant": {
-        "protocol_id": 1626
-      },
-      "minecraft:entity.wolf_sad.whine": {
-        "protocol_id": 1627
-      },
-      "minecraft:entity.zoglin.ambient": {
-        "protocol_id": 1670
-      },
-      "minecraft:entity.zoglin.angry": {
-        "protocol_id": 1671
-      },
-      "minecraft:entity.zoglin.attack": {
-        "protocol_id": 1672
-      },
-      "minecraft:entity.zoglin.death": {
-        "protocol_id": 1673
-      },
-      "minecraft:entity.zoglin.hurt": {
-        "protocol_id": 1674
-      },
-      "minecraft:entity.zoglin.step": {
-        "protocol_id": 1675
-      },
-      "minecraft:entity.zombie.ambient": {
-        "protocol_id": 1676
-      },
-      "minecraft:entity.zombie.attack_iron_door": {
-        "protocol_id": 1678
-      },
-      "minecraft:entity.zombie.attack_wooden_door": {
-        "protocol_id": 1677
-      },
-      "minecraft:entity.zombie.break_wooden_door": {
-        "protocol_id": 1679
-      },
-      "minecraft:entity.zombie.converted_to_drowned": {
-        "protocol_id": 1680
-      },
-      "minecraft:entity.zombie.death": {
-        "protocol_id": 1681
-      },
-      "minecraft:entity.zombie.destroy_egg": {
-        "protocol_id": 1682
-      },
-      "minecraft:entity.zombie.hurt": {
-        "protocol_id": 1686
-      },
-      "minecraft:entity.zombie.infect": {
-        "protocol_id": 1687
-      },
-      "minecraft:entity.zombie.step": {
-        "protocol_id": 1692
-      },
-      "minecraft:entity.zombie_horse.ambient": {
-        "protocol_id": 1683
-      },
-      "minecraft:entity.zombie_horse.death": {
-        "protocol_id": 1684
-      },
-      "minecraft:entity.zombie_horse.hurt": {
-        "protocol_id": 1685
-      },
-      "minecraft:entity.zombie_villager.ambient": {
-        "protocol_id": 1693
-      },
-      "minecraft:entity.zombie_villager.converted": {
-        "protocol_id": 1694
-      },
-      "minecraft:entity.zombie_villager.cure": {
-        "protocol_id": 1695
-      },
-      "minecraft:entity.zombie_villager.death": {
-        "protocol_id": 1696
-      },
-      "minecraft:entity.zombie_villager.hurt": {
-        "protocol_id": 1697
-      },
-      "minecraft:entity.zombie_villager.step": {
-        "protocol_id": 1698
-      },
-      "minecraft:entity.zombified_piglin.ambient": {
-        "protocol_id": 1688
-      },
-      "minecraft:entity.zombified_piglin.angry": {
-        "protocol_id": 1689
-      },
-      "minecraft:entity.zombified_piglin.death": {
-        "protocol_id": 1690
-      },
-      "minecraft:entity.zombified_piglin.hurt": {
-        "protocol_id": 1691
-      },
-      "minecraft:event.mob_effect.bad_omen": {
-        "protocol_id": 1699
-      },
-      "minecraft:event.mob_effect.raid_omen": {
-        "protocol_id": 1701
-      },
-      "minecraft:event.mob_effect.trial_omen": {
-        "protocol_id": 1700
-      },
-      "minecraft:event.raid.horn": {
-        "protocol_id": 1192
-      },
-      "minecraft:intentionally_empty": {
-        "protocol_id": 978
-      },
-      "minecraft:item.armor.equip_chain": {
         "protocol_id": 67
       },
-      "minecraft:item.armor.equip_diamond": {
+      "minecraft:entity.arrow.hit_player": {
         "protocol_id": 68
       },
-      "minecraft:item.armor.equip_elytra": {
+      "minecraft:entity.arrow.shoot": {
         "protocol_id": 69
       },
-      "minecraft:item.armor.equip_generic": {
-        "protocol_id": 70
-      },
-      "minecraft:item.armor.equip_gold": {
-        "protocol_id": 71
-      },
-      "minecraft:item.armor.equip_iron": {
-        "protocol_id": 72
-      },
-      "minecraft:item.armor.equip_leather": {
+      "minecraft:entity.axolotl.attack": {
         "protocol_id": 73
       },
-      "minecraft:item.armor.equip_netherite": {
+      "minecraft:entity.axolotl.death": {
         "protocol_id": 74
       },
-      "minecraft:item.armor.equip_turtle": {
+      "minecraft:entity.axolotl.hurt": {
         "protocol_id": 75
       },
-      "minecraft:item.armor.equip_wolf": {
+      "minecraft:entity.axolotl.idle_air": {
         "protocol_id": 76
       },
-      "minecraft:item.armor.unequip_wolf": {
+      "minecraft:entity.axolotl.idle_water": {
         "protocol_id": 77
       },
-      "minecraft:item.axe.scrape": {
-        "protocol_id": 86
+      "minecraft:entity.axolotl.splash": {
+        "protocol_id": 78
       },
-      "minecraft:item.axe.strip": {
-        "protocol_id": 85
+      "minecraft:entity.axolotl.swim": {
+        "protocol_id": 79
       },
-      "minecraft:item.axe.wax_off": {
-        "protocol_id": 87
+      "minecraft:entity.bat.ambient": {
+        "protocol_id": 120
       },
-      "minecraft:item.bone_meal.use": {
-        "protocol_id": 179
+      "minecraft:entity.bat.death": {
+        "protocol_id": 121
       },
-      "minecraft:item.book.page_turn": {
-        "protocol_id": 180
+      "minecraft:entity.bat.hurt": {
+        "protocol_id": 122
       },
-      "minecraft:item.book.put": {
-        "protocol_id": 181
+      "minecraft:entity.bat.loop": {
+        "protocol_id": 123
       },
-      "minecraft:item.bottle.empty": {
-        "protocol_id": 183
+      "minecraft:entity.bat.takeoff": {
+        "protocol_id": 124
       },
-      "minecraft:item.bottle.fill": {
-        "protocol_id": 184
+      "minecraft:entity.bee.death": {
+        "protocol_id": 129
       },
-      "minecraft:item.bottle.fill_dragonbreath": {
-        "protocol_id": 185
+      "minecraft:entity.bee.hurt": {
+        "protocol_id": 130
       },
-      "minecraft:item.brush.brushing.generic": {
+      "minecraft:entity.bee.loop": {
+        "protocol_id": 132
+      },
+      "minecraft:entity.bee.loop_aggressive": {
+        "protocol_id": 131
+      },
+      "minecraft:entity.bee.pollinate": {
+        "protocol_id": 134
+      },
+      "minecraft:entity.bee.sting": {
+        "protocol_id": 133
+      },
+      "minecraft:entity.blaze.ambient": {
+        "protocol_id": 147
+      },
+      "minecraft:entity.blaze.burn": {
+        "protocol_id": 148
+      },
+      "minecraft:entity.blaze.death": {
+        "protocol_id": 149
+      },
+      "minecraft:entity.blaze.hurt": {
+        "protocol_id": 150
+      },
+      "minecraft:entity.blaze.shoot": {
+        "protocol_id": 151
+      },
+      "minecraft:entity.boat.paddle_land": {
+        "protocol_id": 152
+      },
+      "minecraft:entity.boat.paddle_water": {
+        "protocol_id": 153
+      },
+      "minecraft:entity.camel.ambient": {
+        "protocol_id": 198
+      },
+      "minecraft:entity.camel.dash": {
+        "protocol_id": 199
+      },
+      "minecraft:entity.camel.dash_ready": {
         "protocol_id": 200
       },
-      "minecraft:item.brush.brushing.gravel": {
-        "protocol_id": 202
-      },
-      "minecraft:item.brush.brushing.gravel.complete": {
-        "protocol_id": 204
-      },
-      "minecraft:item.brush.brushing.sand": {
+      "minecraft:entity.camel.death": {
         "protocol_id": 201
       },
-      "minecraft:item.brush.brushing.sand.complete": {
+      "minecraft:entity.camel.eat": {
+        "protocol_id": 202
+      },
+      "minecraft:entity.camel.hurt": {
         "protocol_id": 203
       },
-      "minecraft:item.bucket.empty": {
-        "protocol_id": 211
+      "minecraft:entity.camel.saddle": {
+        "protocol_id": 204
       },
-      "minecraft:item.bucket.empty_axolotl": {
-        "protocol_id": 212
+      "minecraft:entity.camel.sit": {
+        "protocol_id": 205
       },
-      "minecraft:item.bucket.empty_fish": {
-        "protocol_id": 213
+      "minecraft:entity.camel.stand": {
+        "protocol_id": 206
       },
-      "minecraft:item.bucket.empty_lava": {
-        "protocol_id": 214
+      "minecraft:entity.camel.step": {
+        "protocol_id": 207
       },
-      "minecraft:item.bucket.empty_powder_snow": {
-        "protocol_id": 215
+      "minecraft:entity.camel.step_sand": {
+        "protocol_id": 208
       },
-      "minecraft:item.bucket.empty_tadpole": {
-        "protocol_id": 216
-      },
-      "minecraft:item.bucket.fill": {
+      "minecraft:entity.cat.ambient": {
         "protocol_id": 217
       },
-      "minecraft:item.bucket.fill_axolotl": {
-        "protocol_id": 218
-      },
-      "minecraft:item.bucket.fill_fish": {
-        "protocol_id": 219
-      },
-      "minecraft:item.bucket.fill_lava": {
-        "protocol_id": 220
-      },
-      "minecraft:item.bucket.fill_powder_snow": {
-        "protocol_id": 221
-      },
-      "minecraft:item.bucket.fill_tadpole": {
+      "minecraft:entity.cat.beg_for_food": {
         "protocol_id": 222
       },
-      "minecraft:item.bundle.drop_contents": {
+      "minecraft:entity.cat.death": {
+        "protocol_id": 219
+      },
+      "minecraft:entity.cat.eat": {
+        "protocol_id": 220
+      },
+      "minecraft:entity.cat.hiss": {
+        "protocol_id": 221
+      },
+      "minecraft:entity.cat.hurt": {
         "protocol_id": 223
       },
-      "minecraft:item.bundle.insert": {
+      "minecraft:entity.cat.purr": {
         "protocol_id": 224
       },
-      "minecraft:item.bundle.insert_fail": {
+      "minecraft:entity.cat.purreow": {
         "protocol_id": 225
       },
-      "minecraft:item.bundle.remove_one": {
-        "protocol_id": 226
+      "minecraft:entity.cat.stray_ambient": {
+        "protocol_id": 218
       },
-      "minecraft:item.chorus_fruit.teleport": {
-        "protocol_id": 323
+      "minecraft:entity.chicken.ambient": {
+        "protocol_id": 270
       },
-      "minecraft:item.crop.plant": {
+      "minecraft:entity.chicken.death": {
+        "protocol_id": 271
+      },
+      "minecraft:entity.chicken.egg": {
+        "protocol_id": 272
+      },
+      "minecraft:entity.chicken.hurt": {
+        "protocol_id": 273
+      },
+      "minecraft:entity.chicken.step": {
+        "protocol_id": 274
+      },
+      "minecraft:entity.cod.ambient": {
+        "protocol_id": 287
+      },
+      "minecraft:entity.cod.death": {
+        "protocol_id": 288
+      },
+      "minecraft:entity.cod.flop": {
+        "protocol_id": 289
+      },
+      "minecraft:entity.cod.hurt": {
+        "protocol_id": 290
+      },
+      "minecraft:entity.cow.ambient": {
+        "protocol_id": 311
+      },
+      "minecraft:entity.cow.death": {
+        "protocol_id": 312
+      },
+      "minecraft:entity.cow.hurt": {
+        "protocol_id": 313
+      },
+      "minecraft:entity.cow.milk": {
+        "protocol_id": 314
+      },
+      "minecraft:entity.cow.step": {
+        "protocol_id": 315
+      },
+      "minecraft:entity.creeper.death": {
+        "protocol_id": 316
+      },
+      "minecraft:entity.creeper.hurt": {
+        "protocol_id": 317
+      },
+      "minecraft:entity.creeper.primed": {
+        "protocol_id": 318
+      },
+      "minecraft:entity.dolphin.ambient": {
+        "protocol_id": 353
+      },
+      "minecraft:entity.dolphin.ambient_water": {
+        "protocol_id": 354
+      },
+      "minecraft:entity.dolphin.attack": {
+        "protocol_id": 355
+      },
+      "minecraft:entity.dolphin.death": {
+        "protocol_id": 356
+      },
+      "minecraft:entity.dolphin.eat": {
+        "protocol_id": 357
+      },
+      "minecraft:entity.dolphin.hurt": {
+        "protocol_id": 358
+      },
+      "minecraft:entity.dolphin.jump": {
+        "protocol_id": 359
+      },
+      "minecraft:entity.dolphin.play": {
+        "protocol_id": 360
+      },
+      "minecraft:entity.dolphin.splash": {
+        "protocol_id": 361
+      },
+      "minecraft:entity.dolphin.swim": {
+        "protocol_id": 362
+      },
+      "minecraft:entity.donkey.ambient": {
+        "protocol_id": 363
+      },
+      "minecraft:entity.donkey.angry": {
+        "protocol_id": 364
+      },
+      "minecraft:entity.donkey.chest": {
+        "protocol_id": 365
+      },
+      "minecraft:entity.donkey.death": {
+        "protocol_id": 366
+      },
+      "minecraft:entity.donkey.eat": {
+        "protocol_id": 367
+      },
+      "minecraft:entity.donkey.hurt": {
+        "protocol_id": 368
+      },
+      "minecraft:entity.dragon_fireball.explode": {
+        "protocol_id": 411
+      },
+      "minecraft:entity.drowned.ambient": {
+        "protocol_id": 386
+      },
+      "minecraft:entity.drowned.ambient_water": {
+        "protocol_id": 387
+      },
+      "minecraft:entity.drowned.death": {
+        "protocol_id": 388
+      },
+      "minecraft:entity.drowned.death_water": {
+        "protocol_id": 389
+      },
+      "minecraft:entity.drowned.hurt": {
+        "protocol_id": 390
+      },
+      "minecraft:entity.drowned.hurt_water": {
+        "protocol_id": 391
+      },
+      "minecraft:entity.drowned.shoot": {
+        "protocol_id": 392
+      },
+      "minecraft:entity.drowned.step": {
+        "protocol_id": 393
+      },
+      "minecraft:entity.drowned.swim": {
+        "protocol_id": 394
+      },
+      "minecraft:entity.egg.throw": {
+        "protocol_id": 396
+      },
+      "minecraft:entity.elder_guardian.ambient": {
+        "protocol_id": 397
+      },
+      "minecraft:entity.elder_guardian.ambient_land": {
+        "protocol_id": 398
+      },
+      "minecraft:entity.elder_guardian.curse": {
         "protocol_id": 399
       },
-      "minecraft:item.crossbow.hit": {
+      "minecraft:entity.elder_guardian.death": {
         "protocol_id": 400
       },
-      "minecraft:item.crossbow.loading_end": {
+      "minecraft:entity.elder_guardian.death_land": {
         "protocol_id": 401
       },
-      "minecraft:item.crossbow.loading_middle": {
+      "minecraft:entity.elder_guardian.flop": {
         "protocol_id": 402
       },
-      "minecraft:item.crossbow.loading_start": {
+      "minecraft:entity.elder_guardian.hurt": {
         "protocol_id": 403
       },
-      "minecraft:item.crossbow.quick_charge_1": {
+      "minecraft:entity.elder_guardian.hurt_land": {
         "protocol_id": 404
       },
-      "minecraft:item.crossbow.quick_charge_2": {
-        "protocol_id": 405
+      "minecraft:entity.ender_dragon.ambient": {
+        "protocol_id": 409
       },
-      "minecraft:item.crossbow.quick_charge_3": {
-        "protocol_id": 406
+      "minecraft:entity.ender_dragon.death": {
+        "protocol_id": 410
       },
-      "minecraft:item.crossbow.shoot": {
-        "protocol_id": 407
+      "minecraft:entity.ender_dragon.flap": {
+        "protocol_id": 412
       },
-      "minecraft:item.dye.use": {
-        "protocol_id": 478
+      "minecraft:entity.ender_dragon.growl": {
+        "protocol_id": 413
       },
-      "minecraft:item.elytra.flying": {
-        "protocol_id": 488
+      "minecraft:entity.ender_dragon.hurt": {
+        "protocol_id": 414
       },
-      "minecraft:item.firecharge.use": {
-        "protocol_id": 533
+      "minecraft:entity.ender_dragon.shoot": {
+        "protocol_id": 415
       },
-      "minecraft:item.flintandsteel.use": {
+      "minecraft:entity.ender_eye.death": {
+        "protocol_id": 416
+      },
+      "minecraft:entity.ender_eye.launch": {
+        "protocol_id": 417
+      },
+      "minecraft:entity.ender_pearl.throw": {
+        "protocol_id": 428
+      },
+      "minecraft:entity.enderman.ambient": {
+        "protocol_id": 418
+      },
+      "minecraft:entity.enderman.death": {
+        "protocol_id": 419
+      },
+      "minecraft:entity.enderman.hurt": {
+        "protocol_id": 420
+      },
+      "minecraft:entity.enderman.scream": {
+        "protocol_id": 421
+      },
+      "minecraft:entity.enderman.stare": {
+        "protocol_id": 422
+      },
+      "minecraft:entity.enderman.teleport": {
+        "protocol_id": 423
+      },
+      "minecraft:entity.endermite.ambient": {
+        "protocol_id": 424
+      },
+      "minecraft:entity.endermite.death": {
+        "protocol_id": 425
+      },
+      "minecraft:entity.endermite.hurt": {
+        "protocol_id": 426
+      },
+      "minecraft:entity.endermite.step": {
+        "protocol_id": 427
+      },
+      "minecraft:entity.evoker.ambient": {
+        "protocol_id": 432
+      },
+      "minecraft:entity.evoker.cast_spell": {
+        "protocol_id": 433
+      },
+      "minecraft:entity.evoker.celebrate": {
+        "protocol_id": 434
+      },
+      "minecraft:entity.evoker.death": {
+        "protocol_id": 435
+      },
+      "minecraft:entity.evoker.hurt": {
+        "protocol_id": 437
+      },
+      "minecraft:entity.evoker.prepare_attack": {
+        "protocol_id": 438
+      },
+      "minecraft:entity.evoker.prepare_summon": {
+        "protocol_id": 439
+      },
+      "minecraft:entity.evoker.prepare_wololo": {
+        "protocol_id": 440
+      },
+      "minecraft:entity.evoker_fangs.attack": {
+        "protocol_id": 436
+      },
+      "minecraft:entity.experience_bottle.throw": {
+        "protocol_id": 441
+      },
+      "minecraft:entity.experience_orb.pickup": {
+        "protocol_id": 442
+      },
+      "minecraft:entity.firework_rocket.blast": {
+        "protocol_id": 446
+      },
+      "minecraft:entity.firework_rocket.blast_far": {
+        "protocol_id": 447
+      },
+      "minecraft:entity.firework_rocket.large_blast": {
+        "protocol_id": 448
+      },
+      "minecraft:entity.firework_rocket.large_blast_far": {
+        "protocol_id": 449
+      },
+      "minecraft:entity.firework_rocket.launch": {
+        "protocol_id": 450
+      },
+      "minecraft:entity.firework_rocket.shoot": {
+        "protocol_id": 451
+      },
+      "minecraft:entity.firework_rocket.twinkle": {
+        "protocol_id": 452
+      },
+      "minecraft:entity.firework_rocket.twinkle_far": {
+        "protocol_id": 453
+      },
+      "minecraft:entity.fish.swim": {
+        "protocol_id": 456
+      },
+      "minecraft:entity.fishing_bobber.retrieve": {
+        "protocol_id": 457
+      },
+      "minecraft:entity.fishing_bobber.splash": {
+        "protocol_id": 458
+      },
+      "minecraft:entity.fishing_bobber.throw": {
+        "protocol_id": 459
+      },
+      "minecraft:entity.fox.aggro": {
+        "protocol_id": 466
+      },
+      "minecraft:entity.fox.ambient": {
+        "protocol_id": 467
+      },
+      "minecraft:entity.fox.bite": {
+        "protocol_id": 468
+      },
+      "minecraft:entity.fox.death": {
+        "protocol_id": 469
+      },
+      "minecraft:entity.fox.eat": {
+        "protocol_id": 470
+      },
+      "minecraft:entity.fox.hurt": {
+        "protocol_id": 471
+      },
+      "minecraft:entity.fox.screech": {
+        "protocol_id": 472
+      },
+      "minecraft:entity.fox.sleep": {
+        "protocol_id": 473
+      },
+      "minecraft:entity.fox.sniff": {
+        "protocol_id": 474
+      },
+      "minecraft:entity.fox.spit": {
+        "protocol_id": 475
+      },
+      "minecraft:entity.fox.teleport": {
+        "protocol_id": 476
+      },
+      "minecraft:entity.frog.ambient": {
+        "protocol_id": 498
+      },
+      "minecraft:entity.frog.death": {
+        "protocol_id": 499
+      },
+      "minecraft:entity.frog.eat": {
+        "protocol_id": 500
+      },
+      "minecraft:entity.frog.hurt": {
+        "protocol_id": 501
+      },
+      "minecraft:entity.frog.lay_spawn": {
+        "protocol_id": 502
+      },
+      "minecraft:entity.frog.long_jump": {
+        "protocol_id": 503
+      },
+      "minecraft:entity.frog.step": {
+        "protocol_id": 504
+      },
+      "minecraft:entity.frog.tongue": {
+        "protocol_id": 505
+      },
+      "minecraft:entity.generic.big_fall": {
+        "protocol_id": 512
+      },
+      "minecraft:entity.generic.burn": {
+        "protocol_id": 513
+      },
+      "minecraft:entity.generic.death": {
+        "protocol_id": 514
+      },
+      "minecraft:entity.generic.drink": {
+        "protocol_id": 515
+      },
+      "minecraft:entity.generic.eat": {
+        "protocol_id": 516
+      },
+      "minecraft:entity.generic.explode": {
+        "protocol_id": 517
+      },
+      "minecraft:entity.generic.extinguish_fire": {
+        "protocol_id": 518
+      },
+      "minecraft:entity.generic.hurt": {
+        "protocol_id": 519
+      },
+      "minecraft:entity.generic.small_fall": {
+        "protocol_id": 520
+      },
+      "minecraft:entity.generic.splash": {
+        "protocol_id": 521
+      },
+      "minecraft:entity.generic.swim": {
+        "protocol_id": 522
+      },
+      "minecraft:entity.ghast.ambient": {
+        "protocol_id": 523
+      },
+      "minecraft:entity.ghast.death": {
+        "protocol_id": 524
+      },
+      "minecraft:entity.ghast.hurt": {
+        "protocol_id": 525
+      },
+      "minecraft:entity.ghast.scream": {
+        "protocol_id": 526
+      },
+      "minecraft:entity.ghast.shoot": {
+        "protocol_id": 527
+      },
+      "minecraft:entity.ghast.warn": {
+        "protocol_id": 528
+      },
+      "minecraft:entity.glow_item_frame.add_item": {
+        "protocol_id": 540
+      },
+      "minecraft:entity.glow_item_frame.break": {
+        "protocol_id": 541
+      },
+      "minecraft:entity.glow_item_frame.place": {
+        "protocol_id": 542
+      },
+      "minecraft:entity.glow_item_frame.remove_item": {
+        "protocol_id": 543
+      },
+      "minecraft:entity.glow_item_frame.rotate_item": {
+        "protocol_id": 544
+      },
+      "minecraft:entity.glow_squid.ambient": {
+        "protocol_id": 545
+      },
+      "minecraft:entity.glow_squid.death": {
+        "protocol_id": 546
+      },
+      "minecraft:entity.glow_squid.hurt": {
+        "protocol_id": 547
+      },
+      "minecraft:entity.glow_squid.squirt": {
+        "protocol_id": 548
+      },
+      "minecraft:entity.goat.ambient": {
         "protocol_id": 549
       },
-      "minecraft:item.glow_ink_sac.use": {
-        "protocol_id": 628
+      "minecraft:entity.goat.death": {
+        "protocol_id": 550
       },
-      "minecraft:item.goat_horn.sound.0": {
-        "protocol_id": 734
+      "minecraft:entity.goat.eat": {
+        "protocol_id": 551
       },
-      "minecraft:item.goat_horn.sound.1": {
-        "protocol_id": 735
+      "minecraft:entity.goat.horn_break": {
+        "protocol_id": 557
       },
-      "minecraft:item.goat_horn.sound.2": {
-        "protocol_id": 736
+      "minecraft:entity.goat.hurt": {
+        "protocol_id": 552
       },
-      "minecraft:item.goat_horn.sound.3": {
-        "protocol_id": 737
+      "minecraft:entity.goat.long_jump": {
+        "protocol_id": 553
       },
-      "minecraft:item.goat_horn.sound.4": {
-        "protocol_id": 738
+      "minecraft:entity.goat.milk": {
+        "protocol_id": 554
       },
-      "minecraft:item.goat_horn.sound.5": {
-        "protocol_id": 739
+      "minecraft:entity.goat.prepare_ram": {
+        "protocol_id": 555
       },
-      "minecraft:item.goat_horn.sound.6": {
-        "protocol_id": 740
+      "minecraft:entity.goat.ram_impact": {
+        "protocol_id": 556
       },
-      "minecraft:item.goat_horn.sound.7": {
+      "minecraft:entity.goat.screaming.ambient": {
+        "protocol_id": 559
+      },
+      "minecraft:entity.goat.screaming.death": {
+        "protocol_id": 560
+      },
+      "minecraft:entity.goat.screaming.eat": {
+        "protocol_id": 561
+      },
+      "minecraft:entity.goat.screaming.horn_break": {
+        "protocol_id": 567
+      },
+      "minecraft:entity.goat.screaming.hurt": {
+        "protocol_id": 562
+      },
+      "minecraft:entity.goat.screaming.long_jump": {
+        "protocol_id": 563
+      },
+      "minecraft:entity.goat.screaming.milk": {
+        "protocol_id": 564
+      },
+      "minecraft:entity.goat.screaming.prepare_ram": {
+        "protocol_id": 565
+      },
+      "minecraft:entity.goat.screaming.ram_impact": {
+        "protocol_id": 566
+      },
+      "minecraft:entity.goat.step": {
+        "protocol_id": 568
+      },
+      "minecraft:entity.guardian.ambient": {
+        "protocol_id": 581
+      },
+      "minecraft:entity.guardian.ambient_land": {
+        "protocol_id": 582
+      },
+      "minecraft:entity.guardian.attack": {
+        "protocol_id": 583
+      },
+      "minecraft:entity.guardian.death": {
+        "protocol_id": 584
+      },
+      "minecraft:entity.guardian.death_land": {
+        "protocol_id": 585
+      },
+      "minecraft:entity.guardian.flop": {
+        "protocol_id": 586
+      },
+      "minecraft:entity.guardian.hurt": {
+        "protocol_id": 587
+      },
+      "minecraft:entity.guardian.hurt_land": {
+        "protocol_id": 588
+      },
+      "minecraft:entity.hoglin.ambient": {
+        "protocol_id": 610
+      },
+      "minecraft:entity.hoglin.angry": {
+        "protocol_id": 611
+      },
+      "minecraft:entity.hoglin.attack": {
+        "protocol_id": 612
+      },
+      "minecraft:entity.hoglin.converted_to_zombified": {
+        "protocol_id": 613
+      },
+      "minecraft:entity.hoglin.death": {
+        "protocol_id": 614
+      },
+      "minecraft:entity.hoglin.hurt": {
+        "protocol_id": 615
+      },
+      "minecraft:entity.hoglin.retreat": {
+        "protocol_id": 616
+      },
+      "minecraft:entity.hoglin.step": {
+        "protocol_id": 617
+      },
+      "minecraft:entity.horse.ambient": {
+        "protocol_id": 634
+      },
+      "minecraft:entity.horse.angry": {
+        "protocol_id": 635
+      },
+      "minecraft:entity.horse.armor": {
+        "protocol_id": 636
+      },
+      "minecraft:entity.horse.breathe": {
+        "protocol_id": 637
+      },
+      "minecraft:entity.horse.death": {
+        "protocol_id": 638
+      },
+      "minecraft:entity.horse.eat": {
+        "protocol_id": 639
+      },
+      "minecraft:entity.horse.gallop": {
+        "protocol_id": 640
+      },
+      "minecraft:entity.horse.hurt": {
+        "protocol_id": 641
+      },
+      "minecraft:entity.horse.jump": {
+        "protocol_id": 642
+      },
+      "minecraft:entity.horse.land": {
+        "protocol_id": 643
+      },
+      "minecraft:entity.horse.saddle": {
+        "protocol_id": 644
+      },
+      "minecraft:entity.horse.step": {
+        "protocol_id": 645
+      },
+      "minecraft:entity.horse.step_wood": {
+        "protocol_id": 646
+      },
+      "minecraft:entity.hostile.big_fall": {
+        "protocol_id": 647
+      },
+      "minecraft:entity.hostile.death": {
+        "protocol_id": 648
+      },
+      "minecraft:entity.hostile.hurt": {
+        "protocol_id": 649
+      },
+      "minecraft:entity.hostile.small_fall": {
+        "protocol_id": 650
+      },
+      "minecraft:entity.hostile.splash": {
+        "protocol_id": 651
+      },
+      "minecraft:entity.hostile.swim": {
+        "protocol_id": 652
+      },
+      "minecraft:entity.husk.ambient": {
+        "protocol_id": 653
+      },
+      "minecraft:entity.husk.converted_to_zombie": {
+        "protocol_id": 654
+      },
+      "minecraft:entity.husk.death": {
+        "protocol_id": 655
+      },
+      "minecraft:entity.husk.hurt": {
+        "protocol_id": 656
+      },
+      "minecraft:entity.husk.step": {
+        "protocol_id": 657
+      },
+      "minecraft:entity.illusioner.ambient": {
+        "protocol_id": 658
+      },
+      "minecraft:entity.illusioner.cast_spell": {
+        "protocol_id": 659
+      },
+      "minecraft:entity.illusioner.death": {
+        "protocol_id": 660
+      },
+      "minecraft:entity.illusioner.hurt": {
+        "protocol_id": 661
+      },
+      "minecraft:entity.illusioner.mirror_move": {
+        "protocol_id": 662
+      },
+      "minecraft:entity.illusioner.prepare_blindness": {
+        "protocol_id": 663
+      },
+      "minecraft:entity.illusioner.prepare_mirror": {
+        "protocol_id": 664
+      },
+      "minecraft:entity.iron_golem.attack": {
+        "protocol_id": 668
+      },
+      "minecraft:entity.iron_golem.damage": {
+        "protocol_id": 669
+      },
+      "minecraft:entity.iron_golem.death": {
+        "protocol_id": 670
+      },
+      "minecraft:entity.iron_golem.hurt": {
+        "protocol_id": 671
+      },
+      "minecraft:entity.iron_golem.repair": {
+        "protocol_id": 672
+      },
+      "minecraft:entity.iron_golem.step": {
+        "protocol_id": 673
+      },
+      "minecraft:entity.item.break": {
+        "protocol_id": 681
+      },
+      "minecraft:entity.item.pickup": {
+        "protocol_id": 682
+      },
+      "minecraft:entity.item_frame.add_item": {
+        "protocol_id": 676
+      },
+      "minecraft:entity.item_frame.break": {
+        "protocol_id": 677
+      },
+      "minecraft:entity.item_frame.place": {
+        "protocol_id": 678
+      },
+      "minecraft:entity.item_frame.remove_item": {
+        "protocol_id": 679
+      },
+      "minecraft:entity.item_frame.rotate_item": {
+        "protocol_id": 680
+      },
+      "minecraft:entity.leash_knot.break": {
+        "protocol_id": 698
+      },
+      "minecraft:entity.leash_knot.place": {
+        "protocol_id": 699
+      },
+      "minecraft:entity.lightning_bolt.impact": {
+        "protocol_id": 701
+      },
+      "minecraft:entity.lightning_bolt.thunder": {
+        "protocol_id": 702
+      },
+      "minecraft:entity.lingering_potion.throw": {
+        "protocol_id": 703
+      },
+      "minecraft:entity.llama.ambient": {
+        "protocol_id": 704
+      },
+      "minecraft:entity.llama.angry": {
+        "protocol_id": 705
+      },
+      "minecraft:entity.llama.chest": {
+        "protocol_id": 706
+      },
+      "minecraft:entity.llama.death": {
+        "protocol_id": 707
+      },
+      "minecraft:entity.llama.eat": {
+        "protocol_id": 708
+      },
+      "minecraft:entity.llama.hurt": {
+        "protocol_id": 709
+      },
+      "minecraft:entity.llama.spit": {
+        "protocol_id": 710
+      },
+      "minecraft:entity.llama.step": {
+        "protocol_id": 711
+      },
+      "minecraft:entity.llama.swag": {
+        "protocol_id": 712
+      },
+      "minecraft:entity.magma_cube.death": {
+        "protocol_id": 720
+      },
+      "minecraft:entity.magma_cube.death_small": {
+        "protocol_id": 713
+      },
+      "minecraft:entity.magma_cube.hurt": {
+        "protocol_id": 721
+      },
+      "minecraft:entity.magma_cube.hurt_small": {
+        "protocol_id": 722
+      },
+      "minecraft:entity.magma_cube.jump": {
+        "protocol_id": 723
+      },
+      "minecraft:entity.magma_cube.squish": {
+        "protocol_id": 724
+      },
+      "minecraft:entity.magma_cube.squish_small": {
+        "protocol_id": 725
+      },
+      "minecraft:entity.minecart.inside": {
         "protocol_id": 741
       },
-      "minecraft:item.hoe.till": {
-        "protocol_id": 717
+      "minecraft:entity.minecart.inside.underwater": {
+        "protocol_id": 740
       },
-      "minecraft:item.honey_bottle.drink": {
-        "protocol_id": 733
+      "minecraft:entity.minecart.riding": {
+        "protocol_id": 742
       },
-      "minecraft:item.honeycomb.wax_on": {
-        "protocol_id": 732
+      "minecraft:entity.mooshroom.convert": {
+        "protocol_id": 743
       },
-      "minecraft:item.ink_sac.use": {
-        "protocol_id": 773
+      "minecraft:entity.mooshroom.eat": {
+        "protocol_id": 744
       },
-      "minecraft:item.lodestone_compass.lock": {
-        "protocol_id": 837
+      "minecraft:entity.mooshroom.milk": {
+        "protocol_id": 745
       },
-      "minecraft:item.mace.smash_air": {
-        "protocol_id": 838
+      "minecraft:entity.mooshroom.shear": {
+        "protocol_id": 747
       },
-      "minecraft:item.mace.smash_ground": {
-        "protocol_id": 839
+      "minecraft:entity.mooshroom.suspicious_milk": {
+        "protocol_id": 746
       },
-      "minecraft:item.mace.smash_ground_heavy": {
-        "protocol_id": 840
+      "minecraft:entity.mule.ambient": {
+        "protocol_id": 778
       },
-      "minecraft:item.nether_wart.plant": {
-        "protocol_id": 962
+      "minecraft:entity.mule.angry": {
+        "protocol_id": 779
       },
-      "minecraft:item.ominous_bottle.dispose": {
-        "protocol_id": 1049
+      "minecraft:entity.mule.chest": {
+        "protocol_id": 780
       },
-      "minecraft:item.shield.block": {
-        "protocol_id": 1273
+      "minecraft:entity.mule.death": {
+        "protocol_id": 781
       },
-      "minecraft:item.shield.break": {
-        "protocol_id": 1274
+      "minecraft:entity.mule.eat": {
+        "protocol_id": 782
       },
-      "minecraft:item.shovel.flatten": {
-        "protocol_id": 1280
+      "minecraft:entity.mule.hurt": {
+        "protocol_id": 783
       },
-      "minecraft:item.spyglass.stop_using": {
-        "protocol_id": 1412
-      },
-      "minecraft:item.spyglass.use": {
-        "protocol_id": 1411
-      },
-      "minecraft:item.totem.use": {
-        "protocol_id": 1439
-      },
-      "minecraft:item.trident.hit": {
-        "protocol_id": 1440
-      },
-      "minecraft:item.trident.hit_ground": {
-        "protocol_id": 1441
-      },
-      "minecraft:item.trident.return": {
-        "protocol_id": 1442
-      },
-      "minecraft:item.trident.riptide_1": {
-        "protocol_id": 1443
-      },
-      "minecraft:item.trident.riptide_2": {
-        "protocol_id": 1444
-      },
-      "minecraft:item.trident.riptide_3": {
-        "protocol_id": 1445
-      },
-      "minecraft:item.trident.throw": {
-        "protocol_id": 1446
-      },
-      "minecraft:item.trident.thunder": {
-        "protocol_id": 1447
-      },
-      "minecraft:item.wolf_armor.break": {
-        "protocol_id": 1604
-      },
-      "minecraft:item.wolf_armor.crack": {
-        "protocol_id": 1605
-      },
-      "minecraft:item.wolf_armor.damage": {
-        "protocol_id": 1606
-      },
-      "minecraft:item.wolf_armor.repair": {
-        "protocol_id": 1607
-      },
-      "minecraft:music.creative": {
-        "protocol_id": 906
-      },
-      "minecraft:music.credits": {
-        "protocol_id": 907
-      },
-      "minecraft:music.dragon": {
-        "protocol_id": 927
-      },
-      "minecraft:music.end": {
-        "protocol_id": 928
-      },
-      "minecraft:music.game": {
-        "protocol_id": 929
-      },
-      "minecraft:music.menu": {
-        "protocol_id": 930
-      },
-      "minecraft:music.nether.basalt_deltas": {
-        "protocol_id": 931
-      },
-      "minecraft:music.nether.crimson_forest": {
-        "protocol_id": 932
-      },
-      "minecraft:music.nether.nether_wastes": {
-        "protocol_id": 943
-      },
-      "minecraft:music.nether.soul_sand_valley": {
-        "protocol_id": 946
-      },
-      "minecraft:music.nether.warped_forest": {
-        "protocol_id": 948
-      },
-      "minecraft:music.overworld.badlands": {
-        "protocol_id": 951
-      },
-      "minecraft:music.overworld.bamboo_jungle": {
-        "protocol_id": 954
-      },
-      "minecraft:music.overworld.cherry_grove": {
-        "protocol_id": 942
-      },
-      "minecraft:music.overworld.deep_dark": {
-        "protocol_id": 933
-      },
-      "minecraft:music.overworld.desert": {
-        "protocol_id": 950
-      },
-      "minecraft:music.overworld.dripstone_caves": {
-        "protocol_id": 934
-      },
-      "minecraft:music.overworld.flower_forest": {
-        "protocol_id": 949
-      },
-      "minecraft:music.overworld.forest": {
-        "protocol_id": 939
-      },
-      "minecraft:music.overworld.frozen_peaks": {
-        "protocol_id": 944
-      },
-      "minecraft:music.overworld.grove": {
-        "protocol_id": 935
-      },
-      "minecraft:music.overworld.jagged_peaks": {
-        "protocol_id": 936
-      },
-      "minecraft:music.overworld.jungle": {
-        "protocol_id": 952
-      },
-      "minecraft:music.overworld.lush_caves": {
-        "protocol_id": 937
-      },
-      "minecraft:music.overworld.meadow": {
-        "protocol_id": 941
-      },
-      "minecraft:music.overworld.old_growth_taiga": {
-        "protocol_id": 940
-      },
-      "minecraft:music.overworld.snowy_slopes": {
-        "protocol_id": 945
-      },
-      "minecraft:music.overworld.sparse_jungle": {
-        "protocol_id": 953
-      },
-      "minecraft:music.overworld.stony_peaks": {
-        "protocol_id": 947
-      },
-      "minecraft:music.overworld.swamp": {
-        "protocol_id": 938
-      },
-      "minecraft:music.under_water": {
-        "protocol_id": 955
-      },
-      "minecraft:music_disc.11": {
-        "protocol_id": 909
-      },
-      "minecraft:music_disc.13": {
-        "protocol_id": 910
-      },
-      "minecraft:music_disc.5": {
-        "protocol_id": 908
-      },
-      "minecraft:music_disc.blocks": {
-        "protocol_id": 911
-      },
-      "minecraft:music_disc.cat": {
-        "protocol_id": 912
-      },
-      "minecraft:music_disc.chirp": {
-        "protocol_id": 913
-      },
-      "minecraft:music_disc.creator": {
-        "protocol_id": 924
-      },
-      "minecraft:music_disc.creator_music_box": {
-        "protocol_id": 925
-      },
-      "minecraft:music_disc.far": {
-        "protocol_id": 914
-      },
-      "minecraft:music_disc.mall": {
-        "protocol_id": 915
-      },
-      "minecraft:music_disc.mellohi": {
-        "protocol_id": 916
-      },
-      "minecraft:music_disc.otherside": {
+      "minecraft:entity.ocelot.ambient": {
         "protocol_id": 922
       },
-      "minecraft:music_disc.pigstep": {
-        "protocol_id": 917
-      },
-      "minecraft:music_disc.precipice": {
-        "protocol_id": 926
-      },
-      "minecraft:music_disc.relic": {
+      "minecraft:entity.ocelot.death": {
         "protocol_id": 923
       },
-      "minecraft:music_disc.stal": {
-        "protocol_id": 918
-      },
-      "minecraft:music_disc.strad": {
-        "protocol_id": 919
-      },
-      "minecraft:music_disc.wait": {
-        "protocol_id": 920
-      },
-      "minecraft:music_disc.ward": {
+      "minecraft:entity.ocelot.hurt": {
         "protocol_id": 921
       },
-      "minecraft:particle.soul_escape": {
+      "minecraft:entity.painting.break": {
+        "protocol_id": 924
+      },
+      "minecraft:entity.painting.place": {
+        "protocol_id": 925
+      },
+      "minecraft:entity.panda.aggressive_ambient": {
+        "protocol_id": 933
+      },
+      "minecraft:entity.panda.ambient": {
+        "protocol_id": 928
+      },
+      "minecraft:entity.panda.bite": {
+        "protocol_id": 936
+      },
+      "minecraft:entity.panda.cant_breed": {
+        "protocol_id": 932
+      },
+      "minecraft:entity.panda.death": {
+        "protocol_id": 929
+      },
+      "minecraft:entity.panda.eat": {
+        "protocol_id": 930
+      },
+      "minecraft:entity.panda.hurt": {
+        "protocol_id": 935
+      },
+      "minecraft:entity.panda.pre_sneeze": {
+        "protocol_id": 926
+      },
+      "minecraft:entity.panda.sneeze": {
+        "protocol_id": 927
+      },
+      "minecraft:entity.panda.step": {
+        "protocol_id": 931
+      },
+      "minecraft:entity.panda.worried_ambient": {
+        "protocol_id": 934
+      },
+      "minecraft:entity.parrot.ambient": {
+        "protocol_id": 937
+      },
+      "minecraft:entity.parrot.death": {
+        "protocol_id": 938
+      },
+      "minecraft:entity.parrot.eat": {
+        "protocol_id": 939
+      },
+      "minecraft:entity.parrot.fly": {
+        "protocol_id": 940
+      },
+      "minecraft:entity.parrot.hurt": {
+        "protocol_id": 941
+      },
+      "minecraft:entity.parrot.imitate.blaze": {
+        "protocol_id": 942
+      },
+      "minecraft:entity.parrot.imitate.creeper": {
+        "protocol_id": 943
+      },
+      "minecraft:entity.parrot.imitate.drowned": {
+        "protocol_id": 944
+      },
+      "minecraft:entity.parrot.imitate.elder_guardian": {
+        "protocol_id": 945
+      },
+      "minecraft:entity.parrot.imitate.ender_dragon": {
+        "protocol_id": 946
+      },
+      "minecraft:entity.parrot.imitate.endermite": {
+        "protocol_id": 947
+      },
+      "minecraft:entity.parrot.imitate.evoker": {
+        "protocol_id": 948
+      },
+      "minecraft:entity.parrot.imitate.ghast": {
+        "protocol_id": 949
+      },
+      "minecraft:entity.parrot.imitate.guardian": {
+        "protocol_id": 950
+      },
+      "minecraft:entity.parrot.imitate.hoglin": {
+        "protocol_id": 951
+      },
+      "minecraft:entity.parrot.imitate.husk": {
+        "protocol_id": 952
+      },
+      "minecraft:entity.parrot.imitate.illusioner": {
+        "protocol_id": 953
+      },
+      "minecraft:entity.parrot.imitate.magma_cube": {
+        "protocol_id": 954
+      },
+      "minecraft:entity.parrot.imitate.phantom": {
+        "protocol_id": 955
+      },
+      "minecraft:entity.parrot.imitate.piglin": {
+        "protocol_id": 956
+      },
+      "minecraft:entity.parrot.imitate.piglin_brute": {
+        "protocol_id": 957
+      },
+      "minecraft:entity.parrot.imitate.pillager": {
+        "protocol_id": 958
+      },
+      "minecraft:entity.parrot.imitate.ravager": {
+        "protocol_id": 959
+      },
+      "minecraft:entity.parrot.imitate.shulker": {
+        "protocol_id": 960
+      },
+      "minecraft:entity.parrot.imitate.silverfish": {
+        "protocol_id": 961
+      },
+      "minecraft:entity.parrot.imitate.skeleton": {
+        "protocol_id": 962
+      },
+      "minecraft:entity.parrot.imitate.slime": {
+        "protocol_id": 963
+      },
+      "minecraft:entity.parrot.imitate.spider": {
+        "protocol_id": 964
+      },
+      "minecraft:entity.parrot.imitate.stray": {
+        "protocol_id": 965
+      },
+      "minecraft:entity.parrot.imitate.vex": {
+        "protocol_id": 966
+      },
+      "minecraft:entity.parrot.imitate.vindicator": {
+        "protocol_id": 967
+      },
+      "minecraft:entity.parrot.imitate.warden": {
+        "protocol_id": 968
+      },
+      "minecraft:entity.parrot.imitate.witch": {
+        "protocol_id": 969
+      },
+      "minecraft:entity.parrot.imitate.wither": {
+        "protocol_id": 970
+      },
+      "minecraft:entity.parrot.imitate.wither_skeleton": {
+        "protocol_id": 971
+      },
+      "minecraft:entity.parrot.imitate.zoglin": {
+        "protocol_id": 972
+      },
+      "minecraft:entity.parrot.imitate.zombie": {
+        "protocol_id": 973
+      },
+      "minecraft:entity.parrot.imitate.zombie_villager": {
+        "protocol_id": 974
+      },
+      "minecraft:entity.parrot.step": {
+        "protocol_id": 975
+      },
+      "minecraft:entity.phantom.ambient": {
+        "protocol_id": 976
+      },
+      "minecraft:entity.phantom.bite": {
+        "protocol_id": 977
+      },
+      "minecraft:entity.phantom.death": {
+        "protocol_id": 978
+      },
+      "minecraft:entity.phantom.flap": {
+        "protocol_id": 979
+      },
+      "minecraft:entity.phantom.hurt": {
+        "protocol_id": 980
+      },
+      "minecraft:entity.phantom.swoop": {
+        "protocol_id": 981
+      },
+      "minecraft:entity.pig.ambient": {
+        "protocol_id": 982
+      },
+      "minecraft:entity.pig.death": {
+        "protocol_id": 983
+      },
+      "minecraft:entity.pig.hurt": {
+        "protocol_id": 984
+      },
+      "minecraft:entity.pig.saddle": {
+        "protocol_id": 985
+      },
+      "minecraft:entity.pig.step": {
+        "protocol_id": 986
+      },
+      "minecraft:entity.piglin.admiring_item": {
+        "protocol_id": 987
+      },
+      "minecraft:entity.piglin.ambient": {
+        "protocol_id": 988
+      },
+      "minecraft:entity.piglin.angry": {
+        "protocol_id": 989
+      },
+      "minecraft:entity.piglin.celebrate": {
+        "protocol_id": 990
+      },
+      "minecraft:entity.piglin.converted_to_zombified": {
+        "protocol_id": 996
+      },
+      "minecraft:entity.piglin.death": {
+        "protocol_id": 991
+      },
+      "minecraft:entity.piglin.hurt": {
+        "protocol_id": 993
+      },
+      "minecraft:entity.piglin.jealous": {
+        "protocol_id": 992
+      },
+      "minecraft:entity.piglin.retreat": {
+        "protocol_id": 994
+      },
+      "minecraft:entity.piglin.step": {
+        "protocol_id": 995
+      },
+      "minecraft:entity.piglin_brute.ambient": {
+        "protocol_id": 997
+      },
+      "minecraft:entity.piglin_brute.angry": {
+        "protocol_id": 998
+      },
+      "minecraft:entity.piglin_brute.converted_to_zombified": {
+        "protocol_id": 1002
+      },
+      "minecraft:entity.piglin_brute.death": {
+        "protocol_id": 999
+      },
+      "minecraft:entity.piglin_brute.hurt": {
+        "protocol_id": 1000
+      },
+      "minecraft:entity.piglin_brute.step": {
+        "protocol_id": 1001
+      },
+      "minecraft:entity.pillager.ambient": {
+        "protocol_id": 1003
+      },
+      "minecraft:entity.pillager.celebrate": {
+        "protocol_id": 1004
+      },
+      "minecraft:entity.pillager.death": {
+        "protocol_id": 1005
+      },
+      "minecraft:entity.pillager.hurt": {
+        "protocol_id": 1006
+      },
+      "minecraft:entity.player.attack.crit": {
+        "protocol_id": 1009
+      },
+      "minecraft:entity.player.attack.knockback": {
+        "protocol_id": 1010
+      },
+      "minecraft:entity.player.attack.nodamage": {
+        "protocol_id": 1011
+      },
+      "minecraft:entity.player.attack.strong": {
+        "protocol_id": 1012
+      },
+      "minecraft:entity.player.attack.sweep": {
+        "protocol_id": 1013
+      },
+      "minecraft:entity.player.attack.weak": {
+        "protocol_id": 1014
+      },
+      "minecraft:entity.player.big_fall": {
+        "protocol_id": 1015
+      },
+      "minecraft:entity.player.breath": {
+        "protocol_id": 1016
+      },
+      "minecraft:entity.player.burp": {
+        "protocol_id": 1017
+      },
+      "minecraft:entity.player.death": {
+        "protocol_id": 1018
+      },
+      "minecraft:entity.player.hurt": {
+        "protocol_id": 1019
+      },
+      "minecraft:entity.player.hurt_drown": {
+        "protocol_id": 1020
+      },
+      "minecraft:entity.player.hurt_freeze": {
+        "protocol_id": 1021
+      },
+      "minecraft:entity.player.hurt_on_fire": {
+        "protocol_id": 1022
+      },
+      "minecraft:entity.player.hurt_sweet_berry_bush": {
+        "protocol_id": 1023
+      },
+      "minecraft:entity.player.levelup": {
+        "protocol_id": 1024
+      },
+      "minecraft:entity.player.small_fall": {
+        "protocol_id": 1025
+      },
+      "minecraft:entity.player.splash": {
+        "protocol_id": 1026
+      },
+      "minecraft:entity.player.splash.high_speed": {
+        "protocol_id": 1027
+      },
+      "minecraft:entity.player.swim": {
+        "protocol_id": 1028
+      },
+      "minecraft:entity.polar_bear.ambient": {
+        "protocol_id": 1029
+      },
+      "minecraft:entity.polar_bear.ambient_baby": {
+        "protocol_id": 1030
+      },
+      "minecraft:entity.polar_bear.death": {
+        "protocol_id": 1031
+      },
+      "minecraft:entity.polar_bear.hurt": {
+        "protocol_id": 1032
+      },
+      "minecraft:entity.polar_bear.step": {
+        "protocol_id": 1033
+      },
+      "minecraft:entity.polar_bear.warning": {
+        "protocol_id": 1034
+      },
+      "minecraft:entity.puffer_fish.ambient": {
+        "protocol_id": 1048
+      },
+      "minecraft:entity.puffer_fish.blow_out": {
+        "protocol_id": 1049
+      },
+      "minecraft:entity.puffer_fish.blow_up": {
+        "protocol_id": 1050
+      },
+      "minecraft:entity.puffer_fish.death": {
+        "protocol_id": 1051
+      },
+      "minecraft:entity.puffer_fish.flop": {
+        "protocol_id": 1052
+      },
+      "minecraft:entity.puffer_fish.hurt": {
+        "protocol_id": 1053
+      },
+      "minecraft:entity.puffer_fish.sting": {
+        "protocol_id": 1054
+      },
+      "minecraft:entity.rabbit.ambient": {
+        "protocol_id": 1056
+      },
+      "minecraft:entity.rabbit.attack": {
+        "protocol_id": 1057
+      },
+      "minecraft:entity.rabbit.death": {
+        "protocol_id": 1058
+      },
+      "minecraft:entity.rabbit.hurt": {
+        "protocol_id": 1059
+      },
+      "minecraft:entity.rabbit.jump": {
+        "protocol_id": 1060
+      },
+      "minecraft:entity.ravager.ambient": {
+        "protocol_id": 1062
+      },
+      "minecraft:entity.ravager.attack": {
+        "protocol_id": 1063
+      },
+      "minecraft:entity.ravager.celebrate": {
+        "protocol_id": 1064
+      },
+      "minecraft:entity.ravager.death": {
+        "protocol_id": 1065
+      },
+      "minecraft:entity.ravager.hurt": {
+        "protocol_id": 1066
+      },
+      "minecraft:entity.ravager.roar": {
+        "protocol_id": 1069
+      },
+      "minecraft:entity.ravager.step": {
+        "protocol_id": 1067
+      },
+      "minecraft:entity.ravager.stunned": {
+        "protocol_id": 1068
+      },
+      "minecraft:entity.salmon.ambient": {
+        "protocol_id": 1090
+      },
+      "minecraft:entity.salmon.death": {
+        "protocol_id": 1091
+      },
+      "minecraft:entity.salmon.flop": {
+        "protocol_id": 1092
+      },
+      "minecraft:entity.salmon.hurt": {
+        "protocol_id": 1093
+      },
+      "minecraft:entity.sheep.ambient": {
+        "protocol_id": 1135
+      },
+      "minecraft:entity.sheep.death": {
+        "protocol_id": 1136
+      },
+      "minecraft:entity.sheep.hurt": {
+        "protocol_id": 1137
+      },
+      "minecraft:entity.sheep.shear": {
+        "protocol_id": 1138
+      },
+      "minecraft:entity.sheep.step": {
+        "protocol_id": 1139
+      },
+      "minecraft:entity.shulker.ambient": {
+        "protocol_id": 1148
+      },
+      "minecraft:entity.shulker.close": {
+        "protocol_id": 1153
+      },
+      "minecraft:entity.shulker.death": {
+        "protocol_id": 1154
+      },
+      "minecraft:entity.shulker.hurt": {
+        "protocol_id": 1155
+      },
+      "minecraft:entity.shulker.hurt_closed": {
+        "protocol_id": 1156
+      },
+      "minecraft:entity.shulker.open": {
+        "protocol_id": 1157
+      },
+      "minecraft:entity.shulker.shoot": {
+        "protocol_id": 1158
+      },
+      "minecraft:entity.shulker.teleport": {
+        "protocol_id": 1159
+      },
+      "minecraft:entity.shulker_bullet.hit": {
+        "protocol_id": 1151
+      },
+      "minecraft:entity.shulker_bullet.hurt": {
+        "protocol_id": 1152
+      },
+      "minecraft:entity.silverfish.ambient": {
+        "protocol_id": 1160
+      },
+      "minecraft:entity.silverfish.death": {
+        "protocol_id": 1161
+      },
+      "minecraft:entity.silverfish.hurt": {
+        "protocol_id": 1162
+      },
+      "minecraft:entity.silverfish.step": {
+        "protocol_id": 1163
+      },
+      "minecraft:entity.skeleton.ambient": {
+        "protocol_id": 1164
+      },
+      "minecraft:entity.skeleton.converted_to_stray": {
+        "protocol_id": 1165
+      },
+      "minecraft:entity.skeleton.death": {
+        "protocol_id": 1166
+      },
+      "minecraft:entity.skeleton.hurt": {
+        "protocol_id": 1175
+      },
+      "minecraft:entity.skeleton.shoot": {
+        "protocol_id": 1176
+      },
+      "minecraft:entity.skeleton.step": {
+        "protocol_id": 1177
+      },
+      "minecraft:entity.skeleton_horse.ambient": {
+        "protocol_id": 1167
+      },
+      "minecraft:entity.skeleton_horse.ambient_water": {
+        "protocol_id": 1171
+      },
+      "minecraft:entity.skeleton_horse.death": {
+        "protocol_id": 1168
+      },
+      "minecraft:entity.skeleton_horse.gallop_water": {
+        "protocol_id": 1172
+      },
+      "minecraft:entity.skeleton_horse.hurt": {
+        "protocol_id": 1169
+      },
+      "minecraft:entity.skeleton_horse.jump_water": {
+        "protocol_id": 1173
+      },
+      "minecraft:entity.skeleton_horse.step_water": {
+        "protocol_id": 1174
+      },
+      "minecraft:entity.skeleton_horse.swim": {
+        "protocol_id": 1170
+      },
+      "minecraft:entity.slime.attack": {
+        "protocol_id": 1178
+      },
+      "minecraft:entity.slime.death": {
+        "protocol_id": 1179
+      },
+      "minecraft:entity.slime.death_small": {
+        "protocol_id": 1220
+      },
+      "minecraft:entity.slime.hurt": {
+        "protocol_id": 1180
+      },
+      "minecraft:entity.slime.hurt_small": {
+        "protocol_id": 1221
+      },
+      "minecraft:entity.slime.jump": {
+        "protocol_id": 1181
+      },
+      "minecraft:entity.slime.jump_small": {
+        "protocol_id": 1222
+      },
+      "minecraft:entity.slime.squish": {
+        "protocol_id": 1182
+      },
+      "minecraft:entity.slime.squish_small": {
+        "protocol_id": 1223
+      },
+      "minecraft:entity.sniffer.death": {
+        "protocol_id": 1230
+      },
+      "minecraft:entity.sniffer.digging": {
+        "protocol_id": 1235
+      },
+      "minecraft:entity.sniffer.digging_stop": {
+        "protocol_id": 1236
+      },
+      "minecraft:entity.sniffer.drop_seed": {
+        "protocol_id": 1231
+      },
+      "minecraft:entity.sniffer.eat": {
+        "protocol_id": 1227
+      },
+      "minecraft:entity.sniffer.happy": {
+        "protocol_id": 1237
+      },
+      "minecraft:entity.sniffer.hurt": {
+        "protocol_id": 1229
+      },
+      "minecraft:entity.sniffer.idle": {
+        "protocol_id": 1228
+      },
+      "minecraft:entity.sniffer.scenting": {
+        "protocol_id": 1232
+      },
+      "minecraft:entity.sniffer.searching": {
+        "protocol_id": 1234
+      },
+      "minecraft:entity.sniffer.sniffing": {
+        "protocol_id": 1233
+      },
+      "minecraft:entity.sniffer.step": {
+        "protocol_id": 1226
+      },
+      "minecraft:entity.snow_golem.ambient": {
+        "protocol_id": 1244
+      },
+      "minecraft:entity.snow_golem.death": {
+        "protocol_id": 1245
+      },
+      "minecraft:entity.snow_golem.hurt": {
+        "protocol_id": 1246
+      },
+      "minecraft:entity.snow_golem.shear": {
+        "protocol_id": 1248
+      },
+      "minecraft:entity.snow_golem.shoot": {
+        "protocol_id": 1247
+      },
+      "minecraft:entity.snowball.throw": {
+        "protocol_id": 1241
+      },
+      "minecraft:entity.spider.ambient": {
+        "protocol_id": 1252
+      },
+      "minecraft:entity.spider.death": {
+        "protocol_id": 1253
+      },
+      "minecraft:entity.spider.hurt": {
+        "protocol_id": 1254
+      },
+      "minecraft:entity.spider.step": {
+        "protocol_id": 1255
+      },
+      "minecraft:entity.splash_potion.break": {
+        "protocol_id": 1256
+      },
+      "minecraft:entity.splash_potion.throw": {
+        "protocol_id": 1257
+      },
+      "minecraft:entity.squid.ambient": {
+        "protocol_id": 1260
+      },
+      "minecraft:entity.squid.death": {
+        "protocol_id": 1261
+      },
+      "minecraft:entity.squid.hurt": {
+        "protocol_id": 1262
+      },
+      "minecraft:entity.squid.squirt": {
+        "protocol_id": 1263
+      },
+      "minecraft:entity.stray.ambient": {
+        "protocol_id": 1273
+      },
+      "minecraft:entity.stray.death": {
+        "protocol_id": 1274
+      },
+      "minecraft:entity.stray.hurt": {
+        "protocol_id": 1275
+      },
+      "minecraft:entity.stray.step": {
+        "protocol_id": 1276
+      },
+      "minecraft:entity.strider.ambient": {
+        "protocol_id": 1211
+      },
+      "minecraft:entity.strider.death": {
+        "protocol_id": 1214
+      },
+      "minecraft:entity.strider.eat": {
+        "protocol_id": 1218
+      },
+      "minecraft:entity.strider.happy": {
+        "protocol_id": 1212
+      },
+      "minecraft:entity.strider.hurt": {
+        "protocol_id": 1215
+      },
+      "minecraft:entity.strider.retreat": {
+        "protocol_id": 1213
+      },
+      "minecraft:entity.strider.saddle": {
+        "protocol_id": 1219
+      },
+      "minecraft:entity.strider.step": {
+        "protocol_id": 1216
+      },
+      "minecraft:entity.strider.step_lava": {
+        "protocol_id": 1217
+      },
+      "minecraft:entity.tadpole.death": {
+        "protocol_id": 1280
+      },
+      "minecraft:entity.tadpole.flop": {
+        "protocol_id": 1281
+      },
+      "minecraft:entity.tadpole.grow_up": {
+        "protocol_id": 1282
+      },
+      "minecraft:entity.tadpole.hurt": {
+        "protocol_id": 1283
+      },
+      "minecraft:entity.tnt.primed": {
+        "protocol_id": 1285
+      },
+      "minecraft:entity.tropical_fish.ambient": {
+        "protocol_id": 1299
+      },
+      "minecraft:entity.tropical_fish.death": {
+        "protocol_id": 1300
+      },
+      "minecraft:entity.tropical_fish.flop": {
+        "protocol_id": 1301
+      },
+      "minecraft:entity.tropical_fish.hurt": {
+        "protocol_id": 1302
+      },
+      "minecraft:entity.turtle.ambient_land": {
+        "protocol_id": 1308
+      },
+      "minecraft:entity.turtle.death": {
+        "protocol_id": 1309
+      },
+      "minecraft:entity.turtle.death_baby": {
+        "protocol_id": 1310
+      },
+      "minecraft:entity.turtle.egg_break": {
+        "protocol_id": 1311
+      },
+      "minecraft:entity.turtle.egg_crack": {
+        "protocol_id": 1312
+      },
+      "minecraft:entity.turtle.egg_hatch": {
+        "protocol_id": 1313
+      },
+      "minecraft:entity.turtle.hurt": {
+        "protocol_id": 1314
+      },
+      "minecraft:entity.turtle.hurt_baby": {
+        "protocol_id": 1315
+      },
+      "minecraft:entity.turtle.lay_egg": {
+        "protocol_id": 1316
+      },
+      "minecraft:entity.turtle.shamble": {
+        "protocol_id": 1317
+      },
+      "minecraft:entity.turtle.shamble_baby": {
+        "protocol_id": 1318
+      },
+      "minecraft:entity.turtle.swim": {
+        "protocol_id": 1319
+      },
+      "minecraft:entity.vex.ambient": {
+        "protocol_id": 1329
+      },
+      "minecraft:entity.vex.charge": {
+        "protocol_id": 1330
+      },
+      "minecraft:entity.vex.death": {
+        "protocol_id": 1331
+      },
+      "minecraft:entity.vex.hurt": {
+        "protocol_id": 1332
+      },
+      "minecraft:entity.villager.ambient": {
+        "protocol_id": 1333
+      },
+      "minecraft:entity.villager.celebrate": {
+        "protocol_id": 1334
+      },
+      "minecraft:entity.villager.death": {
+        "protocol_id": 1335
+      },
+      "minecraft:entity.villager.hurt": {
+        "protocol_id": 1336
+      },
+      "minecraft:entity.villager.no": {
+        "protocol_id": 1337
+      },
+      "minecraft:entity.villager.trade": {
         "protocol_id": 1338
       },
+      "minecraft:entity.villager.work_armorer": {
+        "protocol_id": 1340
+      },
+      "minecraft:entity.villager.work_butcher": {
+        "protocol_id": 1341
+      },
+      "minecraft:entity.villager.work_cartographer": {
+        "protocol_id": 1342
+      },
+      "minecraft:entity.villager.work_cleric": {
+        "protocol_id": 1343
+      },
+      "minecraft:entity.villager.work_farmer": {
+        "protocol_id": 1344
+      },
+      "minecraft:entity.villager.work_fisherman": {
+        "protocol_id": 1345
+      },
+      "minecraft:entity.villager.work_fletcher": {
+        "protocol_id": 1346
+      },
+      "minecraft:entity.villager.work_leatherworker": {
+        "protocol_id": 1347
+      },
+      "minecraft:entity.villager.work_librarian": {
+        "protocol_id": 1348
+      },
+      "minecraft:entity.villager.work_mason": {
+        "protocol_id": 1349
+      },
+      "minecraft:entity.villager.work_shepherd": {
+        "protocol_id": 1350
+      },
+      "minecraft:entity.villager.work_toolsmith": {
+        "protocol_id": 1351
+      },
+      "minecraft:entity.villager.work_weaponsmith": {
+        "protocol_id": 1352
+      },
+      "minecraft:entity.villager.yes": {
+        "protocol_id": 1339
+      },
+      "minecraft:entity.vindicator.ambient": {
+        "protocol_id": 1353
+      },
+      "minecraft:entity.vindicator.celebrate": {
+        "protocol_id": 1354
+      },
+      "minecraft:entity.vindicator.death": {
+        "protocol_id": 1355
+      },
+      "minecraft:entity.vindicator.hurt": {
+        "protocol_id": 1356
+      },
+      "minecraft:entity.wandering_trader.ambient": {
+        "protocol_id": 1363
+      },
+      "minecraft:entity.wandering_trader.death": {
+        "protocol_id": 1364
+      },
+      "minecraft:entity.wandering_trader.disappeared": {
+        "protocol_id": 1365
+      },
+      "minecraft:entity.wandering_trader.drink_milk": {
+        "protocol_id": 1366
+      },
+      "minecraft:entity.wandering_trader.drink_potion": {
+        "protocol_id": 1367
+      },
+      "minecraft:entity.wandering_trader.hurt": {
+        "protocol_id": 1368
+      },
+      "minecraft:entity.wandering_trader.no": {
+        "protocol_id": 1369
+      },
+      "minecraft:entity.wandering_trader.reappeared": {
+        "protocol_id": 1370
+      },
+      "minecraft:entity.wandering_trader.trade": {
+        "protocol_id": 1371
+      },
+      "minecraft:entity.wandering_trader.yes": {
+        "protocol_id": 1372
+      },
+      "minecraft:entity.warden.agitated": {
+        "protocol_id": 1373
+      },
+      "minecraft:entity.warden.ambient": {
+        "protocol_id": 1374
+      },
+      "minecraft:entity.warden.angry": {
+        "protocol_id": 1375
+      },
+      "minecraft:entity.warden.attack_impact": {
+        "protocol_id": 1376
+      },
+      "minecraft:entity.warden.death": {
+        "protocol_id": 1377
+      },
+      "minecraft:entity.warden.dig": {
+        "protocol_id": 1378
+      },
+      "minecraft:entity.warden.emerge": {
+        "protocol_id": 1379
+      },
+      "minecraft:entity.warden.heartbeat": {
+        "protocol_id": 1380
+      },
+      "minecraft:entity.warden.hurt": {
+        "protocol_id": 1381
+      },
+      "minecraft:entity.warden.listening": {
+        "protocol_id": 1382
+      },
+      "minecraft:entity.warden.listening_angry": {
+        "protocol_id": 1383
+      },
+      "minecraft:entity.warden.nearby_close": {
+        "protocol_id": 1384
+      },
+      "minecraft:entity.warden.nearby_closer": {
+        "protocol_id": 1385
+      },
+      "minecraft:entity.warden.nearby_closest": {
+        "protocol_id": 1386
+      },
+      "minecraft:entity.warden.roar": {
+        "protocol_id": 1387
+      },
+      "minecraft:entity.warden.sniff": {
+        "protocol_id": 1388
+      },
+      "minecraft:entity.warden.sonic_boom": {
+        "protocol_id": 1389
+      },
+      "minecraft:entity.warden.sonic_charge": {
+        "protocol_id": 1390
+      },
+      "minecraft:entity.warden.step": {
+        "protocol_id": 1391
+      },
+      "minecraft:entity.warden.tendril_clicks": {
+        "protocol_id": 1392
+      },
+      "minecraft:entity.witch.ambient": {
+        "protocol_id": 1402
+      },
+      "minecraft:entity.witch.celebrate": {
+        "protocol_id": 1403
+      },
+      "minecraft:entity.witch.death": {
+        "protocol_id": 1404
+      },
+      "minecraft:entity.witch.drink": {
+        "protocol_id": 1405
+      },
+      "minecraft:entity.witch.hurt": {
+        "protocol_id": 1406
+      },
+      "minecraft:entity.witch.throw": {
+        "protocol_id": 1407
+      },
+      "minecraft:entity.wither.ambient": {
+        "protocol_id": 1408
+      },
+      "minecraft:entity.wither.break_block": {
+        "protocol_id": 1409
+      },
+      "minecraft:entity.wither.death": {
+        "protocol_id": 1410
+      },
+      "minecraft:entity.wither.hurt": {
+        "protocol_id": 1411
+      },
+      "minecraft:entity.wither.shoot": {
+        "protocol_id": 1412
+      },
+      "minecraft:entity.wither.spawn": {
+        "protocol_id": 1417
+      },
+      "minecraft:entity.wither_skeleton.ambient": {
+        "protocol_id": 1413
+      },
+      "minecraft:entity.wither_skeleton.death": {
+        "protocol_id": 1414
+      },
+      "minecraft:entity.wither_skeleton.hurt": {
+        "protocol_id": 1415
+      },
+      "minecraft:entity.wither_skeleton.step": {
+        "protocol_id": 1416
+      },
+      "minecraft:entity.wolf.ambient": {
+        "protocol_id": 1418
+      },
+      "minecraft:entity.wolf.death": {
+        "protocol_id": 1419
+      },
+      "minecraft:entity.wolf.growl": {
+        "protocol_id": 1420
+      },
+      "minecraft:entity.wolf.howl": {
+        "protocol_id": 1421
+      },
+      "minecraft:entity.wolf.hurt": {
+        "protocol_id": 1422
+      },
+      "minecraft:entity.wolf.pant": {
+        "protocol_id": 1423
+      },
+      "minecraft:entity.wolf.shake": {
+        "protocol_id": 1424
+      },
+      "minecraft:entity.wolf.step": {
+        "protocol_id": 1425
+      },
+      "minecraft:entity.wolf.whine": {
+        "protocol_id": 1426
+      },
+      "minecraft:entity.zoglin.ambient": {
+        "protocol_id": 1445
+      },
+      "minecraft:entity.zoglin.angry": {
+        "protocol_id": 1446
+      },
+      "minecraft:entity.zoglin.attack": {
+        "protocol_id": 1447
+      },
+      "minecraft:entity.zoglin.death": {
+        "protocol_id": 1448
+      },
+      "minecraft:entity.zoglin.hurt": {
+        "protocol_id": 1449
+      },
+      "minecraft:entity.zoglin.step": {
+        "protocol_id": 1450
+      },
+      "minecraft:entity.zombie.ambient": {
+        "protocol_id": 1451
+      },
+      "minecraft:entity.zombie.attack_iron_door": {
+        "protocol_id": 1453
+      },
+      "minecraft:entity.zombie.attack_wooden_door": {
+        "protocol_id": 1452
+      },
+      "minecraft:entity.zombie.break_wooden_door": {
+        "protocol_id": 1454
+      },
+      "minecraft:entity.zombie.converted_to_drowned": {
+        "protocol_id": 1455
+      },
+      "minecraft:entity.zombie.death": {
+        "protocol_id": 1456
+      },
+      "minecraft:entity.zombie.destroy_egg": {
+        "protocol_id": 1457
+      },
+      "minecraft:entity.zombie.hurt": {
+        "protocol_id": 1461
+      },
+      "minecraft:entity.zombie.infect": {
+        "protocol_id": 1462
+      },
+      "minecraft:entity.zombie.step": {
+        "protocol_id": 1467
+      },
+      "minecraft:entity.zombie_horse.ambient": {
+        "protocol_id": 1458
+      },
+      "minecraft:entity.zombie_horse.death": {
+        "protocol_id": 1459
+      },
+      "minecraft:entity.zombie_horse.hurt": {
+        "protocol_id": 1460
+      },
+      "minecraft:entity.zombie_villager.ambient": {
+        "protocol_id": 1468
+      },
+      "minecraft:entity.zombie_villager.converted": {
+        "protocol_id": 1469
+      },
+      "minecraft:entity.zombie_villager.cure": {
+        "protocol_id": 1470
+      },
+      "minecraft:entity.zombie_villager.death": {
+        "protocol_id": 1471
+      },
+      "minecraft:entity.zombie_villager.hurt": {
+        "protocol_id": 1472
+      },
+      "minecraft:entity.zombie_villager.step": {
+        "protocol_id": 1473
+      },
+      "minecraft:entity.zombified_piglin.ambient": {
+        "protocol_id": 1463
+      },
+      "minecraft:entity.zombified_piglin.angry": {
+        "protocol_id": 1464
+      },
+      "minecraft:entity.zombified_piglin.death": {
+        "protocol_id": 1465
+      },
+      "minecraft:entity.zombified_piglin.hurt": {
+        "protocol_id": 1466
+      },
+      "minecraft:event.raid.horn": {
+        "protocol_id": 1061
+      },
+      "minecraft:intentionally_empty": {
+        "protocol_id": 853
+      },
+      "minecraft:item.armor.equip_chain": {
+        "protocol_id": 54
+      },
+      "minecraft:item.armor.equip_diamond": {
+        "protocol_id": 55
+      },
+      "minecraft:item.armor.equip_elytra": {
+        "protocol_id": 56
+      },
+      "minecraft:item.armor.equip_generic": {
+        "protocol_id": 57
+      },
+      "minecraft:item.armor.equip_gold": {
+        "protocol_id": 58
+      },
+      "minecraft:item.armor.equip_iron": {
+        "protocol_id": 59
+      },
+      "minecraft:item.armor.equip_leather": {
+        "protocol_id": 60
+      },
+      "minecraft:item.armor.equip_netherite": {
+        "protocol_id": 61
+      },
+      "minecraft:item.armor.equip_turtle": {
+        "protocol_id": 62
+      },
+      "minecraft:item.axe.scrape": {
+        "protocol_id": 71
+      },
+      "minecraft:item.axe.strip": {
+        "protocol_id": 70
+      },
+      "minecraft:item.axe.wax_off": {
+        "protocol_id": 72
+      },
+      "minecraft:item.bone_meal.use": {
+        "protocol_id": 159
+      },
+      "minecraft:item.book.page_turn": {
+        "protocol_id": 160
+      },
+      "minecraft:item.book.put": {
+        "protocol_id": 161
+      },
+      "minecraft:item.bottle.empty": {
+        "protocol_id": 163
+      },
+      "minecraft:item.bottle.fill": {
+        "protocol_id": 164
+      },
+      "minecraft:item.bottle.fill_dragonbreath": {
+        "protocol_id": 165
+      },
+      "minecraft:item.brush.brushing.generic": {
+        "protocol_id": 167
+      },
+      "minecraft:item.brush.brushing.gravel": {
+        "protocol_id": 169
+      },
+      "minecraft:item.brush.brushing.gravel.complete": {
+        "protocol_id": 171
+      },
+      "minecraft:item.brush.brushing.sand": {
+        "protocol_id": 168
+      },
+      "minecraft:item.brush.brushing.sand.complete": {
+        "protocol_id": 170
+      },
+      "minecraft:item.bucket.empty": {
+        "protocol_id": 177
+      },
+      "minecraft:item.bucket.empty_axolotl": {
+        "protocol_id": 178
+      },
+      "minecraft:item.bucket.empty_fish": {
+        "protocol_id": 179
+      },
+      "minecraft:item.bucket.empty_lava": {
+        "protocol_id": 180
+      },
+      "minecraft:item.bucket.empty_powder_snow": {
+        "protocol_id": 181
+      },
+      "minecraft:item.bucket.empty_tadpole": {
+        "protocol_id": 182
+      },
+      "minecraft:item.bucket.fill": {
+        "protocol_id": 183
+      },
+      "minecraft:item.bucket.fill_axolotl": {
+        "protocol_id": 184
+      },
+      "minecraft:item.bucket.fill_fish": {
+        "protocol_id": 185
+      },
+      "minecraft:item.bucket.fill_lava": {
+        "protocol_id": 186
+      },
+      "minecraft:item.bucket.fill_powder_snow": {
+        "protocol_id": 187
+      },
+      "minecraft:item.bucket.fill_tadpole": {
+        "protocol_id": 188
+      },
+      "minecraft:item.bundle.drop_contents": {
+        "protocol_id": 189
+      },
+      "minecraft:item.bundle.insert": {
+        "protocol_id": 190
+      },
+      "minecraft:item.bundle.remove_one": {
+        "protocol_id": 191
+      },
+      "minecraft:item.chorus_fruit.teleport": {
+        "protocol_id": 286
+      },
+      "minecraft:item.crop.plant": {
+        "protocol_id": 320
+      },
+      "minecraft:item.crossbow.hit": {
+        "protocol_id": 321
+      },
+      "minecraft:item.crossbow.loading_end": {
+        "protocol_id": 322
+      },
+      "minecraft:item.crossbow.loading_middle": {
+        "protocol_id": 323
+      },
+      "minecraft:item.crossbow.loading_start": {
+        "protocol_id": 324
+      },
+      "minecraft:item.crossbow.quick_charge_1": {
+        "protocol_id": 325
+      },
+      "minecraft:item.crossbow.quick_charge_2": {
+        "protocol_id": 326
+      },
+      "minecraft:item.crossbow.quick_charge_3": {
+        "protocol_id": 327
+      },
+      "minecraft:item.crossbow.shoot": {
+        "protocol_id": 328
+      },
+      "minecraft:item.dye.use": {
+        "protocol_id": 395
+      },
+      "minecraft:item.elytra.flying": {
+        "protocol_id": 405
+      },
+      "minecraft:item.firecharge.use": {
+        "protocol_id": 445
+      },
+      "minecraft:item.flintandsteel.use": {
+        "protocol_id": 460
+      },
+      "minecraft:item.glow_ink_sac.use": {
+        "protocol_id": 539
+      },
+      "minecraft:item.goat_horn.play": {
+        "protocol_id": 558
+      },
+      "minecraft:item.goat_horn.sound.0": {
+        "protocol_id": 626
+      },
+      "minecraft:item.goat_horn.sound.1": {
+        "protocol_id": 627
+      },
+      "minecraft:item.goat_horn.sound.2": {
+        "protocol_id": 628
+      },
+      "minecraft:item.goat_horn.sound.3": {
+        "protocol_id": 629
+      },
+      "minecraft:item.goat_horn.sound.4": {
+        "protocol_id": 630
+      },
+      "minecraft:item.goat_horn.sound.5": {
+        "protocol_id": 631
+      },
+      "minecraft:item.goat_horn.sound.6": {
+        "protocol_id": 632
+      },
+      "minecraft:item.goat_horn.sound.7": {
+        "protocol_id": 633
+      },
+      "minecraft:item.hoe.till": {
+        "protocol_id": 609
+      },
+      "minecraft:item.honey_bottle.drink": {
+        "protocol_id": 625
+      },
+      "minecraft:item.honeycomb.wax_on": {
+        "protocol_id": 624
+      },
+      "minecraft:item.ink_sac.use": {
+        "protocol_id": 665
+      },
+      "minecraft:item.lodestone_compass.lock": {
+        "protocol_id": 719
+      },
+      "minecraft:item.nether_wart.plant": {
+        "protocol_id": 837
+      },
+      "minecraft:item.shield.block": {
+        "protocol_id": 1140
+      },
+      "minecraft:item.shield.break": {
+        "protocol_id": 1141
+      },
+      "minecraft:item.shovel.flatten": {
+        "protocol_id": 1147
+      },
+      "minecraft:item.spyglass.stop_using": {
+        "protocol_id": 1259
+      },
+      "minecraft:item.spyglass.use": {
+        "protocol_id": 1258
+      },
+      "minecraft:item.totem.use": {
+        "protocol_id": 1286
+      },
+      "minecraft:item.trident.hit": {
+        "protocol_id": 1287
+      },
+      "minecraft:item.trident.hit_ground": {
+        "protocol_id": 1288
+      },
+      "minecraft:item.trident.return": {
+        "protocol_id": 1289
+      },
+      "minecraft:item.trident.riptide_1": {
+        "protocol_id": 1290
+      },
+      "minecraft:item.trident.riptide_2": {
+        "protocol_id": 1291
+      },
+      "minecraft:item.trident.riptide_3": {
+        "protocol_id": 1292
+      },
+      "minecraft:item.trident.throw": {
+        "protocol_id": 1293
+      },
+      "minecraft:item.trident.thunder": {
+        "protocol_id": 1294
+      },
+      "minecraft:music.creative": {
+        "protocol_id": 784
+      },
+      "minecraft:music.credits": {
+        "protocol_id": 785
+      },
+      "minecraft:music.dragon": {
+        "protocol_id": 802
+      },
+      "minecraft:music.end": {
+        "protocol_id": 803
+      },
+      "minecraft:music.game": {
+        "protocol_id": 804
+      },
+      "minecraft:music.menu": {
+        "protocol_id": 805
+      },
+      "minecraft:music.nether.basalt_deltas": {
+        "protocol_id": 806
+      },
+      "minecraft:music.nether.crimson_forest": {
+        "protocol_id": 807
+      },
+      "minecraft:music.nether.nether_wastes": {
+        "protocol_id": 818
+      },
+      "minecraft:music.nether.soul_sand_valley": {
+        "protocol_id": 821
+      },
+      "minecraft:music.nether.warped_forest": {
+        "protocol_id": 823
+      },
+      "minecraft:music.overworld.badlands": {
+        "protocol_id": 826
+      },
+      "minecraft:music.overworld.bamboo_jungle": {
+        "protocol_id": 829
+      },
+      "minecraft:music.overworld.cherry_grove": {
+        "protocol_id": 817
+      },
+      "minecraft:music.overworld.deep_dark": {
+        "protocol_id": 808
+      },
+      "minecraft:music.overworld.desert": {
+        "protocol_id": 825
+      },
+      "minecraft:music.overworld.dripstone_caves": {
+        "protocol_id": 809
+      },
+      "minecraft:music.overworld.flower_forest": {
+        "protocol_id": 824
+      },
+      "minecraft:music.overworld.forest": {
+        "protocol_id": 814
+      },
+      "minecraft:music.overworld.frozen_peaks": {
+        "protocol_id": 819
+      },
+      "minecraft:music.overworld.grove": {
+        "protocol_id": 810
+      },
+      "minecraft:music.overworld.jagged_peaks": {
+        "protocol_id": 811
+      },
+      "minecraft:music.overworld.jungle": {
+        "protocol_id": 827
+      },
+      "minecraft:music.overworld.lush_caves": {
+        "protocol_id": 812
+      },
+      "minecraft:music.overworld.meadow": {
+        "protocol_id": 816
+      },
+      "minecraft:music.overworld.old_growth_taiga": {
+        "protocol_id": 815
+      },
+      "minecraft:music.overworld.snowy_slopes": {
+        "protocol_id": 820
+      },
+      "minecraft:music.overworld.sparse_jungle": {
+        "protocol_id": 828
+      },
+      "minecraft:music.overworld.stony_peaks": {
+        "protocol_id": 822
+      },
+      "minecraft:music.overworld.swamp": {
+        "protocol_id": 813
+      },
+      "minecraft:music.under_water": {
+        "protocol_id": 830
+      },
+      "minecraft:music_disc.11": {
+        "protocol_id": 787
+      },
+      "minecraft:music_disc.13": {
+        "protocol_id": 788
+      },
+      "minecraft:music_disc.5": {
+        "protocol_id": 786
+      },
+      "minecraft:music_disc.blocks": {
+        "protocol_id": 789
+      },
+      "minecraft:music_disc.cat": {
+        "protocol_id": 790
+      },
+      "minecraft:music_disc.chirp": {
+        "protocol_id": 791
+      },
+      "minecraft:music_disc.far": {
+        "protocol_id": 792
+      },
+      "minecraft:music_disc.mall": {
+        "protocol_id": 793
+      },
+      "minecraft:music_disc.mellohi": {
+        "protocol_id": 794
+      },
+      "minecraft:music_disc.otherside": {
+        "protocol_id": 800
+      },
+      "minecraft:music_disc.pigstep": {
+        "protocol_id": 795
+      },
+      "minecraft:music_disc.relic": {
+        "protocol_id": 801
+      },
+      "minecraft:music_disc.stal": {
+        "protocol_id": 796
+      },
+      "minecraft:music_disc.strad": {
+        "protocol_id": 797
+      },
+      "minecraft:music_disc.wait": {
+        "protocol_id": 798
+      },
+      "minecraft:music_disc.ward": {
+        "protocol_id": 799
+      },
+      "minecraft:particle.soul_escape": {
+        "protocol_id": 1205
+      },
       "minecraft:ui.button.click": {
-        "protocol_id": 1483
+        "protocol_id": 1320
       },
       "minecraft:ui.cartography_table.take_result": {
-        "protocol_id": 1486
-      },
-      "minecraft:ui.hud.bubble_pop": {
-        "protocol_id": 210
+        "protocol_id": 1323
       },
       "minecraft:ui.loom.select_pattern": {
-        "protocol_id": 1484
+        "protocol_id": 1321
       },
       "minecraft:ui.loom.take_result": {
-        "protocol_id": 1485
+        "protocol_id": 1322
       },
       "minecraft:ui.stonecutter.select_recipe": {
-        "protocol_id": 1488
+        "protocol_id": 1325
       },
       "minecraft:ui.stonecutter.take_result": {
-        "protocol_id": 1487
+        "protocol_id": 1324
       },
       "minecraft:ui.toast.challenge_complete": {
-        "protocol_id": 1489
+        "protocol_id": 1326
       },
       "minecraft:ui.toast.in": {
-        "protocol_id": 1490
+        "protocol_id": 1327
       },
       "minecraft:ui.toast.out": {
-        "protocol_id": 1491
+        "protocol_id": 1328
       },
       "minecraft:weather.rain": {
-        "protocol_id": 1573
+        "protocol_id": 1395
       },
       "minecraft:weather.rain.above": {
-        "protocol_id": 1574
+        "protocol_id": 1396
       }
     },
     "protocol_id": 1
-  },
-  "minecraft:spawn_condition_type": {
-    "entries": {
-      "minecraft:biome": {
-        "protocol_id": 2
-      },
-      "minecraft:moon_brightness": {
-        "protocol_id": 1
-      },
-      "minecraft:structure": {
-        "protocol_id": 0
-      }
-    },
-    "protocol_id": 81
   },
   "minecraft:stat_type": {
     "entries": {
@@ -17550,248 +14590,7 @@
         "protocol_id": 2
       }
     },
-    "protocol_id": 21
-  },
-  "minecraft:test_environment_definition_type": {
-    "entries": {
-      "minecraft:all_of": {
-        "protocol_id": 0
-      },
-      "minecraft:function": {
-        "protocol_id": 4
-      },
-      "minecraft:game_rules": {
-        "protocol_id": 1
-      },
-      "minecraft:time_of_day": {
-        "protocol_id": 2
-      },
-      "minecraft:weather": {
-        "protocol_id": 3
-      }
-    },
-    "protocol_id": 79
-  },
-  "minecraft:test_function": {
-    "entries": {
-      "minecraft:always_pass": {
-        "protocol_id": 0
-      }
-    },
-    "protocol_id": 82
-  },
-  "minecraft:test_instance_type": {
-    "entries": {
-      "minecraft:block_based": {
-        "protocol_id": 0
-      },
-      "minecraft:function": {
-        "protocol_id": 1
-      }
-    },
-    "protocol_id": 80
-  },
-  "minecraft:ticket_type": {
-    "entries": {
-      "minecraft:dragon": {
-        "protocol_id": 1
-      },
-      "minecraft:ender_pearl": {
-        "protocol_id": 6
-      },
-      "minecraft:forced": {
-        "protocol_id": 4
-      },
-      "minecraft:player_loading": {
-        "protocol_id": 2
-      },
-      "minecraft:player_simulation": {
-        "protocol_id": 3
-      },
-      "minecraft:portal": {
-        "protocol_id": 5
-      },
-      "minecraft:start": {
-        "protocol_id": 0
-      },
-      "minecraft:unknown": {
-        "protocol_id": 7
-      }
-    },
-    "protocol_id": 78
-  },
-  "minecraft:trigger_type": {
-    "entries": {
-      "minecraft:allay_drop_item_on_block": {
-        "protocol_id": 51
-      },
-      "minecraft:any_block_use": {
-        "protocol_id": 40
-      },
-      "minecraft:avoid_vibration": {
-        "protocol_id": 52
-      },
-      "minecraft:bee_nest_destroyed": {
-        "protocol_id": 36
-      },
-      "minecraft:bred_animals": {
-        "protocol_id": 14
-      },
-      "minecraft:brewed_potion": {
-        "protocol_id": 10
-      },
-      "minecraft:changed_dimension": {
-        "protocol_id": 21
-      },
-      "minecraft:channeled_lightning": {
-        "protocol_id": 30
-      },
-      "minecraft:construct_beacon": {
-        "protocol_id": 11
-      },
-      "minecraft:consume_item": {
-        "protocol_id": 25
-      },
-      "minecraft:crafter_recipe_crafted": {
-        "protocol_id": 54
-      },
-      "minecraft:cured_zombie_villager": {
-        "protocol_id": 17
-      },
-      "minecraft:default_block_use": {
-        "protocol_id": 39
-      },
-      "minecraft:effects_changed": {
-        "protocol_id": 26
-      },
-      "minecraft:enchanted_item": {
-        "protocol_id": 8
-      },
-      "minecraft:enter_block": {
-        "protocol_id": 3
-      },
-      "minecraft:entity_hurt_player": {
-        "protocol_id": 7
-      },
-      "minecraft:entity_killed_player": {
-        "protocol_id": 2
-      },
-      "minecraft:fall_after_explosion": {
-        "protocol_id": 55
-      },
-      "minecraft:fall_from_height": {
-        "protocol_id": 48
-      },
-      "minecraft:filled_bucket": {
-        "protocol_id": 9
-      },
-      "minecraft:fishing_rod_hooked": {
-        "protocol_id": 29
-      },
-      "minecraft:hero_of_the_village": {
-        "protocol_id": 33
-      },
-      "minecraft:impossible": {
-        "protocol_id": 0
-      },
-      "minecraft:inventory_changed": {
-        "protocol_id": 4
-      },
-      "minecraft:item_durability_changed": {
-        "protocol_id": 19
-      },
-      "minecraft:item_used_on_block": {
-        "protocol_id": 38
-      },
-      "minecraft:kill_mob_near_sculk_catalyst": {
-        "protocol_id": 50
-      },
-      "minecraft:killed_by_arrow": {
-        "protocol_id": 32
-      },
-      "minecraft:levitation": {
-        "protocol_id": 20
-      },
-      "minecraft:lightning_strike": {
-        "protocol_id": 46
-      },
-      "minecraft:location": {
-        "protocol_id": 15
-      },
-      "minecraft:nether_travel": {
-        "protocol_id": 28
-      },
-      "minecraft:placed_block": {
-        "protocol_id": 24
-      },
-      "minecraft:player_generates_container_loot": {
-        "protocol_id": 41
-      },
-      "minecraft:player_hurt_entity": {
-        "protocol_id": 6
-      },
-      "minecraft:player_interacted_with_entity": {
-        "protocol_id": 44
-      },
-      "minecraft:player_killed_entity": {
-        "protocol_id": 1
-      },
-      "minecraft:recipe_crafted": {
-        "protocol_id": 53
-      },
-      "minecraft:recipe_unlocked": {
-        "protocol_id": 5
-      },
-      "minecraft:ride_entity_in_lava": {
-        "protocol_id": 49
-      },
-      "minecraft:shot_crossbow": {
-        "protocol_id": 31
-      },
-      "minecraft:slept_in_bed": {
-        "protocol_id": 16
-      },
-      "minecraft:slide_down_block": {
-        "protocol_id": 35
-      },
-      "minecraft:started_riding": {
-        "protocol_id": 45
-      },
-      "minecraft:summoned_entity": {
-        "protocol_id": 13
-      },
-      "minecraft:tame_animal": {
-        "protocol_id": 23
-      },
-      "minecraft:target_hit": {
-        "protocol_id": 37
-      },
-      "minecraft:thrown_item_picked_up_by_entity": {
-        "protocol_id": 42
-      },
-      "minecraft:thrown_item_picked_up_by_player": {
-        "protocol_id": 43
-      },
-      "minecraft:tick": {
-        "protocol_id": 22
-      },
-      "minecraft:used_ender_eye": {
-        "protocol_id": 12
-      },
-      "minecraft:used_totem": {
-        "protocol_id": 27
-      },
-      "minecraft:using_item": {
-        "protocol_id": 47
-      },
-      "minecraft:villager_trade": {
-        "protocol_id": 18
-      },
-      "minecraft:voluntary_exile": {
-        "protocol_id": 34
-      }
-    },
-    "protocol_id": 62
+    "protocol_id": 23
   },
   "minecraft:villager_profession": {
     "default": "minecraft:none",
@@ -17842,7 +14641,7 @@
         "protocol_id": 14
       }
     },
-    "protocol_id": 23
+    "protocol_id": 25
   },
   "minecraft:villager_type": {
     "default": "minecraft:plains",
@@ -17869,7 +14668,7 @@
         "protocol_id": 6
       }
     },
-    "protocol_id": 22
+    "protocol_id": 24
   },
   "minecraft:worldgen/biome_source": {
     "entries": {
@@ -17886,7 +14685,7 @@
         "protocol_id": 3
       }
     },
-    "protocol_id": 51
+    "protocol_id": 53
   },
   "minecraft:worldgen/block_state_provider_type": {
     "entries": {
@@ -17912,7 +14711,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 45
+    "protocol_id": 47
   },
   "minecraft:worldgen/carver": {
     "entries": {
@@ -17926,7 +14725,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 39
+    "protocol_id": 41
   },
   "minecraft:worldgen/chunk_generator": {
     "entries": {
@@ -17940,7 +14739,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 52
+    "protocol_id": 54
   },
   "minecraft:worldgen/density_function_type": {
     "entries": {
@@ -18041,201 +14840,195 @@
         "protocol_id": 31
       }
     },
-    "protocol_id": 55
+    "protocol_id": 57
   },
   "minecraft:worldgen/feature": {
     "entries": {
       "minecraft:bamboo": {
-        "protocol_id": 43
+        "protocol_id": 41
       },
       "minecraft:basalt_columns": {
-        "protocol_id": 48
+        "protocol_id": 46
       },
       "minecraft:basalt_pillar": {
-        "protocol_id": 53
+        "protocol_id": 51
       },
       "minecraft:block_column": {
-        "protocol_id": 19
+        "protocol_id": 18
       },
       "minecraft:block_pile": {
-        "protocol_id": 6
+        "protocol_id": 5
       },
       "minecraft:blue_ice": {
-        "protocol_id": 26
+        "protocol_id": 25
       },
       "minecraft:bonus_chest": {
-        "protocol_id": 52
+        "protocol_id": 50
       },
       "minecraft:chorus_plant": {
-        "protocol_id": 8
+        "protocol_id": 7
       },
       "minecraft:coral_claw": {
-        "protocol_id": 40
-      },
-      "minecraft:coral_mushroom": {
-        "protocol_id": 39
-      },
-      "minecraft:coral_tree": {
         "protocol_id": 38
       },
+      "minecraft:coral_mushroom": {
+        "protocol_id": 37
+      },
+      "minecraft:coral_tree": {
+        "protocol_id": 36
+      },
       "minecraft:delta_feature": {
-        "protocol_id": 49
+        "protocol_id": 47
       },
       "minecraft:desert_well": {
-        "protocol_id": 11
+        "protocol_id": 10
       },
       "minecraft:disk": {
-        "protocol_id": 29
+        "protocol_id": 28
       },
       "minecraft:dripstone_cluster": {
-        "protocol_id": 59
+        "protocol_id": 57
       },
       "minecraft:end_gateway": {
-        "protocol_id": 35
+        "protocol_id": 33
       },
       "minecraft:end_island": {
-        "protocol_id": 34
-      },
-      "minecraft:end_platform": {
         "protocol_id": 32
       },
       "minecraft:end_spike": {
-        "protocol_id": 33
-      },
-      "minecraft:fallen_tree": {
-        "protocol_id": 2
+        "protocol_id": 31
       },
       "minecraft:fill_layer": {
-        "protocol_id": 51
+        "protocol_id": 49
       },
       "minecraft:flower": {
-        "protocol_id": 3
+        "protocol_id": 2
       },
       "minecraft:forest_rock": {
-        "protocol_id": 28
-      },
-      "minecraft:fossil": {
-        "protocol_id": 12
-      },
-      "minecraft:freeze_top_layer": {
-        "protocol_id": 17
-      },
-      "minecraft:geode": {
-        "protocol_id": 58
-      },
-      "minecraft:glowstone_blob": {
-        "protocol_id": 16
-      },
-      "minecraft:huge_brown_mushroom": {
-        "protocol_id": 14
-      },
-      "minecraft:huge_fungus": {
-        "protocol_id": 44
-      },
-      "minecraft:huge_red_mushroom": {
-        "protocol_id": 13
-      },
-      "minecraft:ice_spike": {
-        "protocol_id": 15
-      },
-      "minecraft:iceberg": {
         "protocol_id": 27
       },
+      "minecraft:fossil": {
+        "protocol_id": 11
+      },
+      "minecraft:freeze_top_layer": {
+        "protocol_id": 16
+      },
+      "minecraft:geode": {
+        "protocol_id": 56
+      },
+      "minecraft:glowstone_blob": {
+        "protocol_id": 15
+      },
+      "minecraft:huge_brown_mushroom": {
+        "protocol_id": 13
+      },
+      "minecraft:huge_fungus": {
+        "protocol_id": 42
+      },
+      "minecraft:huge_red_mushroom": {
+        "protocol_id": 12
+      },
+      "minecraft:ice_spike": {
+        "protocol_id": 14
+      },
+      "minecraft:iceberg": {
+        "protocol_id": 26
+      },
       "minecraft:kelp": {
-        "protocol_id": 37
+        "protocol_id": 35
       },
       "minecraft:lake": {
-        "protocol_id": 30
+        "protocol_id": 29
       },
       "minecraft:large_dripstone": {
-        "protocol_id": 60
+        "protocol_id": 58
       },
       "minecraft:monster_room": {
-        "protocol_id": 25
+        "protocol_id": 24
       },
       "minecraft:multiface_growth": {
-        "protocol_id": 23
+        "protocol_id": 22
       },
       "minecraft:nether_forest_vegetation": {
-        "protocol_id": 45
+        "protocol_id": 43
       },
       "minecraft:netherrack_replace_blobs": {
-        "protocol_id": 50
+        "protocol_id": 48
       },
       "minecraft:no_bonemeal_flower": {
-        "protocol_id": 4
+        "protocol_id": 3
       },
       "minecraft:no_op": {
         "protocol_id": 0
       },
       "minecraft:ore": {
-        "protocol_id": 31
+        "protocol_id": 30
       },
       "minecraft:pointed_dripstone": {
-        "protocol_id": 61
+        "protocol_id": 59
       },
       "minecraft:random_boolean_selector": {
-        "protocol_id": 57
-      },
-      "minecraft:random_patch": {
-        "protocol_id": 5
-      },
-      "minecraft:random_selector": {
         "protocol_id": 55
       },
+      "minecraft:random_patch": {
+        "protocol_id": 4
+      },
+      "minecraft:random_selector": {
+        "protocol_id": 53
+      },
       "minecraft:replace_single_block": {
-        "protocol_id": 9
+        "protocol_id": 8
       },
       "minecraft:root_system": {
-        "protocol_id": 22
+        "protocol_id": 21
       },
       "minecraft:scattered_ore": {
-        "protocol_id": 54
+        "protocol_id": 52
       },
       "minecraft:sculk_patch": {
-        "protocol_id": 62
+        "protocol_id": 60
       },
       "minecraft:sea_pickle": {
-        "protocol_id": 41
+        "protocol_id": 39
       },
       "minecraft:seagrass": {
-        "protocol_id": 36
+        "protocol_id": 34
       },
       "minecraft:simple_block": {
-        "protocol_id": 42
+        "protocol_id": 40
       },
       "minecraft:simple_random_selector": {
-        "protocol_id": 56
+        "protocol_id": 54
       },
       "minecraft:spring_feature": {
-        "protocol_id": 7
+        "protocol_id": 6
       },
       "minecraft:tree": {
         "protocol_id": 1
       },
       "minecraft:twisting_vines": {
-        "protocol_id": 47
+        "protocol_id": 45
       },
       "minecraft:underwater_magma": {
-        "protocol_id": 24
+        "protocol_id": 23
       },
       "minecraft:vegetation_patch": {
-        "protocol_id": 20
+        "protocol_id": 19
       },
       "minecraft:vines": {
-        "protocol_id": 18
+        "protocol_id": 17
       },
       "minecraft:void_start_platform": {
-        "protocol_id": 10
+        "protocol_id": 9
       },
       "minecraft:waterlogged_vegetation_patch": {
-        "protocol_id": 21
+        "protocol_id": 20
       },
       "minecraft:weeping_vines": {
-        "protocol_id": 46
+        "protocol_id": 44
       }
     },
-    "protocol_id": 40
+    "protocol_id": 42
   },
   "minecraft:worldgen/feature_size_type": {
     "entries": {
@@ -18246,7 +15039,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 50
+    "protocol_id": 52
   },
   "minecraft:worldgen/foliage_placer_type": {
     "entries": {
@@ -18284,7 +15077,7 @@
         "protocol_id": 1
       }
     },
-    "protocol_id": 46
+    "protocol_id": 48
   },
   "minecraft:worldgen/material_condition": {
     "entries": {
@@ -18322,7 +15115,7 @@
         "protocol_id": 3
       }
     },
-    "protocol_id": 53
+    "protocol_id": 55
   },
   "minecraft:worldgen/material_rule": {
     "entries": {
@@ -18339,7 +15132,7 @@
         "protocol_id": 2
       }
     },
-    "protocol_id": 54
+    "protocol_id": 56
   },
   "minecraft:worldgen/placement_modifier_type": {
     "entries": {
@@ -18349,6 +15142,9 @@
       "minecraft:block_predicate_filter": {
         "protocol_id": 0
       },
+      "minecraft:carving_mask": {
+        "protocol_id": 14
+      },
       "minecraft:count": {
         "protocol_id": 5
       },
@@ -18357,9 +15153,6 @@
       },
       "minecraft:environment_scan": {
         "protocol_id": 9
-      },
-      "minecraft:fixed_placement": {
-        "protocol_id": 14
       },
       "minecraft:height_range": {
         "protocol_id": 11
@@ -18389,21 +15182,7 @@
         "protocol_id": 3
       }
     },
-    "protocol_id": 44
-  },
-  "minecraft:worldgen/pool_alias_binding": {
-    "entries": {
-      "minecraft:direct": {
-        "protocol_id": 2
-      },
-      "minecraft:random": {
-        "protocol_id": 0
-      },
-      "minecraft:random_group": {
-        "protocol_id": 1
-      }
-    },
-    "protocol_id": 59
+    "protocol_id": 46
   },
   "minecraft:worldgen/root_placer_type": {
     "entries": {
@@ -18411,7 +15190,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 48
+    "protocol_id": 50
   },
   "minecraft:worldgen/structure_piece": {
     "entries": {
@@ -18584,7 +15363,7 @@
         "protocol_id": 51
       }
     },
-    "protocol_id": 42
+    "protocol_id": 44
   },
   "minecraft:worldgen/structure_placement": {
     "entries": {
@@ -18595,7 +15374,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 41
+    "protocol_id": 43
   },
   "minecraft:worldgen/structure_pool_element": {
     "entries": {
@@ -18615,7 +15394,7 @@
         "protocol_id": 0
       }
     },
-    "protocol_id": 58
+    "protocol_id": 59
   },
   "minecraft:worldgen/structure_processor": {
     "entries": {
@@ -18653,7 +15432,7 @@
         "protocol_id": 4
       }
     },
-    "protocol_id": 57
+    "protocol_id": 58
   },
   "minecraft:worldgen/structure_type": {
     "entries": {
@@ -18706,42 +15485,30 @@
         "protocol_id": 15
       }
     },
-    "protocol_id": 43
+    "protocol_id": 45
   },
   "minecraft:worldgen/tree_decorator_type": {
     "entries": {
       "minecraft:alter_ground": {
-        "protocol_id": 6
-      },
-      "minecraft:attached_to_leaves": {
-        "protocol_id": 7
-      },
-      "minecraft:attached_to_logs": {
-        "protocol_id": 9
-      },
-      "minecraft:beehive": {
-        "protocol_id": 5
-      },
-      "minecraft:cocoa": {
         "protocol_id": 4
       },
-      "minecraft:creaking_heart": {
+      "minecraft:attached_to_leaves": {
+        "protocol_id": 5
+      },
+      "minecraft:beehive": {
         "protocol_id": 3
+      },
+      "minecraft:cocoa": {
+        "protocol_id": 2
       },
       "minecraft:leave_vine": {
         "protocol_id": 1
-      },
-      "minecraft:pale_moss": {
-        "protocol_id": 2
-      },
-      "minecraft:place_on_ground": {
-        "protocol_id": 8
       },
       "minecraft:trunk_vine": {
         "protocol_id": 0
       }
     },
-    "protocol_id": 49
+    "protocol_id": 51
   },
   "minecraft:worldgen/trunk_placer_type": {
     "entries": {
@@ -18773,6 +15540,6 @@
         "protocol_id": 7
       }
     },
-    "protocol_id": 47
+    "protocol_id": 49
   }
 }

--- a/scripts/generate_packets.py
+++ b/scripts/generate_packets.py
@@ -1,0 +1,66 @@
+import json
+import sys
+from pathlib import Path
+
+usage = "Usage: generate_packets.py <protocol.json> <out_file> [old_packets.json]"
+
+if not (3 <= len(sys.argv) <= 4):
+    print(usage)
+    sys.exit(1)
+
+protocol_path = Path(sys.argv[1])
+out_path = Path(sys.argv[2])
+old_path = Path(sys.argv[3]) if len(sys.argv) == 4 else None
+
+with protocol_path.open() as f:
+    protocol = json.load(f)
+
+old_index = {}
+if old_path and old_path.exists():
+    with old_path.open() as f:
+        old = json.load(f)
+    for state, dirs in old.items():
+        old_index[state] = {}
+        for bound, pkts in dirs.items():
+            old_index[state][bound] = {v["protocol_id"]: k.split(":", 1)[1] for k, v in pkts.items()}
+
+STATE_MAP = {
+    "handshake": "handshaking",
+    "login": "login",
+    "play": "play",
+    "status": "status",
+}
+
+BOUND_MAP = {
+    "clientbound": "toClient",
+    "serverbound": "toServer",
+}
+
+out = {
+    "configuration": {"clientbound": {}, "serverbound": {}},
+}
+
+def extract(state_key):
+    proto_state = protocol.get(STATE_MAP[state_key], {})
+    out_state = {}
+    for bound_out, bound_in in BOUND_MAP.items():
+        try:
+            fields = proto_state[bound_in]["types"]["packet"][1]
+            name_field = next(f for f in fields if f.get("name") == "name")
+            mappings = name_field["type"][1]["mappings"]
+            result = {}
+            for pid_hex, default_name in mappings.items():
+                pid = int(pid_hex, 16)
+                name = old_index.get(state_key, {}).get(bound_out, {}).get(pid, default_name)
+                result[f"minecraft:{name}"] = {"protocol_id": pid}
+            out_state[bound_out] = result
+        except Exception:
+            out_state[bound_out] = {}
+    out[state_key] = out_state
+
+for s in ["handshake", "login", "play", "status"]:
+    extract(s)
+
+with out_path.open('w') as f:
+    json.dump(out, f, indent=2)
+    f.write('\n')


### PR DESCRIPTION
## Summary
- refresh packet and registry JSON data for 1.20.1
- add script for regenerating packet tables from protocol definitions

## Testing
- `cargo +nightly build` *(fails: lookup_packet! missing entries such as `minecraft:login_acknowledged`)*

------
https://chatgpt.com/codex/tasks/task_b_6893cdc1cb90832984b35c3f3e29ee02