### PR TITLE
feat: support dimension-aware worlds

### DIFF
--- a/src/bin/src/main.rs
+++ b/src/bin/src/main.rs
@@ -89,7 +89,7 @@ fn generate_chunks(state: GlobalState) -> Result<(), BinaryError> {
         batch.execute(move || {
             let chunk = state_clone
                 .terrain_generator
-                .generate_chunk(x, z)
+                .generate_chunk(x, z, "overworld")
                 .map(Arc::new);
             if let Err(e) = chunk {
                 error!("Error generating chunk ({}, {}): {:?}", x, z, e);

--- a/src/bin/src/packet_handlers/play_packets/player_action.rs
+++ b/src/bin/src/packet_handlers/play_packets/player_action.rs
@@ -56,11 +56,11 @@ pub fn handle(
                         Ok(chunk) => chunk,
                         Err(e) => {
                             trace!("Chunk not found, generating new chunk: {:?}", e);
-                            state
-                                .0
-                                .clone()
-                                .terrain_generator
-                                .generate_chunk(event.location.x >> 4, event.location.z >> 4)?
+                            state.0.clone().terrain_generator.generate_chunk(
+                                event.location.x >> 4,
+                                event.location.z >> 4,
+                                "overworld",
+                            )?
                         }
                     };
                     let (relative_x, relative_y, relative_z) = (

--- a/src/bin/src/register_events.rs
+++ b/src/bin/src/register_events.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::event::EventRegistry;
 use bevy_ecs::prelude::World;
 use ferrumc_core::chunks::cross_chunk_boundary_event::CrossChunkBoundaryEvent;
+use ferrumc_core::conn::change_dimension_event::ChangeDimensionEvent;
 use ferrumc_core::conn::force_player_recount_event::ForcePlayerRecountEvent;
 use ferrumc_net::packets::packet_events::TransformEvent;
 
@@ -8,4 +9,5 @@ pub fn register_events(world: &mut World) {
     EventRegistry::register_event::<TransformEvent>(world);
     EventRegistry::register_event::<CrossChunkBoundaryEvent>(world);
     EventRegistry::register_event::<ForcePlayerRecountEvent>(world);
+    EventRegistry::register_event::<ChangeDimensionEvent>(world);
 }

--- a/src/bin/src/systems/change_dimension.rs
+++ b/src/bin/src/systems/change_dimension.rs
@@ -1,0 +1,28 @@
+use bevy_ecs::prelude::{EventReader, Query, Res};
+use ferrumc_core::conn::change_dimension_event::ChangeDimensionEvent;
+use ferrumc_net::{connection::StreamWriter, packets::outgoing::respawn::Respawn};
+use ferrumc_state::GlobalStateResource;
+use tracing::error;
+
+pub fn handle_change_dimension(
+    mut events: EventReader<ChangeDimensionEvent>,
+    mut query: Query<&mut StreamWriter>,
+    state: Res<GlobalStateResource>,
+) {
+    for event in events.read() {
+        if let Ok(mut conn) = query.get_mut(event.player) {
+            let packet = Respawn::new(
+                format!("minecraft:{}", event.dimension),
+                format!("minecraft:{}", event.dimension),
+            );
+            if let Err(e) = conn.send_packet_ref(&packet) {
+                error!("Failed to send respawn packet: {:?}", e);
+                continue;
+            }
+            state
+                .0
+                .players
+                .set_dimension(event.player, event.dimension.clone());
+        }
+    }
+}

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_dimension;
 pub mod chat_message;
 pub mod connection_killer;
 mod cross_chunk_boundary;
@@ -13,6 +14,7 @@ pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
     schedule.add_systems(new_connections::accept_new_connections);
     schedule.add_systems(cross_chunk_boundary::cross_chunk_boundary);
     schedule.add_systems(player_count_update::player_count_updater);
+    schedule.add_systems(change_dimension::handle_change_dimension);
     schedule.add_systems(world_sync::sync_world);
 
     // Should always be last

--- a/src/bin/src/systems/send_chunks.rs
+++ b/src/bin/src/systems/send_chunks.rs
@@ -60,7 +60,7 @@ pub fn send_chunks(
                 // Don't bother saving the chunk if it hasn't been edited yet
                 let chunk = state_clone
                     .terrain_generator
-                    .generate_chunk(x, z)
+                    .generate_chunk(x, z, &dim)
                     .map_err(|err| NetError::Misc(err.to_string()))?;
                 Ok((ChunkAndLightData::from_chunk(&chunk), x, z))
             }?;

--- a/src/lib/core/src/conn/change_dimension_event.rs
+++ b/src/lib/core/src/conn/change_dimension_event.rs
@@ -1,0 +1,7 @@
+use bevy_ecs::prelude::{Entity, Event};
+
+#[derive(Event)]
+pub struct ChangeDimensionEvent {
+    pub player: Entity,
+    pub dimension: String,
+}

--- a/src/lib/core/src/conn/mod.rs
+++ b/src/lib/core/src/conn/mod.rs
@@ -1,3 +1,4 @@
+pub mod change_dimension_event;
 pub mod force_player_recount_event;
 pub mod keepalive;
 pub mod player_count_update_cooldown;

--- a/src/lib/core/state/src/player_list.rs
+++ b/src/lib/core/state/src/player_list.rs
@@ -7,6 +7,7 @@ use ferrumc_world::block_id::BlockId;
 pub struct PlayerList {
     pub player_list: DashMap<Entity, (u128, String)>,
     pub held_items: DashMap<Entity, [BlockId; 2]>,
+    pub dimensions: DashMap<Entity, String>,
     pub disconnection_queue: SegQueue<(Entity, Option<String>)>,
 }
 
@@ -18,6 +19,7 @@ impl PlayerList {
     pub fn disconnect(&self, entity: Entity, reason: Option<String>) {
         self.player_list.remove(&entity);
         self.held_items.remove(&entity);
+        self.dimensions.remove(&entity);
         self.disconnection_queue.push((entity, reason));
     }
 
@@ -29,5 +31,13 @@ impl PlayerList {
 
     pub fn get_held_item(&self, entity: Entity, hand: usize) -> Option<BlockId> {
         self.held_items.get(&entity).map(|v| v[hand])
+    }
+
+    pub fn set_dimension(&self, entity: Entity, dimension: String) {
+        self.dimensions.insert(entity, dimension);
+    }
+
+    pub fn get_dimension(&self, entity: Entity) -> Option<String> {
+        self.dimensions.get(&entity).map(|v| v.clone())
     }
 }

--- a/src/lib/net/benches/packets.rs
+++ b/src/lib/net/benches/packets.rs
@@ -8,7 +8,7 @@ pub fn bench_packets(c: &mut criterion::BenchmarkGroup<WallTime>) {
 
 fn bench_chunk_packet(c: &mut criterion::BenchmarkGroup<WallTime>) {
     let chunk = ferrumc_world_gen::WorldGenerator::new(0)
-        .generate_chunk(0, 0)
+        .generate_chunk(0, 0, "overworld")
         .unwrap();
     let chunk_packet = black_box(
         ferrumc_net::packets::outgoing::chunk_and_light_data::ChunkAndLightData::from_chunk(&chunk)

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -14,6 +14,7 @@ pub mod login_encryption_request;
 pub mod login_play;
 pub mod login_success;
 pub mod ping_response;
+pub mod respawn;
 pub mod set_center_chunk;
 pub mod set_default_spawn_position;
 pub mod set_render_distance;

--- a/src/lib/net/src/packets/outgoing/respawn.rs
+++ b/src/lib/net/src/packets/outgoing/respawn.rs
@@ -1,0 +1,17 @@
+use ferrumc_macros::{packet, NetEncode};
+
+#[derive(NetEncode)]
+#[packet(packet_id = "respawn", state = "play")]
+pub struct Respawn {
+    pub dimension_type: String,
+    pub dimension_name: String,
+}
+
+impl Respawn {
+    pub fn new(dimension_type: String, dimension_name: String) -> Self {
+        Self {
+            dimension_type,
+            dimension_name,
+        }
+    }
+}

--- a/src/lib/world/Cargo.toml
+++ b/src/lib/world/Cargo.toml
@@ -30,6 +30,7 @@ moka = { workspace = true, features = ["sync"] }
 ahash = { workspace = true }
 rand = { workspace = true }
 yazi = { workspace = true }
+dashmap = { workspace = true }
 
 [[bench]]
 name = "world_bench"

--- a/src/lib/world_gen/Cargo.toml
+++ b/src/lib/world_gen/Cargo.toml
@@ -8,6 +8,7 @@ ferrumc-world = { workspace = true }
 thiserror = { workspace = true }
 noise = { workspace = true }
 rand = { workspace = true }
+dashmap = { workspace = true }
 
 [lints]
 workspace = true

--- a/src/lib/world_gen/src/dimensions/mod.rs
+++ b/src/lib/world_gen/src/dimensions/mod.rs
@@ -1,0 +1,1 @@
+pub mod overworld;

--- a/src/lib/world_gen/src/dimensions/overworld.rs
+++ b/src/lib/world_gen/src/dimensions/overworld.rs
@@ -1,0 +1,24 @@
+use crate::biomes;
+use crate::errors::WorldGenError;
+use crate::{BiomeGenerator, DimensionGenerator, NoiseGenerator};
+use ferrumc_world::chunk_format::Chunk;
+
+pub struct OverworldGenerator;
+
+impl OverworldGenerator {
+    fn get_biome(&self, _x: i32, _z: i32) -> Box<dyn BiomeGenerator> {
+        Box::new(biomes::plains::PlainsBiome)
+    }
+}
+
+impl DimensionGenerator for OverworldGenerator {
+    fn generate_chunk(
+        &self,
+        x: i32,
+        z: i32,
+        noise: &NoiseGenerator,
+    ) -> Result<Chunk, WorldGenError> {
+        let biome = self.get_biome(x, z);
+        biome.generate_chunk(x, z, noise)
+    }
+}

--- a/src/lib/world_gen/src/errors.rs
+++ b/src/lib/world_gen/src/errors.rs
@@ -9,4 +9,6 @@ pub enum WorldGenError {
     ChunkGenerationError(String),
     #[error("World error: {0}")]
     WorldError(#[from] WorldError),
+    #[error("Invalid dimension")]
+    InvalidDimension,
 }


### PR DESCRIPTION
## Summary
- cache chunks per dimension and expose dimension management on `World`
- add dimension-specific world generators with overworld implementation
- send respawn packets and track player dimensions

## Testing
- `RUSTC_BOOTSTRAP=1 cargo test -p ferrumc-world`
- `RUSTC_BOOTSTRAP=1 cargo test -p ferrumc-world-gen`
- `RUSTC_BOOTSTRAP=1 cargo test -p ferrumc-net` *(fails: cannot return value referencing temporary value in ferrumc-core/src/inventory.rs:30)*
- `RUSTC_BOOTSTRAP=1 cargo test -p ferrumc-core` *(fails: cannot return value referencing temporary value in ferrumc-core/src/inventory.rs:30)*

------
https://chatgpt.com/codex/tasks/task_b_68954c50c7248329831ae7267abdeb22