### PR TITLE
Add command dispatcher and basic /say command

### DIFF
--- a/src/bin/src/commands/mod.rs
+++ b/src/bin/src/commands/mod.rs
@@ -1,0 +1,67 @@
+use bevy_ecs::prelude::{Entity, Query, Resource};
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_state::GlobalStateResource;
+use ferrumc_text::TextComponent;
+use std::collections::HashMap;
+use tracing::warn;
+
+use crate::systems::chat_message;
+
+/// Context provided to command handlers when they are executed.
+pub struct CommandContext<'a> {
+    /// Entity that issued the command.
+    pub sender: Entity,
+    /// Query used to access all connected clients.
+    pub query: &'a Query<'a, 'a, (Entity, &'a StreamWriter)>,
+    /// Global server state.
+    pub state: &'a GlobalStateResource,
+}
+
+/// Trait implemented by individual command handlers.
+pub trait CommandHandler: Send + Sync {
+    /// Handles the command with the provided arguments and context.
+    fn handle(&self, args: &str, ctx: CommandContext);
+}
+
+/// Dispatcher that routes parsed commands to their handlers.
+#[derive(Default, Resource)]
+pub struct CommandDispatcher {
+    handlers: HashMap<&'static str, Box<dyn CommandHandler>>,
+}
+
+impl CommandDispatcher {
+    /// Creates a new empty dispatcher.
+    pub fn new() -> Self {
+        Self {
+            handlers: HashMap::new(),
+        }
+    }
+
+    /// Registers a command handler for a given command name.
+    pub fn register(&mut self, name: &'static str, handler: impl CommandHandler + 'static) {
+        self.handlers.insert(name, Box::new(handler));
+    }
+
+    /// Dispatches a command line to the appropriate handler.
+    pub fn dispatch<'a>(&self, line: &str, ctx: CommandContext<'a>) {
+        let mut parts = line.splitn(2, ' ');
+        if let Some(cmd) = parts.next() {
+            if let Some(handler) = self.handlers.get(cmd) {
+                let args = parts.next().unwrap_or("");
+                handler.handle(args, ctx);
+            } else {
+                warn!("Unknown command: {}", cmd);
+            }
+        }
+    }
+}
+
+/// Simple `/say` command that broadcasts a message to all players.
+pub struct SayCommand;
+
+impl CommandHandler for SayCommand {
+    fn handle(&self, args: &str, ctx: CommandContext) {
+        let text = TextComponent::from(args.to_string());
+        chat_message::broadcast_text(text, ctx.query, ctx.state);
+    }
+}

--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -18,6 +18,7 @@ pub(crate) mod errors;
 use crate::cli::{CLIArgs, Command, ImportArgs};
 mod chunk_sending;
 mod cli;
+mod commands;
 mod game_loop;
 mod packet_handlers;
 mod register_events;

--- a/src/bin/src/register_resources.rs
+++ b/src/bin/src/register_resources.rs
@@ -1,3 +1,4 @@
+use crate::commands::{CommandDispatcher, SayCommand};
 use crate::systems::new_connections::NewConnectionRecv;
 use bevy_ecs::prelude::World;
 use crossbeam_channel::Receiver;
@@ -19,4 +20,8 @@ pub fn register_resources(
     world.insert_resource(WorldSyncTracker {
         last_synced: std::time::Instant::now(),
     });
+
+    let mut dispatcher = CommandDispatcher::new();
+    dispatcher.register("say", SayCommand);
+    world.insert_resource(dispatcher);
 }

--- a/src/bin/src/systems/chat_message.rs
+++ b/src/bin/src/systems/chat_message.rs
@@ -1,25 +1,49 @@
 use bevy_ecs::prelude::{Entity, Query, Res};
-use ferrumc_net::{IncomingChatMessagePacketReceiver, connection::StreamWriter, packets::outgoing::chat_message::OutgoingChatMessagePacket};
+use ferrumc_net::{
+    connection::StreamWriter, packets::outgoing::chat_message::OutgoingChatMessagePacket,
+    IncomingChatMessagePacketReceiver,
+};
 use ferrumc_state::GlobalStateResource;
 use ferrumc_text::TextComponent;
 use tracing::error;
+
+use crate::commands::{CommandContext, CommandDispatcher};
+
+/// Broadcasts a text component to all connected players.
+pub fn broadcast_text(
+    message: TextComponent,
+    query: &Query<(Entity, &StreamWriter)>,
+    state: &GlobalStateResource,
+) {
+    let outgoing = OutgoingChatMessagePacket::new(message);
+    for (entity, conn) in query.iter() {
+        if !state.0.players.is_connected(entity) {
+            continue;
+        }
+        if let Err(err) = conn.send_packet_ref(&outgoing) {
+            error!("Failed to send chat message: {:?}", err);
+        }
+    }
+}
 
 pub fn broadcast_chat_messages(
     events: Res<IncomingChatMessagePacketReceiver>,
     query: Query<(Entity, &StreamWriter)>,
     state: Res<GlobalStateResource>,
+    dispatcher: Res<CommandDispatcher>,
 ) {
-    for (packet, _) in events.0.try_iter() {
-        let message = TextComponent::from(packet.message.clone());
-        let outgoing = OutgoingChatMessagePacket::new(message);
-        for (entity, conn) in query.iter() {
-            if !state.0.players.is_connected(entity) {
-                continue;
-            }
-            if let Err(err) = conn.send_packet_ref(&outgoing) {
-                error!("Failed to send chat message: {:?}", err);
-            }
+    for (packet, sender) in events.0.try_iter() {
+        if packet.message.starts_with('/') {
+            let line = packet.message.trim_start_matches('/');
+            let ctx = CommandContext {
+                sender,
+                query: &query,
+                state: state.as_ref(),
+            };
+            dispatcher.dispatch(line, ctx);
+        } else {
+            let message = TextComponent::from(packet.message.clone());
+            broadcast_text(message, &query, state.as_ref());
         }
     }
 }
-


### PR DESCRIPTION
## Summary
- introduce a command handler trait and dispatcher with a sample `/say` command
- route leading-slash chat messages to the dispatcher and broadcast server text
- register dispatcher as a resource during startup

## Testing
- `cargo +nightly test` *(fails: could not compile `ferrumc-net` due to missing packet registry definitions)*

------
https://chatgpt.com/codex/tasks/task_b_6894fdceab3883299aa1d524b14a6640