### PR TITLE
Add online mode flag to server configuration

### DIFF
--- a/.etc/example-config.toml
+++ b/.etc/example-config.toml
@@ -12,6 +12,8 @@ tps = 20
 world = "world"
 # Whether the server should validate players via the whitelist
 whitelist = false
+# Whether the server should authenticate players via Mojang. Set to false for offline mode.
+online_mode = true
 # Network compression threshold (can be negative). This decides how long a packet has to be before it is compressed.
 # Very small packets may actually increase in size when compressed, so setting it to 0 won't be perfect in all situations.
 # Set to -1 to disable compression.

--- a/assets/data/configs/main-config.toml
+++ b/assets/data/configs/main-config.toml
@@ -12,6 +12,8 @@ tps = 20
 world = "world"
 # Whether the server should validate players via the whitelist
 whitelist = false
+# Whether the server should authenticate players via Mojang. Set to false for offline mode.
+online_mode = true
 # Network compression threshold (can be negative). This decides how long a packet has to be before it is compressed.
 # Very small packets may actually increase in size when compressed, so setting it to 0 won't be perfect in all situations.
 # Set to -1 to disable compression.

--- a/src/lib/config/src/server_config.rs
+++ b/src/lib/config/src/server_config.rs
@@ -35,9 +35,10 @@ pub fn set_global_config(config: ServerConfig) {
 /// - `world`: The name of the world that the server will load.
 /// - `network_compression_threshold`: The threshold at which the server will compress network packets.
 /// - `whitelist`: Whether the server whitelist is enabled or not.
+/// - `online_mode`: Whether the server should authenticate players or run in offline mode.
 /// - `chunk_render_distance`: The render distance of the chunks. This is the number of chunks that will be
 ///   loaded around the player.
-#[derive(Debug, Deserialize, Serialize, Default)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct ServerConfig {
     pub host: String,
     pub port: u16, // 0-65535
@@ -49,7 +50,32 @@ pub struct ServerConfig {
     pub network_compression_threshold: i32, // Can be negative
     pub verify_decompressed_packets: bool,
     pub whitelist: bool,
+    #[serde(default = "default_online_mode")]
+    pub online_mode: bool,
     pub chunk_render_distance: u32,
+}
+
+const fn default_online_mode() -> bool {
+    true
+}
+
+impl Default for ServerConfig {
+    fn default() -> Self {
+        Self {
+            host: Default::default(),
+            port: Default::default(),
+            motd: Default::default(),
+            max_players: Default::default(),
+            tps: Default::default(),
+            database: Default::default(),
+            world: Default::default(),
+            network_compression_threshold: Default::default(),
+            verify_decompressed_packets: Default::default(),
+            whitelist: Default::default(),
+            online_mode: default_online_mode(),
+            chunk_render_distance: Default::default(),
+        }
+    }
 }
 
 /// The database configuration section from [ServerConfig].

--- a/src/lib/utils/config/src/server_config.rs
+++ b/src/lib/utils/config/src/server_config.rs
@@ -16,6 +16,7 @@ use serde_derive::{Deserialize, Serialize};
 /// - `world`: The name of the world that the server will load.
 /// - `network_compression_threshold`: The threshold at which the server will compress network packets.
 /// - `whitelist`: Whether the server whitelist is enabled or not.
+/// - `online_mode`: Whether the server should authenticate players or run in offline mode.
 /// - `chunk_render_distance`: The render distance of the chunks. This is the number of chunks that will be
 ///   loaded around the player.
 #[derive(Debug, Deserialize, Serialize)]
@@ -29,7 +30,13 @@ pub struct ServerConfig {
     pub world: String,
     pub network_compression_threshold: i32, // Can be negative
     pub whitelist: bool,
+    #[serde(default = "default_online_mode")]
+    pub online_mode: bool,
     pub chunk_render_distance: u32,
+}
+
+const fn default_online_mode() -> bool {
+    true
 }
 
 /// The database configuration section from [ServerConfig].


### PR DESCRIPTION
## Summary
- add `online_mode` flag to server configuration, defaulting to true
- propagate new flag through configuration accessors
- document `online_mode` in default config files

## Testing
- `cargo +nightly test` *(fails: Could not find key: `minecraft:swing` in the packet registry)*
- `cargo +nightly test -p ferrumc-config --manifest-path src/lib/config/Cargo.toml`
- `cargo +nightly test --manifest-path src/lib/utils/config/Cargo.toml` *(fails: current package believes it's in a workspace when it's not)*

------
https://chatgpt.com/codex/tasks/task_b_6894582955bc83299543ab05aa6846ef