### PR TITLE
Handle player teleport confirmation

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/confirm_player_teleport.rs
+++ b/src/bin/src/packet_handlers/play_packets/confirm_player_teleport.rs
@@ -1,3 +1,61 @@
-pub fn handle() {
-    // TODO
+use bevy_ecs::prelude::{Commands, Entity, Query, Res};
+use ferrumc_core::identity::player_identity::PlayerIdentity;
+use ferrumc_core::transform::grounded::OnGround;
+use ferrumc_core::transform::pending_teleport::PendingTeleport;
+use ferrumc_core::transform::position::Position;
+use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::entity_position_sync::TeleportEntityPacket;
+use ferrumc_net::ConfirmPlayerTeleportReceiver;
+use ferrumc_state::GlobalStateResource;
+use tracing::{error, warn};
+
+pub fn handle(
+    events: Res<ConfirmPlayerTeleportReceiver>,
+    mut commands: Commands,
+    mut pos_query: Query<(&mut Position, &mut OnGround, &Rotation, &PlayerIdentity)>,
+    pending_query: Query<&PendingTeleport>,
+    conn_query: Query<(Entity, &StreamWriter)>,
+    state: Res<GlobalStateResource>,
+) {
+    for (event, eid) in events.0.try_iter() {
+        if !state.0.players.is_connected(eid) {
+            warn!("Entity {:?} is not connected, cannot confirm teleport", eid);
+            continue;
+        }
+
+        let Ok(pending) = pending_query.get(eid) else {
+            warn!("No pending teleport for entity {:?}", eid);
+            continue;
+        };
+
+        if event.teleport_id.0 != pending.id {
+            warn!(
+                "Teleport ID mismatch for entity {:?}: expected {}, got {}",
+                eid, pending.id, event.teleport_id.0
+            );
+            continue;
+        }
+
+        if let Ok((mut pos, mut on_ground, rot, identity)) = pos_query.get_mut(eid) {
+            *pos = Position::new(pending.position.x, pending.position.y, pending.position.z);
+            on_ground.0 = false;
+            commands.entity(eid).remove::<PendingTeleport>();
+
+            let packet = TeleportEntityPacket::new(identity, &pos, rot, on_ground.0);
+            for (entity, conn) in conn_query.iter() {
+                if entity == eid || !state.0.players.is_connected(entity) {
+                    continue;
+                }
+                if let Err(err) = conn.send_packet_ref(&packet) {
+                    error!(
+                        "Failed to send teleport entity packet to {:?}: {:?}",
+                        entity, err
+                    );
+                }
+            }
+        } else {
+            warn!("Failed to get position components for entity {:?}", eid);
+        }
+    }
 }

--- a/src/bin/src/packet_handlers/play_packets/player_loaded.rs
+++ b/src/bin/src/packet_handlers/play_packets/player_loaded.rs
@@ -1,4 +1,5 @@
-use bevy_ecs::prelude::{Entity, Query, Res};
+use bevy_ecs::prelude::{Commands, Entity, Query, Res};
+use ferrumc_core::transform::pending_teleport::PendingTeleport;
 use ferrumc_core::transform::position::Position;
 use ferrumc_net::connection::StreamWriter;
 use ferrumc_net::packets::outgoing::synchronize_player_position::SynchronizePlayerPositionPacket;
@@ -10,6 +11,7 @@ use tracing::warn;
 pub fn handle(
     ev: Res<PlayerLoadedReceiver>,
     state: Res<GlobalStateResource>,
+    mut commands: Commands,
     query: Query<(Entity, &Position, &StreamWriter)>,
 ) {
     for (_, player) in ev.0.try_iter() {
@@ -61,6 +63,10 @@ pub fn handle(
                         "Sent synchronize player position packet for player {}",
                         player
                     );
+                    let teleport_pos = Position::new(packet.x, packet.y, packet.z);
+                    commands
+                        .entity(entity)
+                        .insert(PendingTeleport::new(packet.teleport_id.0, teleport_pos));
                 }
             }
         } else {

--- a/src/lib/core/src/transform/mod.rs
+++ b/src/lib/core/src/transform/mod.rs
@@ -1,3 +1,4 @@
 pub mod grounded;
+pub mod pending_teleport;
 pub mod position;
 pub mod rotation;

--- a/src/lib/core/src/transform/pending_teleport.rs
+++ b/src/lib/core/src/transform/pending_teleport.rs
@@ -1,0 +1,16 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+use super::position::Position;
+
+#[derive(TypeName, Component)]
+pub struct PendingTeleport {
+    pub id: i32,
+    pub position: Position,
+}
+
+impl PendingTeleport {
+    pub fn new(id: i32, position: Position) -> Self {
+        Self { id, position }
+    }
+}


### PR DESCRIPTION
## Summary
- Track pending teleports per player to validate confirm packets
- Save pending teleport when issuing initial spawn teleport
- Verify teleport IDs and broadcast entity teleports to other players

## Testing
- `cargo +nightly test` *(fails: Could not find key: `minecraft:swing` in the packet registry)*


------
https://chatgpt.com/codex/tasks/task_b_68940a5bb8d8832982ffeb4847d365c8