### PR TITLE
feat: stub unhandled play packets

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/chat_ack.rs
+++ b/src/bin/src/packet_handlers/play_packets/chat_ack.rs
@@ -1,0 +1,9 @@
+use bevy_ecs::prelude::Res;
+use ferrumc_net::ChatAckPacketReceiver;
+use tracing::info;
+
+pub fn handle(events: Res<ChatAckPacketReceiver>) {
+    for (_, entity) in events.0.try_iter() {
+        info!("Received chat acknowledgment from {:?}", entity);
+    }
+}

--- a/src/bin/src/packet_handlers/play_packets/client_information.rs
+++ b/src/bin/src/packet_handlers/play_packets/client_information.rs
@@ -1,0 +1,9 @@
+use bevy_ecs::prelude::Res;
+use ferrumc_net::ClientInformationPacketReceiver;
+use tracing::info;
+
+pub fn handle(events: Res<ClientInformationPacketReceiver>) {
+    for (_, entity) in events.0.try_iter() {
+        info!("Received client information from {:?}", entity);
+    }
+}

--- a/src/bin/src/packet_handlers/play_packets/mod.rs
+++ b/src/bin/src/packet_handlers/play_packets/mod.rs
@@ -10,6 +10,8 @@ mod player_command;
 mod container_slot_state_changed;
 mod container_close;
 mod player_loaded;
+mod chat_ack;
+mod client_information;
 mod set_player_position;
 mod set_player_position_and_rotation;
 mod set_player_rotation;
@@ -29,6 +31,8 @@ pub fn register_packet_handlers(schedule: &mut Schedule) {
     schedule.add_systems(container_slot_state_changed::handle);
     schedule.add_systems(container_close::handle);
     schedule.add_systems(chat_message::broadcast_chat_messages);
+    schedule.add_systems(chat_ack::handle);
+    schedule.add_systems(client_information::handle);
     schedule.add_systems(set_player_position::handle);
     schedule.add_systems(set_player_position_and_rotation::handle);
     schedule.add_systems(set_player_rotation::handle);

--- a/src/lib/net/src/packets/incoming/chat_ack.rs
+++ b/src/lib/net/src/packets/incoming/chat_ack.rs
@@ -1,0 +1,5 @@
+use ferrumc_macros::{packet, NetDecode};
+
+#[derive(NetDecode)]
+#[packet(packet_id = "chat_ack", state = "play")]
+pub struct ChatAckPacket;

--- a/src/lib/net/src/packets/incoming/client_information.rs
+++ b/src/lib/net/src/packets/incoming/client_information.rs
@@ -1,0 +1,5 @@
+use ferrumc_macros::{packet, NetDecode};
+
+#[derive(NetDecode)]
+#[packet(packet_id = "client_information", state = "play")]
+pub struct ClientInformationPacket;

--- a/src/lib/net/src/packets/incoming/mod.rs
+++ b/src/lib/net/src/packets/incoming/mod.rs
@@ -28,3 +28,5 @@ pub mod player_input;
 
 pub mod block_entity_tag_query;
 pub mod player_loaded;
+pub mod chat_ack;
+pub mod client_information;

--- a/src/lib/net/src/packets/outgoing/add_entity.rs
+++ b/src/lib/net/src/packets/outgoing/add_entity.rs
@@ -1,0 +1,6 @@
+use ferrumc_macros::{packet, NetEncode};
+use std::io::Write;
+
+#[derive(NetEncode)]
+#[packet(packet_id = "add_entity", state = "play")]
+pub struct AddEntityPacket;

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -21,6 +21,7 @@ pub mod status_response;
 pub mod synchronize_player_position;
 pub mod transfer;
 
+pub mod add_entity;
 pub mod remove_entities;
 pub mod spawn_entity;
 


### PR DESCRIPTION
## Summary
- add stub implementations for unhandled play packets: `chat_ack`, `client_information`, and `add_entity`
- register new packets with lookup tables and handlers logging receipt

## Testing
- `cargo +nightly test` *(fails: Could not find key `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_6895e6daa0788329b6404371795e31e1