### PR TITLE
Add chat message packet and broadcast system

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/mod.rs
+++ b/src/bin/src/packet_handlers/play_packets/mod.rs
@@ -1,4 +1,5 @@
 use bevy_ecs::schedule::Schedule;
+use crate::systems::chat_message;
 
 mod chunk_batch_ack;
 mod confirm_player_teleport;
@@ -21,6 +22,7 @@ pub fn register_packet_handlers(schedule: &mut Schedule) {
     schedule.add_systems(place_block::handle);
     schedule.add_systems(player_action::handle);
     schedule.add_systems(player_command::handle);
+    schedule.add_systems(chat_message::broadcast_chat_messages);
     schedule.add_systems(set_player_position::handle);
     schedule.add_systems(set_player_position_and_rotation::handle);
     schedule.add_systems(set_player_rotation::handle);

--- a/src/bin/src/systems/chat_message.rs
+++ b/src/bin/src/systems/chat_message.rs
@@ -1,0 +1,25 @@
+use bevy_ecs::prelude::{Entity, Query, Res};
+use ferrumc_net::{IncomingChatMessagePacketReceiver, connection::StreamWriter, packets::outgoing::chat_message::OutgoingChatMessagePacket};
+use ferrumc_state::GlobalStateResource;
+use ferrumc_text::TextComponent;
+use tracing::error;
+
+pub fn broadcast_chat_messages(
+    events: Res<IncomingChatMessagePacketReceiver>,
+    query: Query<(Entity, &StreamWriter)>,
+    state: Res<GlobalStateResource>,
+) {
+    for (packet, _) in events.0.try_iter() {
+        let message = TextComponent::from(packet.message.clone());
+        let outgoing = OutgoingChatMessagePacket::new(message);
+        for (entity, conn) in query.iter() {
+            if !state.0.players.is_connected(entity) {
+                continue;
+            }
+            if let Err(err) = conn.send_packet_ref(&outgoing) {
+                error!("Failed to send chat message: {:?}", err);
+            }
+        }
+    }
+}
+

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -1,4 +1,5 @@
 pub mod connection_killer;
+pub mod chat_message;
 mod cross_chunk_boundary;
 mod keep_alive_system;
 pub mod new_connections;

--- a/src/lib/net/src/packets/incoming/chat_message.rs
+++ b/src/lib/net/src/packets/incoming/chat_message.rs
@@ -1,0 +1,8 @@
+use ferrumc_macros::{packet, NetDecode};
+
+#[derive(NetDecode, Debug)]
+#[packet(packet_id = "chat_message", state = "play")]
+pub struct IncomingChatMessagePacket {
+    pub message: String,
+}
+

--- a/src/lib/net/src/packets/incoming/mod.rs
+++ b/src/lib/net/src/packets/incoming/mod.rs
@@ -7,6 +7,7 @@ pub mod known_packs;
 
 pub mod keep_alive;
 pub mod packet_skeleton;
+pub mod chat_message;
 
 pub mod place_block;
 pub mod player_command;

--- a/src/lib/net/src/packets/outgoing/chat_message.rs
+++ b/src/lib/net/src/packets/outgoing/chat_message.rs
@@ -1,0 +1,16 @@
+use ferrumc_macros::{packet, NetEncode};
+use ferrumc_text::TextComponent;
+use std::io::Write;
+
+#[derive(NetEncode, Clone)]
+#[packet(packet_id = "chat_message", state = "play")]
+pub struct OutgoingChatMessagePacket {
+    pub message: TextComponent,
+}
+
+impl OutgoingChatMessagePacket {
+    pub fn new(message: TextComponent) -> Self {
+        Self { message }
+    }
+}
+

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -3,6 +3,7 @@ pub mod chunk_batch_finish;
 pub mod chunk_batch_start;
 pub mod disconnect;
 pub mod game_event;
+pub mod chat_message;
 pub mod keep_alive;
 pub mod login_disconnect;
 pub mod login_play;


### PR DESCRIPTION
## Summary
- add chat message packets for encoding/decoding in play state
- broadcast received chat messages to all connected players each tick
- register broadcast system in play packet schedule

## Testing
- `cargo test` *(fails: ferrumc-macros requires nightly `proc_macro_quote` feature)*

------
https://chatgpt.com/codex/tasks/task_b_68948f7ad11883298d17b20e42ff12f9