### PR TITLE
feat: expand player info update actions

### DIFF
--- a/src/lib/net/src/packets/outgoing/player_info_update.rs
+++ b/src/lib/net/src/packets/outgoing/player_info_update.rs
@@ -78,6 +78,10 @@ impl PlayerWithActions {
         for action in &self.actions {
             mask |= match action {
                 PlayerAction::AddPlayer { .. } => 0x01,
+                PlayerAction::UpdateGameMode { .. } => 0x04,
+                PlayerAction::UpdateListed { .. } => 0x08,
+                PlayerAction::UpdateLatency { .. } => 0x10,
+                PlayerAction::UpdateDisplayName { .. } => 0x20,
             }
         }
         mask
@@ -92,6 +96,38 @@ impl PlayerWithActions {
             }],
         }
     }
+
+    pub fn update_game_mode(uuid: i32, game_mode: i32) -> Self {
+        Self {
+            uuid,
+            actions: vec![PlayerAction::UpdateGameMode {
+                game_mode: VarInt::new(game_mode),
+            }],
+        }
+    }
+
+    pub fn update_listed(uuid: i32, listed: bool) -> Self {
+        Self {
+            uuid,
+            actions: vec![PlayerAction::UpdateListed { listed }],
+        }
+    }
+
+    pub fn update_latency(uuid: i32, latency: i32) -> Self {
+        Self {
+            uuid,
+            actions: vec![PlayerAction::UpdateLatency {
+                latency: VarInt::new(latency),
+            }],
+        }
+    }
+
+    pub fn update_display_name(uuid: i32, display_name: Option<String>) -> Self {
+        Self {
+            uuid,
+            actions: vec![PlayerAction::UpdateDisplayName { display_name }],
+        }
+    }
 }
 
 #[derive(NetEncode, Debug)]
@@ -99,6 +135,18 @@ pub enum PlayerAction {
     AddPlayer {
         name: String,
         properties: LengthPrefixedVec<PlayerProperty>,
+    },
+    UpdateGameMode {
+        game_mode: VarInt,
+    },
+    UpdateListed {
+        listed: bool,
+    },
+    UpdateLatency {
+        latency: VarInt,
+    },
+    UpdateDisplayName {
+        display_name: Option<String>,
     },
 }
 


### PR DESCRIPTION
## Summary
- add player info update actions for game mode, listed status, latency and display name
- support bitmask generation and constructor helpers for each action

## Testing
- `cargo +nightly test` *(fails: Could not find key: `minecraft:use_item_on` in the packet registry, unresolved imports in ferrumc-net)*

------
https://chatgpt.com/codex/tasks/task_b_68948bc3536083299298515248ca1f39