### PR TITLE
Handle additional player action statuses

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/player_action.rs
+++ b/src/bin/src/packet_handlers/play_packets/player_action.rs
@@ -12,6 +12,23 @@ use ferrumc_world::block_id::BlockId;
 use ferrumc_world::vanilla_chunk_format::BlockData;
 use tracing::{debug, error, trace};
 
+fn send_ack(
+    query: &Query<(Entity, &StreamWriter)>,
+    state: &GlobalStateResource,
+    eid: Entity,
+    sequence: VarInt,
+) -> Result<(), BinaryError> {
+    if let Ok((entity, conn)) = query.get(eid) {
+        if state.0.players.is_connected(entity) {
+            let ack_packet = BlockChangeAck { sequence };
+            conn.send_packet_ref(&ack_packet)?;
+        }
+    } else {
+        debug!("Failed to find connection for entity {:?}", eid);
+    }
+    Ok(())
+}
+
 pub fn handle(
     events: Res<PlayerActionReceiver>,
     state: Res<GlobalStateResource>,
@@ -22,6 +39,15 @@ pub fn handle(
         let res: Result<(), BinaryError> = try {
             match event.status.0 {
                 0 => {
+                    // Started digging
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
+                }
+                1 => {
+                    // Cancelled digging
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
+                }
+                2 => {
+                    // Finished digging
                     let mut chunk = match state.0.clone().world.load_chunk_owned(
                         event.location.x >> 4,
                         event.location.z >> 4,
@@ -43,29 +69,54 @@ pub fn handle(
                         event.location.z.abs() % 16,
                     );
                     chunk.set_block(relative_x, relative_y, relative_z, BlockData::default())?;
-                    // Save the chunk to disk
                     state.0.world.save_chunk(Arc::new(chunk))?;
-                    for (eid, conn) in query {
-                        if !state.0.players.is_connected(eid) {
+                    let block_update_packet = BlockUpdate {
+                        location: event.location.clone(),
+                        block_id: VarInt::from(BlockId::default()),
+                    };
+                    for (eid, conn) in query.iter() {
+                        if !state.0.players.is_connected(*eid) {
                             continue;
                         }
-                        // If the player is the one who placed the block, send the BlockChangeAck packet
-                        let block_update_packet = BlockUpdate {
-                            location: event.location.clone(),
-                            block_id: VarInt::from(BlockId::default()),
-                        };
                         conn.send_packet_ref(&block_update_packet)?;
-                        if eid == trigger_eid {
-                            let ack_packet = BlockChangeAck {
-                                sequence: event.sequence,
-                            };
-                            conn.send_packet_ref(&ack_packet)?;
-                        }
                     }
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
                 }
-
-                1 => {
-                    debug!("You shouldn't be seeing this in creative mode.");
+                3 => {
+                    // Drop item stack
+                    state
+                        .0
+                        .players
+                        .set_held_item(trigger_eid, 0, BlockId::default());
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
+                }
+                4 => {
+                    // Drop single item
+                    state
+                        .0
+                        .players
+                        .set_held_item(trigger_eid, 0, BlockId::default());
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
+                }
+                5 => {
+                    // Release use item
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
+                }
+                6 => {
+                    // Swap hand items
+                    let main = state
+                        .0
+                        .players
+                        .get_held_item(trigger_eid, 0)
+                        .unwrap_or_default();
+                    let off = state
+                        .0
+                        .players
+                        .get_held_item(trigger_eid, 1)
+                        .unwrap_or_default();
+                    state.0.players.set_held_item(trigger_eid, 0, off);
+                    state.0.players.set_held_item(trigger_eid, 1, main);
+                    send_ack(&query, &state, trigger_eid, event.sequence)?;
                 }
                 _ => {}
             };


### PR DESCRIPTION
## Summary
- handle start, cancel, finish digging, item drops, item release, and hand swaps in `player_action` packet handler
- centralize block change acknowledgements to avoid duplicated logic

## Testing
- `cargo test` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_b_689412a20b68832984989710afbc6135