### PR TITLE
Add basic entity components and systems

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/despawn_entity.rs
+++ b/src/bin/src/packet_handlers/play_packets/despawn_entity.rs
@@ -1,0 +1,37 @@
+use bevy_ecs::prelude::{Entity, Query, Res};
+use ferrumc_core::identity::player_identity::PlayerIdentity;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::remove_entities::RemoveEntitiesPacket;
+use ferrumc_state::GlobalStateResource;
+use tracing::warn;
+
+pub fn handle(
+    state: Res<GlobalStateResource>,
+    query: Query<(Entity, &StreamWriter, &PlayerIdentity)>,
+) {
+    let mut pending = Vec::new();
+    while let Some(item) = state.0.players.disconnection_queue.pop() {
+        pending.push(item);
+    }
+    if pending.is_empty() {
+        return;
+    }
+    for (entity, _reason) in &pending {
+        let Ok((_, _, identity)) = query.get(*entity) else {
+            warn!("Failed to get identity for despawning entity {:?}", entity);
+            continue;
+        };
+        let packet = RemoveEntitiesPacket::from_entities([identity.clone()]);
+        for (other_entity, conn, _) in query.iter() {
+            if other_entity == *entity {
+                continue;
+            }
+            if let Err(e) = conn.send_packet_ref(&packet) {
+                warn!("Failed to send remove entities packet to {:?}: {:?}", other_entity, e);
+            }
+        }
+    }
+    for item in pending {
+        state.0.players.disconnection_queue.push(item);
+    }
+}

--- a/src/bin/src/packet_handlers/play_packets/mod.rs
+++ b/src/bin/src/packet_handlers/play_packets/mod.rs
@@ -12,6 +12,8 @@ mod set_player_position;
 mod set_player_position_and_rotation;
 mod set_player_rotation;
 mod swing_arm;
+mod spawn_entity;
+mod despawn_entity;
 
 pub fn register_packet_handlers(schedule: &mut Schedule) {
     // Added separately so if we mess up the signature of one of the systems we can know exactly
@@ -28,4 +30,6 @@ pub fn register_packet_handlers(schedule: &mut Schedule) {
     schedule.add_systems(set_player_rotation::handle);
     schedule.add_systems(swing_arm::handle);
     schedule.add_systems(player_loaded::handle);
+    schedule.add_systems(spawn_entity::handle);
+    schedule.add_systems(despawn_entity::handle);
 }

--- a/src/bin/src/packet_handlers/play_packets/spawn_entity.rs
+++ b/src/bin/src/packet_handlers/play_packets/spawn_entity.rs
@@ -1,0 +1,55 @@
+use bevy_ecs::prelude::{Entity, Query, Res};
+use ferrumc_core::identity::player_identity::PlayerIdentity;
+use ferrumc_core::transform::position::Position;
+use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::spawn_entity::SpawnEntityPacket;
+use ferrumc_net::PlayerLoadedReceiver;
+use ferrumc_state::GlobalStateResource;
+use tracing::warn;
+
+pub fn handle(
+    events: Res<PlayerLoadedReceiver>,
+    state: Res<GlobalStateResource>,
+    player_comps: Query<(&PlayerIdentity, &Position, &Rotation)>,
+    connections: Query<(Entity, &StreamWriter)>,
+) {
+    for (_, entity) in events.0.try_iter() {
+        if !state.0.players.is_connected(entity) {
+            warn!("Entity {:?} is not connected, cannot broadcast spawn", entity);
+            continue;
+        }
+
+        let Ok(new_player_packet) = SpawnEntityPacket::player(entity, player_comps) else {
+            warn!("Failed to build spawn packet for entity {:?}", entity);
+            continue;
+        };
+
+        for (other_entity, conn) in connections.iter() {
+            if other_entity == entity {
+                continue;
+            }
+            if let Err(e) = conn.send_packet_ref(&new_player_packet) {
+                warn!("Failed to send spawn packet to {:?}: {:?}", other_entity, e);
+            }
+        }
+
+        let Ok((_, new_conn)) = connections.get(entity) else {
+            warn!("Failed to get connection for new entity {:?}", entity);
+            continue;
+        };
+        for (other_entity, _) in connections.iter() {
+            if other_entity == entity {
+                continue;
+            }
+            if let Ok(packet) = SpawnEntityPacket::player(other_entity, player_comps) {
+                if let Err(e) = new_conn.send_packet_ref(&packet) {
+                    warn!(
+                        "Failed to send existing entity {:?} to new player {:?}: {:?}",
+                        other_entity, entity, e
+                    );
+                }
+            }
+        }
+    }
+}

--- a/src/bin/src/systems/ai.rs
+++ b/src/bin/src/systems/ai.rs
@@ -1,0 +1,20 @@
+use bevy_ecs::prelude::Query;
+use ferrumc_core::ai::AIGoal;
+use ferrumc_core::movement::Movement;
+
+pub fn update_ai(mut query: Query<(&AIGoal, &mut Movement)>) {
+    for (goal, mut movement) in query.iter_mut() {
+        match goal {
+            AIGoal::Idle => {
+                movement.vx = 0.0;
+                movement.vy = 0.0;
+                movement.vz = 0.0;
+            }
+            AIGoal::Wander => {
+                if movement.vx == 0.0 && movement.vz == 0.0 {
+                    movement.vx = 0.1;
+                }
+            }
+        }
+    }
+}

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -7,6 +7,8 @@ mod player_count_update;
 pub mod send_chunks;
 pub mod shutdown_systems;
 mod world_sync;
+mod ai;
+mod physics;
 
 pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
     schedule.add_systems(keep_alive_system::keep_alive_system);
@@ -14,6 +16,8 @@ pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
     schedule.add_systems(cross_chunk_boundary::cross_chunk_boundary);
     schedule.add_systems(player_count_update::player_count_updater);
     schedule.add_systems(world_sync::sync_world);
+    schedule.add_systems(ai::update_ai);
+    schedule.add_systems(physics::update_physics);
 
     // Should always be last
     schedule.add_systems(connection_killer::connection_killer);

--- a/src/bin/src/systems/physics.rs
+++ b/src/bin/src/systems/physics.rs
@@ -1,0 +1,11 @@
+use bevy_ecs::prelude::Query;
+use ferrumc_core::movement::Movement;
+use ferrumc_core::transform::position::Position;
+
+pub fn update_physics(mut query: Query<(&mut Position, &Movement)>) {
+    for (mut pos, movement) in query.iter_mut() {
+        pos.x += movement.vx;
+        pos.y += movement.vy;
+        pos.z += movement.vz;
+    }
+}

--- a/src/lib/core/src/ai.rs
+++ b/src/lib/core/src/ai.rs
@@ -1,0 +1,14 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+#[derive(TypeName, Component, Debug, Clone, Eq, PartialEq)]
+pub enum AIGoal {
+    Idle,
+    Wander,
+}
+
+impl Default for AIGoal {
+    fn default() -> Self {
+        AIGoal::Idle
+    }
+}

--- a/src/lib/core/src/health.rs
+++ b/src/lib/core/src/health.rs
@@ -1,0 +1,26 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub struct Health {
+    pub current: i32,
+    pub max: i32,
+}
+
+impl Health {
+    pub fn new(max: i32) -> Self {
+        Self { current: max, max }
+    }
+
+    pub fn damage(&mut self, amount: i32) {
+        self.current = (self.current - amount).max(0);
+    }
+
+    pub fn heal(&mut self, amount: i32) {
+        self.current = (self.current + amount).min(self.max);
+    }
+
+    pub fn is_dead(&self) -> bool {
+        self.current <= 0
+    }
+}

--- a/src/lib/core/src/lib.rs
+++ b/src/lib/core/src/lib.rs
@@ -8,3 +8,6 @@ pub mod identity;
 pub mod inventory;
 pub mod state;
 pub mod transform;
+pub mod health;
+pub mod ai;
+pub mod movement;

--- a/src/lib/core/src/movement.rs
+++ b/src/lib/core/src/movement.rs
@@ -1,0 +1,15 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+#[derive(TypeName, Component, Debug, Clone, Copy, Default)]
+pub struct Movement {
+    pub vx: f64,
+    pub vy: f64,
+    pub vz: f64,
+}
+
+impl Movement {
+    pub fn new(vx: f64, vy: f64, vz: f64) -> Self {
+        Self { vx, vy, vz }
+    }
+}


### PR DESCRIPTION
## Summary
- add core ECS components for health, AI goals, and movement
- handle player spawn/despawn network packets
- introduce simple AI and physics tick systems

## Testing
- `cargo +nightly test` *(fails: cannot return value referencing temporary value in inventory.rs)*

------
https://chatgpt.com/codex/tasks/task_b_68954c4f216c8329bb61fe52b1ae974f