### PR TITLE
Implement RSA/AES helpers for network encryption

### DIFF
--- a/src/lib/net/crates/encryption/Cargo.toml
+++ b/src/lib/net/crates/encryption/Cargo.toml
@@ -5,3 +5,8 @@ edition = "2021"
 
 [dependencies]
 thiserror = { workspace = true }
+rsa = "0.9"
+aes = "0.8"
+cfb8 = "0.8"
+sha1 = "0.10"
+rand = { workspace = true }

--- a/src/lib/net/crates/encryption/src/errors.rs
+++ b/src/lib/net/crates/encryption/src/errors.rs
@@ -2,6 +2,12 @@ use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
 pub enum NetEncryptionError {
-    #[error("Something failed lol")]
-    SomeError,
+    #[error("RSA error: {0}")]
+    RsaError(String),
+
+    #[error("AES error: {0}")]
+    AesError(String),
+
+    #[error("Invalid verify token")]
+    InvalidVerifyToken,
 }

--- a/src/lib/net/crates/encryption/src/lib.rs
+++ b/src/lib/net/crates/encryption/src/lib.rs
@@ -1,16 +1,70 @@
 pub mod errors;
 
-pub fn add(left: u64, right: u64) -> u64 {
-    left + right
+use aes::Aes128;
+use aes::cipher::{AsyncStreamCipher, KeyIvInit};
+use cfb8::{Decryptor as Cfb8Decryptor, Encryptor as Cfb8Encryptor};
+use errors::NetEncryptionError;
+use rsa::pkcs1v15::Pkcs1v15Encrypt;
+use rsa::rand_core::{OsRng, RngCore};
+use rsa::{RsaPrivateKey, RsaPublicKey};
+
+pub fn generate_rsa_keypair() -> Result<(RsaPrivateKey, RsaPublicKey), NetEncryptionError> {
+    let mut rng = OsRng;
+    let private_key = RsaPrivateKey::new(&mut rng, 1024)
+        .map_err(|e| NetEncryptionError::RsaError(e.to_string()))?;
+    let public_key = RsaPublicKey::from(&private_key);
+    Ok((private_key, public_key))
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+pub fn generate_verify_token() -> [u8; 4] {
+    let mut token = [0u8; 4];
+    OsRng.fill_bytes(&mut token);
+    token
+}
 
-    #[test]
-    fn it_works() {
-        let result = add(2, 2);
-        assert_eq!(result, 4);
+pub fn decrypt_shared_secret(
+    private_key: &RsaPrivateKey,
+    input: &[u8],
+) -> Result<Vec<u8>, NetEncryptionError> {
+    private_key
+        .decrypt(Pkcs1v15Encrypt, input)
+        .map_err(|e| NetEncryptionError::RsaError(e.to_string()))
+}
+
+pub struct Aes128Cfb8Encryptor {
+    key: [u8; 16],
+    iv: [u8; 16],
+}
+
+impl Aes128Cfb8Encryptor {
+    pub fn new(key: [u8; 16], iv: [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+
+    pub fn encrypt(&self, data: &[u8]) -> Result<Vec<u8>, NetEncryptionError> {
+        let mut buf = data.to_vec();
+        let cipher = Cfb8Encryptor::<Aes128>::new_from_slices(&self.key, &self.iv)
+            .map_err(|e| NetEncryptionError::AesError(e.to_string()))?;
+        cipher.encrypt(&mut buf);
+        Ok(buf)
+    }
+}
+
+pub struct Aes128Cfb8Decryptor {
+    key: [u8; 16],
+    iv: [u8; 16],
+}
+
+impl Aes128Cfb8Decryptor {
+    pub fn new(key: [u8; 16], iv: [u8; 16]) -> Self {
+        Self { key, iv }
+    }
+
+    pub fn decrypt(&self, data: &[u8]) -> Result<Vec<u8>, NetEncryptionError> {
+        let mut buf = data.to_vec();
+        let cipher = Cfb8Decryptor::<Aes128>::new_from_slices(&self.key, &self.iv)
+            .map_err(|e| NetEncryptionError::AesError(e.to_string()))?;
+        cipher.decrypt(&mut buf);
+        Ok(buf)
     }
 }


### PR DESCRIPTION
## Summary
- add RSA/AES/CFB8/SHA1/rand dependencies for net encryption crate
- implement RSA keypair generation, verify token, RSA decryption and AES-128-CFB8 wrappers
- extend encryption errors with RSA/AES and token variants

## Testing
- `cargo test -p ferrumc-net-encryption`


------
https://chatgpt.com/codex/tasks/task_b_689455e4dd8c83299ed85749e214636c