### PR TITLE
refactor: centralize Minecraft version constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 ## 📖 About
 
-FerrumC is a **1.20.1** Minecraft server implementation written from the ground up in Rust. Leveraging the power of the
+FerrumC is a **MINECRAFT_VERSION** Minecraft server implementation written from the ground up in Rust. Leveraging the power of the
 Rust programming language, it is completely multithreaded and offers high performance as well as amazing memory
 efficiency!
 
@@ -74,7 +74,7 @@ our [Discord server](https://discord.gg/qT5J8EMjwk) for help or to discuss the p
       <img src="https://github.com/ferrumc-rs/ferrumc/blob/master/assets/README/chunk_importing.gif?raw=true" alt="Configuration">
     </li>
     <li>
-      <h4>🌐 Compatible with vanilla Minecraft clients (Version 1.20.1)</h4>
+      <h4>🌐 Compatible with vanilla Minecraft clients (Version MINECRAFT_VERSION)</h4>
     </li>
     <li>
       <h4>📦 Fully multithreaded; Utilizes all available CPU cores, instead of a single "main" thread</h4>

--- a/src/lib/net/src/conn_init/mod.rs
+++ b/src/lib/net/src/conn_init/mod.rs
@@ -26,8 +26,12 @@ pub(crate) struct LoginResult {
     pub compression: bool,
 }
 
-/// Protocol version supported by this server implementation (Minecraft 1.20.1).
-/// Used for rejecting clients with mismatched versions during handshake.
+/// Minecraft version targeted by this server implementation.
+pub const MINECRAFT_VERSION: &str = "1.20.1";
+
+/// Protocol version supported by this server implementation (Minecraft
+/// `MINECRAFT_VERSION`). Used for rejecting clients with mismatched versions
+/// during handshake.
 pub const PROTOCOL_VERSION_1_20_1: i32 = 763;
 
 /// Handles the initial handshake sequence from a connecting client.
@@ -87,7 +91,8 @@ pub async fn handle_handshake(
     if hs_packet.protocol_version.0 != PROTOCOL_VERSION_1_20_1 {
         trace!(
             "Protocol version mismatch: {} != {}",
-            hs_packet.protocol_version.0, PROTOCOL_VERSION_1_20_1
+            hs_packet.protocol_version.0,
+            PROTOCOL_VERSION_1_20_1
         );
         return handle_version_mismatch(hs_packet, conn_read, conn_write, state).await;
     }
@@ -133,7 +138,8 @@ async fn handle_version_mismatch(
         1 => {
             trace!(
                 "Protocol version mismatch during status request: {} != {}",
-                hs_packet.protocol_version.0, PROTOCOL_VERSION_1_20_1
+                hs_packet.protocol_version.0,
+                PROTOCOL_VERSION_1_20_1
             );
             status(conn_read, conn_write, state).await
         }
@@ -152,7 +158,8 @@ async fn handle_version_mismatch(
 
             trace!(
                 "Sent login disconnect due to protocol version mismatch: {} != {}",
-                hs_packet.protocol_version.0, PROTOCOL_VERSION_1_20_1
+                hs_packet.protocol_version.0,
+                PROTOCOL_VERSION_1_20_1
             );
 
             Err(NetError::MismatchedProtocolVersion(
@@ -173,7 +180,7 @@ async fn handle_version_mismatch(
 /// # Format
 /// ```text
 /// Your client is outdated!
-/// Please use Minecraft version 1.20.1 to connect to this server.
+/// Please use Minecraft version `MINECRAFT_VERSION` to connect to this server.
 /// Server Version: 763 | Your Version: <client_version>
 /// ```
 ///
@@ -190,7 +197,7 @@ fn get_mismatched_version_message(client_version: i32) -> TextComponent {
         .extra(ComponentBuilder::text("\n\n"))
         .extra(ComponentBuilder::text("Please use Minecraft version ").color(NamedColor::Gray))
         .extra(
-            ComponentBuilder::text("1.20.1")
+            ComponentBuilder::text(MINECRAFT_VERSION)
                 .color(NamedColor::Green)
                 .bold(),
         )

--- a/src/lib/net/src/conn_init/status.rs
+++ b/src/lib/net/src/conn_init/status.rs
@@ -1,5 +1,4 @@
-use crate::conn_init::LoginResult;
-use crate::conn_init::PROTOCOL_VERSION_1_20_1;
+use crate::conn_init::{LoginResult, MINECRAFT_VERSION, PROTOCOL_VERSION_1_20_1};
 use crate::connection::StreamWriter;
 use crate::errors::{NetError, PacketError};
 use crate::packets::incoming::packet_skeleton::PacketSkeleton;
@@ -159,7 +158,7 @@ fn get_server_status(state: &GlobalState) -> String {
 
     // Protocol info
     let version = structs::Version {
-        name: "1.20.1",
+        name: MINECRAFT_VERSION,
         protocol: PROTOCOL_VERSION_1_20_1 as u16,
     };
 


### PR DESCRIPTION
## Summary
- centralize Minecraft version string in `MINECRAFT_VERSION`
- use shared version constant across handshake and status modules
- reference version constant in README

## Testing
- `cargo +nightly check` *(fails: Could not find key: `minecraft:use_item_on` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_6893eea215f88329926b31e6f32fa470