### PR TITLE
Handle inventory slot updates with NBT and equipment

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/container_close.rs
+++ b/src/bin/src/packet_handlers/play_packets/container_close.rs
@@ -1,0 +1,10 @@
+use bevy_ecs::prelude::Res;
+use ferrumc_net::ServerboundContainerCloseReceiver;
+use tracing::trace;
+
+pub fn handle(events: Res<ServerboundContainerCloseReceiver>) {
+    for (_event, _eid) in events.0.try_iter() {
+        trace!("Container closed");
+    }
+}
+

--- a/src/bin/src/packet_handlers/play_packets/container_slot_state_changed.rs
+++ b/src/bin/src/packet_handlers/play_packets/container_slot_state_changed.rs
@@ -1,0 +1,49 @@
+use bevy_ecs::prelude::{Entity, Query, Res};
+use ferrumc_core::inventory::{Inventory, ItemStack};
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::container_set_slot::ContainerSetSlotPacket;
+use ferrumc_net::ContainerSlotStateChangedReceiver;
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
+use ferrumc_state::GlobalStateResource;
+use ferrumc_world::block_id::BlockId;
+use tracing::debug;
+
+pub fn handle(
+    events: Res<ContainerSlotStateChangedReceiver>,
+    state: Res<GlobalStateResource>,
+    mut query: Query<(Entity, &StreamWriter, &mut Inventory)>,
+) {
+    for (event, eid) in events.0.try_iter() {
+        let Ok((entity, conn, mut inv)) = query.get_mut(eid) else {
+            debug!("Could not get inventory for entity {:?}", eid);
+            continue;
+        };
+        if !state.0.players.is_connected(entity) {
+            continue;
+        }
+        let slot_index = event.slot as usize;
+        let new_stack = match &event.item.item {
+            PrefixedOptional::Some(data) => {
+                let block_id = BlockId::from_varint(data.item_id);
+                let nbt = if data.nbt.is_empty() {
+                    None
+                } else {
+                    Some(data.nbt.clone())
+                };
+                Some(ItemStack::new(block_id, data.count, 64, nbt))
+            }
+            PrefixedOptional::None => None,
+        };
+        inv.set_slot(slot_index, new_stack);
+        let packet = ContainerSetSlotPacket::new(
+            0,
+            0,
+            event.slot,
+            inv.get_slot(slot_index).and_then(|s| s.as_ref()),
+        );
+        if let Err(e) = conn.send_packet_ref(&packet) {
+            debug!("Failed to send container slot update: {:?}", e);
+        }
+    }
+}
+

--- a/src/bin/src/packet_handlers/play_packets/mod.rs
+++ b/src/bin/src/packet_handlers/play_packets/mod.rs
@@ -7,6 +7,8 @@ mod keep_alive;
 mod place_block;
 mod player_action;
 mod player_command;
+mod container_slot_state_changed;
+mod container_close;
 mod player_loaded;
 mod set_player_position;
 mod set_player_position_and_rotation;
@@ -22,6 +24,8 @@ pub fn register_packet_handlers(schedule: &mut Schedule) {
     schedule.add_systems(place_block::handle);
     schedule.add_systems(player_action::handle);
     schedule.add_systems(player_command::handle);
+    schedule.add_systems(container_slot_state_changed::handle);
+    schedule.add_systems(container_close::handle);
     schedule.add_systems(chat_message::broadcast_chat_messages);
     schedule.add_systems(set_player_position::handle);
     schedule.add_systems(set_player_position_and_rotation::handle);

--- a/src/lib/core/src/inventory.rs
+++ b/src/lib/core/src/inventory.rs
@@ -5,11 +5,19 @@ use ferrumc_world::block_id::BlockId;
 pub struct ItemStack {
     pub item: BlockId,
     pub count: u8,
+    pub max_stack_size: u8,
+    pub nbt: Option<Vec<u8>>,
 }
 
 impl ItemStack {
-    pub fn new(item: BlockId, count: u8) -> Self {
-        Self { item, count }
+    pub fn new(item: BlockId, count: u8, max_stack_size: u8, nbt: Option<Vec<u8>>) -> Self {
+        let count = count.min(max_stack_size);
+        Self {
+            item,
+            count,
+            max_stack_size,
+            nbt,
+        }
     }
 }
 
@@ -19,6 +27,8 @@ pub type Slot = Option<ItemStack>;
 pub struct Inventory {
     pub hotbar: [Slot; 9],
     pub main: [Slot; 27],
+    pub equipment: [Slot; 4],
+    pub offhand: Slot,
 }
 
 impl Inventory {
@@ -27,13 +37,76 @@ impl Inventory {
     }
 
     pub fn get_slot(&self, index: usize) -> Option<&Slot> {
-        self.all_slots().get(index)
+        let main_len = self.main.len();
+        let hotbar_len = self.hotbar.len();
+        let equip_len = self.equipment.len();
+        if index < main_len {
+            Some(&self.main[index])
+        } else if index < main_len + hotbar_len {
+            Some(&self.hotbar[index - main_len])
+        } else if index < main_len + hotbar_len + equip_len {
+            Some(&self.equipment[index - main_len - hotbar_len])
+        } else if index == main_len + hotbar_len + equip_len {
+            Some(&self.offhand)
+        } else {
+            None
+        }
+    }
+
+    pub fn get_slot_mut(&mut self, index: usize) -> Option<&mut Slot> {
+        let main_len = self.main.len();
+        let hotbar_len = self.hotbar.len();
+        let equip_len = self.equipment.len();
+        if index < main_len {
+            Some(&mut self.main[index])
+        } else if index < main_len + hotbar_len {
+            Some(&mut self.hotbar[index - main_len])
+        } else if index < main_len + hotbar_len + equip_len {
+            Some(&mut self.equipment[index - main_len - hotbar_len])
+        } else if index == main_len + hotbar_len + equip_len {
+            Some(&mut self.offhand)
+        } else {
+            None
+        }
+    }
+
+    pub fn set_slot(&mut self, index: usize, slot: Slot) {
+        if let Some(s) = self.get_slot_mut(index) {
+            *s = slot;
+        }
     }
 
     pub fn all_slots(&self) -> Vec<Slot> {
-        let mut slots = Vec::with_capacity(36);
+        let mut slots = Vec::with_capacity(41);
         slots.extend(self.main.iter().cloned());
         slots.extend(self.hotbar.iter().cloned());
+        slots.extend(self.equipment.iter().cloned());
+        slots.push(self.offhand.clone());
         slots
+    }
+
+    /// Attempts to add an item to a slot, respecting max stack sizes.
+    /// Returns any leftover items that couldn't fit.
+    pub fn add_item_to_slot(&mut self, index: usize, mut item: ItemStack) -> Option<ItemStack> {
+        if let Some(slot) = self.get_slot_mut(index) {
+            match slot {
+                Some(existing) if existing.item == item.item && existing.nbt == item.nbt => {
+                    let available = existing.max_stack_size.saturating_sub(existing.count);
+                    let to_add = item.count.min(available);
+                    existing.count += to_add;
+                    item.count -= to_add;
+                    if item.count > 0 { Some(item) } else { None }
+                }
+                Some(_) => Some(item),
+                None => {
+                    let count = item.count.min(item.max_stack_size);
+                    item.count = count;
+                    *slot = Some(item);
+                    None
+                }
+            }
+        } else {
+            Some(item)
+        }
     }
 }

--- a/src/lib/net/src/packets/outgoing/container_close.rs
+++ b/src/lib/net/src/packets/outgoing/container_close.rs
@@ -1,4 +1,5 @@
 use ferrumc_macros::{NetEncode, packet};
+use std::io::Write;
 
 #[derive(NetEncode)]
 #[packet(packet_id = "container_close", state = "play")]

--- a/src/lib/net/src/packets/outgoing/container_set_content.rs
+++ b/src/lib/net/src/packets/outgoing/container_set_content.rs
@@ -2,6 +2,7 @@ use crate::packets::slot::Slot;
 use ferrumc_core::inventory::Inventory;
 use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
+use std::io::Write;
 
 #[derive(NetEncode)]
 #[packet(packet_id = "container_set_content", state = "play")]
@@ -14,9 +15,8 @@ pub struct ContainerSetContentPacket {
 impl ContainerSetContentPacket {
     pub fn from_inventory(inv: &Inventory) -> Self {
         let slot_vec: Vec<Slot> = inv
-            .main
+            .all_slots()
             .iter()
-            .chain(inv.hotbar.iter())
             .map(|s| Slot::from_stack(s.as_ref()))
             .collect();
         Self {

--- a/src/lib/net/src/packets/outgoing/container_set_slot.rs
+++ b/src/lib/net/src/packets/outgoing/container_set_slot.rs
@@ -1,6 +1,7 @@
 use crate::packets::slot::Slot;
 use ferrumc_core::inventory::ItemStack;
 use ferrumc_macros::{NetEncode, packet};
+use std::io::Write;
 
 #[derive(NetEncode)]
 #[packet(packet_id = "container_set_slot", state = "play")]

--- a/src/lib/net/src/packets/slot.rs
+++ b/src/lib/net/src/packets/slot.rs
@@ -2,11 +2,13 @@ use ferrumc_core::inventory::ItemStack;
 use ferrumc_macros::{NetDecode, NetEncode};
 use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
 use ferrumc_net_codec::net_types::var_int::VarInt;
+use std::io::Write;
 
 #[derive(NetEncode, NetDecode, Clone, Debug, Default)]
 pub struct ItemData {
     pub item_id: VarInt,
     pub count: u8,
+    pub nbt: Vec<u8>,
 }
 
 impl From<&ItemStack> for ItemData {
@@ -14,13 +16,22 @@ impl From<&ItemStack> for ItemData {
         Self {
             item_id: VarInt::new(stack.item.0 as i32),
             count: stack.count,
+            nbt: stack.nbt.clone().unwrap_or_default(),
         }
     }
 }
 
-#[derive(NetEncode, NetDecode, Clone, Debug, Default)]
+#[derive(NetEncode, NetDecode)]
 pub struct Slot {
     pub item: PrefixedOptional<ItemData>,
+}
+
+impl Default for Slot {
+    fn default() -> Self {
+        Self {
+            item: PrefixedOptional::None,
+        }
+    }
 }
 
 impl Slot {


### PR DESCRIPTION
## Summary
- track stack limits, equipment slots, and item NBT in inventory
- send full inventory/slot updates with NBT data
- process container slot and close packets to keep server state in sync

## Testing
- `cargo +nightly check -p ferrumc-core`
- `cargo +nightly check -p ferrumc-net` *(fails: Could not find key: `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_68954c42ffa88329b4ce4744d1fa3a46