### PR TITLE
Add basic mob entity system and networking

### DIFF
--- a/src/bin/src/packet_handlers/play_packets/confirm_player_teleport.rs
+++ b/src/bin/src/packet_handlers/play_packets/confirm_player_teleport.rs
@@ -42,7 +42,7 @@ pub fn handle(
             on_ground.0 = false;
             commands.entity(eid).remove::<PendingTeleport>();
 
-            let packet = TeleportEntityPacket::new(identity, &pos, rot, on_ground.0);
+            let packet = TeleportEntityPacket::new(identity.short_uuid, &pos, rot, on_ground.0);
             for (entity, conn) in conn_query.iter() {
                 if entity == eid || !state.0.players.is_connected(entity) {
                     continue;

--- a/src/bin/src/packet_handlers/play_packets/mod.rs
+++ b/src/bin/src/packet_handlers/play_packets/mod.rs
@@ -17,6 +17,8 @@ mod set_player_position_and_rotation;
 mod set_player_rotation;
 mod swing_arm;
 mod spawn_entity;
+mod spawn_mob;
+mod update_mob_position;
 mod despawn_entity;
 
 pub fn register_packet_handlers(schedule: &mut Schedule) {
@@ -37,7 +39,9 @@ pub fn register_packet_handlers(schedule: &mut Schedule) {
     schedule.add_systems(set_player_position_and_rotation::handle);
     schedule.add_systems(set_player_rotation::handle);
     schedule.add_systems(swing_arm::handle);
-    schedule.add_systems(player_loaded::handle);
-    schedule.add_systems(spawn_entity::handle);
-    schedule.add_systems(despawn_entity::handle);
-}
+      schedule.add_systems(player_loaded::handle);
+      schedule.add_systems(spawn_entity::handle);
+      schedule.add_systems(spawn_mob::handle);
+      schedule.add_systems(update_mob_position::handle);
+      schedule.add_systems(despawn_entity::handle);
+  }

--- a/src/bin/src/packet_handlers/play_packets/set_player_position.rs
+++ b/src/bin/src/packet_handlers/play_packets/set_player_position.rs
@@ -105,22 +105,22 @@ fn update_pos_for_all(
 
     let packet: BroadcastMovementPacket = if delta_exceeds_threshold {
         BroadcastMovementPacket::TeleportEntity(TeleportEntityPacket::new(
-            identity, pos, rot, grounded.0,
+            identity.short_uuid, pos, rot, grounded.0,
         ))
     } else {
         match (delta_pos, new_rot) {
             (Some(delta_pos), Some(new_rot)) => {
                 BroadcastMovementPacket::UpdateEntityPositionAndRotation(
                     UpdateEntityPositionAndRotationPacket::new(
-                        identity, delta_pos, &new_rot, grounded.0,
+                        identity.short_uuid, delta_pos, &new_rot, grounded.0,
                     ),
                 )
             }
             (Some(delta_pos), None) => BroadcastMovementPacket::UpdateEntityPosition(
-                UpdateEntityPositionPacket::new(identity, delta_pos, grounded.0),
+                UpdateEntityPositionPacket::new(identity.short_uuid, delta_pos, grounded.0),
             ),
             (None, Some(new_rot)) => BroadcastMovementPacket::UpdateEntityRotation(
-                UpdateEntityRotationPacket::new(identity, &new_rot, grounded.0),
+                UpdateEntityRotationPacket::new(identity.short_uuid, &new_rot, grounded.0),
             ),
             _ => {
                 return Ok(());

--- a/src/bin/src/packet_handlers/play_packets/spawn_mob.rs
+++ b/src/bin/src/packet_handlers/play_packets/spawn_mob.rs
@@ -1,0 +1,24 @@
+use bevy_ecs::prelude::{Commands, Entity, Query, With};
+use ferrumc_core::ai::{Mob, PendingSpawn};
+use ferrumc_core::identity::entity_id::EntityId;
+use ferrumc_core::transform::position::Position;
+use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::spawn_entity::SpawnEntityPacket;
+use tracing::warn;
+
+pub fn handle(
+    mut commands: Commands,
+    mobs: Query<(Entity, &EntityId, &Mob, &Position, &Rotation), With<PendingSpawn>>,
+    connections: Query<&StreamWriter>,
+) {
+    for (entity, id, mob, pos, rot) in mobs.iter() {
+        let packet = SpawnEntityPacket::mob(id, mob.kind, pos, rot);
+        for conn in connections.iter() {
+            if let Err(e) = conn.send_packet_ref(&packet) {
+                warn!("Failed to send spawn packet: {:?}", e);
+            }
+        }
+        commands.entity(entity).remove::<PendingSpawn>();
+    }
+}

--- a/src/bin/src/packet_handlers/play_packets/update_mob_position.rs
+++ b/src/bin/src/packet_handlers/play_packets/update_mob_position.rs
@@ -1,0 +1,22 @@
+use bevy_ecs::prelude::{Query, With};
+use ferrumc_core::ai::Mob;
+use ferrumc_core::identity::entity_id::EntityId;
+use ferrumc_core::transform::position::Position;
+use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_net::connection::StreamWriter;
+use ferrumc_net::packets::outgoing::entity_position_sync::TeleportEntityPacket;
+use tracing::warn;
+
+pub fn handle(
+    mobs: Query<(&EntityId, &Position, &Rotation), With<Mob>>,
+    connections: Query<&StreamWriter>,
+) {
+    for (id, pos, rot) in mobs.iter() {
+        let packet = TeleportEntityPacket::new(id.short_uuid, pos, rot, true);
+        for conn in connections.iter() {
+            if let Err(e) = conn.send_packet_ref(&packet) {
+                warn!("Failed to send position packet: {:?}", e);
+            }
+        }
+    }
+}

--- a/src/bin/src/systems/ai.rs
+++ b/src/bin/src/systems/ai.rs
@@ -1,6 +1,34 @@
-use bevy_ecs::prelude::Query;
-use ferrumc_core::ai::AIGoal;
+use bevy_ecs::prelude::{Commands, Query};
+use ferrumc_core::ai::{AIGoal, EntityKind, Mob, PendingSpawn};
+use ferrumc_core::collisions::bounds::CollisionBounds;
+use ferrumc_core::identity::entity_id::EntityId;
 use ferrumc_core::movement::Movement;
+use ferrumc_core::transform::position::Position;
+use ferrumc_core::transform::rotation::Rotation;
+use rand::Rng;
+
+pub fn spawn_mobs(mut cmd: Commands, query: Query<&Mob>) {
+    if query.is_empty() {
+        let id = EntityId::new(rand::random::<u128>());
+        cmd.spawn((
+            id,
+            Mob { kind: EntityKind::Cow },
+            Position::default(),
+            Rotation::default(),
+            Movement::default(),
+            CollisionBounds {
+                x_offset_start: -0.3,
+                x_offset_end: 0.3,
+                y_offset_start: 0.0,
+                y_offset_end: 1.8,
+                z_offset_start: -0.3,
+                z_offset_end: 0.3,
+            },
+            AIGoal::Wander,
+            PendingSpawn,
+        ));
+    }
+}
 
 pub fn update_ai(mut query: Query<(&AIGoal, &mut Movement)>) {
     for (goal, mut movement) in query.iter_mut() {
@@ -11,9 +39,12 @@ pub fn update_ai(mut query: Query<(&AIGoal, &mut Movement)>) {
                 movement.vz = 0.0;
             }
             AIGoal::Wander => {
+                let mut rng = rand::thread_rng();
                 if movement.vx == 0.0 && movement.vz == 0.0 {
                     movement.vx = 0.1;
                 }
+                movement.vx += rng.gen_range(-0.05..0.05);
+                movement.vz += rng.gen_range(-0.05..0.05);
             }
         }
     }

--- a/src/bin/src/systems/mod.rs
+++ b/src/bin/src/systems/mod.rs
@@ -17,8 +17,9 @@ pub fn register_game_systems(schedule: &mut bevy_ecs::schedule::Schedule) {
     schedule.add_systems(cross_chunk_boundary::cross_chunk_boundary);
     schedule.add_systems(player_count_update::player_count_updater);
     schedule.add_systems(world_sync::sync_world);
-    schedule.add_systems(ai::update_ai);
-    schedule.add_systems(physics::update_physics);
+      schedule.add_systems(ai::spawn_mobs);
+      schedule.add_systems(ai::update_ai);
+      schedule.add_systems(physics::update_physics);
     schedule.add_systems(redstone_update::run_redstone_updates);
 
     // Should always be last

--- a/src/bin/src/systems/physics.rs
+++ b/src/bin/src/systems/physics.rs
@@ -1,11 +1,31 @@
-use bevy_ecs::prelude::Query;
+use bevy_ecs::prelude::{Entity, Query};
+use ferrumc_core::collisions::bounds::CollisionBounds;
 use ferrumc_core::movement::Movement;
 use ferrumc_core::transform::position::Position;
 
-pub fn update_physics(mut query: Query<(&mut Position, &Movement)>) {
-    for (mut pos, movement) in query.iter_mut() {
-        pos.x += movement.vx;
-        pos.y += movement.vy;
-        pos.z += movement.vz;
+pub fn update_physics(
+    mut query: Query<(Entity, &mut Position, &Movement, &CollisionBounds)>,
+) {
+    let snapshot: Vec<(Entity, Position, CollisionBounds)> =
+        query
+            .iter()
+            .map(|(e, pos, _, bounds)| (e, pos.clone(), *bounds))
+            .collect();
+
+    for (entity, mut pos, movement, bounds) in query.iter_mut() {
+        let new_pos = Position::new(pos.x + movement.vx, pos.y + movement.vy, pos.z + movement.vz);
+        let mut collided = false;
+        for (other_e, other_pos, other_bounds) in snapshot.iter() {
+            if entity == *other_e {
+                continue;
+            }
+            if bounds.collides((new_pos.x, new_pos.y, new_pos.z), other_bounds, (other_pos.x, other_pos.y, other_pos.z)) {
+                collided = true;
+                break;
+            }
+        }
+        if !collided {
+            *pos = new_pos;
+        }
     }
 }

--- a/src/lib/core/Cargo.toml
+++ b/src/lib/core/Cargo.toml
@@ -12,6 +12,7 @@ typename = { workspace = true }
 ferrumc-net-codec = { workspace = true }
 uuid = { workspace = true }
 ferrumc-world = { workspace = true }
+ferrumc-macros = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/src/lib/core/src/ai.rs
+++ b/src/lib/core/src/ai.rs
@@ -1,6 +1,31 @@
 use bevy_ecs::prelude::Component;
 use typename::TypeName;
 
+use ferrumc_macros::get_registry_entry;
+
+#[derive(TypeName, Component, Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EntityKind {
+    Cow,
+}
+
+const COW_ID: u64 = get_registry_entry!("minecraft:entity_type.entries.minecraft:cow");
+
+impl EntityKind {
+    pub fn network_id(self) -> i32 {
+        match self {
+            EntityKind::Cow => COW_ID as i32,
+        }
+    }
+}
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub struct Mob {
+    pub kind: EntityKind,
+}
+
+#[derive(TypeName, Component, Debug, Default)]
+pub struct PendingSpawn;
+
 #[derive(TypeName, Component, Debug, Clone, Eq, PartialEq)]
 pub enum AIGoal {
     Idle,

--- a/src/lib/core/src/collisions/bounds.rs
+++ b/src/lib/core/src/collisions/bounds.rs
@@ -1,7 +1,7 @@
 use bevy_ecs::prelude::Component;
 use typename::TypeName;
 
-#[derive(TypeName, Component)]
+#[derive(TypeName, Component, Clone, Copy)]
 pub struct CollisionBounds {
     // Given a start position, where the bounding box starts on the x-axis.
     pub x_offset_start: f64,

--- a/src/lib/core/src/identity/entity_id.rs
+++ b/src/lib/core/src/identity/entity_id.rs
@@ -1,0 +1,23 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+#[derive(TypeName, Debug, Component, Clone)]
+pub struct EntityId {
+    pub uuid: uuid::Uuid,
+    pub short_uuid: i32,
+}
+
+impl EntityId {
+    pub fn new(uuid: u128) -> Self {
+        Self {
+            uuid: uuid::Uuid::from_u128(uuid),
+            short_uuid: uuid as i32,
+        }
+    }
+}
+
+impl Default for EntityId {
+    fn default() -> Self {
+        Self::new(0)
+    }
+}

--- a/src/lib/core/src/identity/mod.rs
+++ b/src/lib/core/src/identity/mod.rs
@@ -1,1 +1,2 @@
 pub mod player_identity;
+pub mod entity_id;

--- a/src/lib/net/src/packets/outgoing/entity_position_sync.rs
+++ b/src/lib/net/src/packets/outgoing/entity_position_sync.rs
@@ -1,4 +1,3 @@
-use ferrumc_core::identity::player_identity::PlayerIdentity;
 use ferrumc_core::transform::position::Position;
 use ferrumc_core::transform::rotation::Rotation;
 use ferrumc_macros::{NetEncode, packet};
@@ -21,21 +20,16 @@ pub struct TeleportEntityPacket {
 }
 
 impl TeleportEntityPacket {
-    pub fn new(
-        entity_id: &PlayerIdentity,
-        position: &Position,
-        angle: &Rotation,
-        on_ground: bool,
-    ) -> Self {
+    pub fn new(short_id: i32, position: &Position, angle: &Rotation, on_ground: bool) -> Self {
         // Todo: Add velocity parameters if needed
         Self {
-            entity_id: VarInt::new(entity_id.short_uuid),
+            entity_id: VarInt::new(short_id),
             x: position.x,
             y: position.y,
             z: position.z,
-            vel_x: 0.0, // Placeholder for velocity in x direction
-            vel_y: 0.0, // Placeholder for velocity in y direction
-            vel_z: 0.0, // Placeholder for velocity in z direction
+            vel_x: 0.0,
+            vel_y: 0.0,
+            vel_z: 0.0,
             yaw: angle.yaw,
             pitch: angle.pitch,
             on_ground,

--- a/src/lib/net/src/packets/outgoing/update_entity_position.rs
+++ b/src/lib/net/src/packets/outgoing/update_entity_position.rs
@@ -1,4 +1,3 @@
-use ferrumc_core::identity::player_identity::PlayerIdentity;
 use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::var_int::VarInt;
 use std::io::Write;
@@ -14,13 +13,9 @@ pub struct UpdateEntityPositionPacket {
 }
 
 impl UpdateEntityPositionPacket {
-    pub fn new(
-        entity_id: &PlayerIdentity,
-        delta_positions: (i16, i16, i16),
-        on_ground: bool,
-    ) -> Self {
+    pub fn new(short_id: i32, delta_positions: (i16, i16, i16), on_ground: bool) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.short_uuid),
+            entity_id: VarInt::new(short_id),
             delta_x: delta_positions.0,
             delta_y: delta_positions.1,
             delta_z: delta_positions.2,

--- a/src/lib/net/src/packets/outgoing/update_entity_position_and_rotation.rs
+++ b/src/lib/net/src/packets/outgoing/update_entity_position_and_rotation.rs
@@ -1,4 +1,3 @@
-use ferrumc_core::identity::player_identity::PlayerIdentity;
 use ferrumc_core::transform::rotation::Rotation;
 use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::angle::NetAngle;
@@ -18,14 +17,9 @@ pub struct UpdateEntityPositionAndRotationPacket {
 }
 
 impl UpdateEntityPositionAndRotationPacket {
-    pub fn new(
-        entity_id: &PlayerIdentity,
-        delta_positions: (i16, i16, i16),
-        new_rot: &Rotation,
-        on_ground: bool,
-    ) -> Self {
+    pub fn new(short_id: i32, delta_positions: (i16, i16, i16), new_rot: &Rotation, on_ground: bool) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.short_uuid),
+            entity_id: VarInt::new(short_id),
             delta_x: delta_positions.0,
             delta_y: delta_positions.1,
             delta_z: delta_positions.2,

--- a/src/lib/net/src/packets/outgoing/update_entity_rotation.rs
+++ b/src/lib/net/src/packets/outgoing/update_entity_rotation.rs
@@ -1,4 +1,3 @@
-use ferrumc_core::identity::player_identity::PlayerIdentity;
 use ferrumc_core::transform::rotation::Rotation;
 use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::angle::NetAngle;
@@ -14,9 +13,9 @@ pub struct UpdateEntityRotationPacket {
     pub on_ground: bool,
 }
 impl UpdateEntityRotationPacket {
-    pub fn new(entity_id: &PlayerIdentity, new_rot: &Rotation, on_ground: bool) -> Self {
+    pub fn new(short_id: i32, new_rot: &Rotation, on_ground: bool) -> Self {
         Self {
-            entity_id: VarInt::new(entity_id.short_uuid),
+            entity_id: VarInt::new(short_id),
             yaw: NetAngle::from_degrees(new_rot.yaw as f64),
             pitch: NetAngle::from_degrees(new_rot.pitch as f64),
             on_ground,


### PR DESCRIPTION
## Summary
- introduce `EntityKind` registry, `Mob` and spawn flag components
- add mob identity and packet handlers to spawn and update mobs for clients
- implement simple mob AI spawn, wandering movement, and collision-aware physics

## Testing
- `cargo +nightly test -p ferrumc-core`
- `cargo +nightly test -p ferrumc` *(fails: Could not find key `minecraft:chat_message` in packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_6898e53acd808329be69cf945ec65ae4