### PR TITLE
Add AES stream encryption support

### DIFF
--- a/src/lib/net/Cargo.toml
+++ b/src/lib/net/Cargo.toml
@@ -35,6 +35,8 @@ indexmap = { workspace = true }
 lazy_static = { workspace = true }
 yazi = { workspace = true }
 rsa = { workspace = true }
+aes = "0.8"
+cfb8 = "0.8"
 
 
 [dev-dependencies]

--- a/src/lib/net/src/packets/incoming/packet_skeleton.rs
+++ b/src/lib/net/src/packets/incoming/packet_skeleton.rs
@@ -1,6 +1,7 @@
 use crate::errors::CompressionError::{
     ChecksumMismatch, CompressedPacketTooSmall, GenericDecompressionError, MissingChecksum,
 };
+use crate::connection::EncryptedReader;
 use crate::errors::{NetError, PacketError};
 use crate::ConnState;
 use ferrumc_config::server_config::get_global_config;
@@ -56,7 +57,7 @@ impl PacketSkeleton {
     /// - Returns `MalformedPacket` if framing data is invalid.
     /// - Returns `DecompressionError` if compressed payload integrity checks fail.
     pub async fn new<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: &mut EncryptedReader<R>,
         compressed: bool,
         state: ConnState,
     ) -> Result<Self, NetError> {
@@ -94,7 +95,7 @@ impl PacketSkeleton {
     /// - Filters out `custom_payload` plugin messages (0x14) in the Play state
     ///   to ignore unused plugin channels.
     async fn read_uncompressed<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: &mut EncryptedReader<R>,
         state: ConnState,
     ) -> Result<Self, NetError> {
         loop {
@@ -154,7 +155,7 @@ impl PacketSkeleton {
     ///
     /// - Plugin messages (0x14) are ignored here as well.
     async fn read_compressed<R: AsyncRead + Unpin>(
-        reader: &mut R,
+        reader: &mut EncryptedReader<R>,
         state: ConnState,
     ) -> Result<Self, NetError> {
         loop {


### PR DESCRIPTION
## Summary
- Support optional AES-128 CFB8 encryption for network streams
- Add reader-side decryption and integrate with packet parsing
- Wire encryption setup during login handshake

## Testing
- `cargo +nightly test -p ferrumc-net` *(fails: parse_packet_attribute failed in setup_packet_handling)*

------
https://chatgpt.com/codex/tasks/task_b_68946c9218988329b4b8759e42d53113