### PR TITLE
Add transfer handshake support

### DIFF
--- a/assets/data/packets.json
+++ b/assets/data/packets.json
@@ -4,7 +4,11 @@
     "serverbound": {}
   },
   "handshake": {
-    "clientbound": {},
+    "clientbound": {
+      "minecraft:transfer": {
+        "protocol_id": 0
+      }
+    },
     "serverbound": {
       "minecraft:intention": {
         "protocol_id": 0

--- a/assets/data/registry_packets.json
+++ b/assets/data/registry_packets.json
@@ -4,7 +4,11 @@
     "serverbound": {}
   },
   "handshake": {
-    "clientbound": {},
+    "clientbound": {
+      "minecraft:transfer": {
+        "protocol_id": 0
+      }
+    },
     "serverbound": {
       "minecraft:set_protocol": {
         "protocol_id": 0

--- a/src/lib/net/src/conn_init/transfer.rs
+++ b/src/lib/net/src/conn_init/transfer.rs
@@ -1,0 +1,31 @@
+use crate::conn_init::LoginResult;
+use crate::connection::{EncryptedReader, StreamWriter};
+use crate::errors::NetError;
+use crate::packets::incoming::handshake::Handshake;
+use ferrumc_state::GlobalState;
+use tokio::io::AsyncRead;
+
+/// Handles cross-server transfer requests during the handshake phase.
+///
+/// Sends a `transfer` packet to the client instructing it to connect to
+/// the specified host and port. The current connection is closed
+/// afterwards.
+pub(super) async fn transfer<R: AsyncRead + Unpin>(
+    hs_packet: Handshake,
+    _conn_read: &mut EncryptedReader<R>,
+    conn_write: &StreamWriter,
+    _state: GlobalState,
+) -> Result<(bool, LoginResult), NetError> {
+    let transfer_packet = crate::packets::outgoing::transfer::TransferPacket::new(
+        hs_packet.server_address,
+        hs_packet.server_port,
+    );
+    conn_write.send_packet(transfer_packet)?;
+    Ok((
+        true,
+        LoginResult {
+            player_identity: None,
+            compression: false,
+        },
+    ))
+}

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -14,6 +14,7 @@ pub mod login_encryption_request;
 pub mod login_play;
 pub mod login_success;
 pub mod ping_response;
+pub mod transfer;
 pub mod set_center_chunk;
 pub mod set_default_spawn_position;
 pub mod set_render_distance;

--- a/src/lib/net/src/packets/outgoing/transfer.rs
+++ b/src/lib/net/src/packets/outgoing/transfer.rs
@@ -1,0 +1,18 @@
+use ferrumc_macros::{packet, NetEncode};
+use std::io::Write;
+
+#[derive(NetEncode)]
+#[packet(packet_id = "transfer", state = "handshake")]
+pub struct TransferPacket {
+    pub host: String,
+    pub port: u16,
+}
+
+impl TransferPacket {
+    pub fn new(host: impl Into<String>, port: u16) -> Self {
+        Self {
+            host: host.into(),
+            port,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- handle transfer state in initial handshake and redirect via new transfer handler
- introduce clientbound `transfer` packet and registry entries

## Testing
- `cargo +nightly-2024-12-25 test -p ferrumc-net` *(fails: cannot return value referencing temporary value src/lib/core/src/inventory.rs:30)*

------
https://chatgpt.com/codex/tasks/task_b_68954c3361fc8329986de64228bf4873