### PR TITLE
Add recipe book packet structs and tests

### DIFF
--- a/src/lib/net/src/packets/incoming/craft_recipe_request.rs
+++ b/src/lib/net/src/packets/incoming/craft_recipe_request.rs
@@ -1,0 +1,15 @@
+use ferrumc_macros::{NetDecode, packet};
+
+/// Sent when the player clicks a recipe in the recipe book to request the
+/// server craft it. Maps to the serverbound `Craft Recipe Request` packet
+/// described in the Minecraft protocol (v763, Play state).
+#[derive(NetDecode, Debug)]
+#[packet(packet_id = "craft_recipe_request", state = "play")]
+pub struct CraftRecipeRequestPacket {
+    /// ID of the window the recipe is crafted in.
+    pub window_id: i8,
+    /// Namespaced identifier of the recipe selected by the client.
+    pub recipe: String,
+    /// Whether to craft as many results as possible rather than a single item.
+    pub make_all: bool,
+}

--- a/src/lib/net/src/packets/incoming/displayed_recipe.rs
+++ b/src/lib/net/src/packets/incoming/displayed_recipe.rs
@@ -1,0 +1,11 @@
+use ferrumc_macros::{NetDecode, packet};
+
+/// Indicates which recipe the client is currently displaying in the recipe
+/// book interface. Maps to the serverbound `Displayed Recipe` packet in the
+/// Minecraft protocol (v763, Play state).
+#[derive(NetDecode, Debug)]
+#[packet(packet_id = "displayed_recipe", state = "play")]
+pub struct DisplayedRecipePacket {
+    /// Namespaced identifier of the recipe being shown.
+    pub recipe: String,
+}

--- a/src/lib/net/src/packets/incoming/mod.rs
+++ b/src/lib/net/src/packets/incoming/mod.rs
@@ -27,6 +27,9 @@ pub mod confirm_player_teleport;
 pub mod player_input;
 
 pub mod block_entity_tag_query;
-pub mod player_loaded;
 pub mod chat_ack;
 pub mod client_information;
+pub mod craft_recipe_request;
+pub mod displayed_recipe;
+pub mod player_loaded;
+pub mod recipe_book;

--- a/src/lib/net/src/packets/incoming/recipe_book.rs
+++ b/src/lib/net/src/packets/incoming/recipe_book.rs
@@ -1,0 +1,16 @@
+use ferrumc_macros::{NetDecode, packet};
+use ferrumc_net_codec::net_types::var_int::VarInt;
+
+/// Notifies the server that the player opened or changed the filtering state
+/// of a recipe book tab. Corresponds to the serverbound `Recipe Book` packet
+/// in the Minecraft protocol (v763, Play state).
+#[derive(NetDecode, Debug)]
+#[packet(packet_id = "recipe_book", state = "play")]
+pub struct RecipeBookPacket {
+    /// Which recipe book tab is affected (0: crafting, 1: furnace, 2: blast furnace, 3: smoker).
+    pub book_id: VarInt,
+    /// Whether the tab should be opened in the client's GUI.
+    pub open: bool,
+    /// Whether the book should filter out unlocked recipes.
+    pub filtering: bool,
+}

--- a/src/lib/net/src/packets/packet_events.rs
+++ b/src/lib/net/src/packets/packet_events.rs
@@ -1,6 +1,7 @@
 use bevy_ecs::prelude::{Entity, Event};
 use ferrumc_core::transform::position::Position;
 use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_net_codec::net_types::var_int::VarInt;
 
 #[derive(Event, Debug)]
 pub struct TransformEvent {
@@ -9,7 +10,6 @@ pub struct TransformEvent {
     pub rotation: Option<Rotation>,
     pub on_ground: Option<bool>,
 }
-
 impl TransformEvent {
     pub fn new(entity: Entity) -> Self {
         Self {
@@ -33,4 +33,23 @@ impl TransformEvent {
         self.on_ground = Some(on_ground);
         self
     }
+}
+
+#[derive(Event, Debug)]
+pub struct CraftRecipeRequestEvent {
+    pub window_id: i8,
+    pub recipe: String,
+    pub make_all: bool,
+}
+
+#[derive(Event, Debug)]
+pub struct RecipeBookEvent {
+    pub book_id: VarInt,
+    pub open: bool,
+    pub filtering: bool,
+}
+
+#[derive(Event, Debug)]
+pub struct DisplayedRecipeEvent {
+    pub recipe: String,
 }

--- a/src/tests/Cargo.toml
+++ b/src/tests/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 ferrumc-nbt = { workspace = true }
 ferrumc-macros = { workspace = true }
 ferrumc-net-codec = { workspace = true }
+ferrumc-net = { workspace = true }
 ferrumc-config = { workspace = true }
 bevy_ecs = { workspace = true}
 ferrumc-core = { workspace = true }

--- a/src/tests/src/net/mod.rs
+++ b/src/tests/src/net/mod.rs
@@ -2,3 +2,4 @@ mod chunk;
 mod codec;
 mod encrypted_login;
 mod offline_login;
+mod recipe_packets;

--- a/src/tests/src/net/recipe_packets.rs
+++ b/src/tests/src/net/recipe_packets.rs
@@ -1,0 +1,45 @@
+use ferrumc_net::packets::incoming::{
+    craft_recipe_request::CraftRecipeRequestPacket, displayed_recipe::DisplayedRecipePacket,
+    recipe_book::RecipeBookPacket,
+};
+use ferrumc_net_codec::decode::{NetDecode, NetDecodeOpts};
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use std::io::{Cursor, Write};
+
+#[test]
+fn decode_craft_recipe_request() {
+    let mut bytes = Vec::new();
+    bytes.write_all(&[5u8]).unwrap();
+    let recipe = b"minecraft:stone";
+    VarInt::from(recipe.len() as i32).write(&mut bytes).unwrap();
+    bytes.extend_from_slice(recipe);
+    bytes.write_all(&[0u8]).unwrap();
+    let mut cursor = Cursor::new(bytes);
+    let pkt = CraftRecipeRequestPacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(pkt.window_id, 5);
+    assert_eq!(pkt.recipe, "minecraft:stone");
+    assert!(!pkt.make_all);
+}
+
+#[test]
+fn decode_displayed_recipe() {
+    let mut bytes = Vec::new();
+    let recipe = b"minecraft:stone";
+    VarInt::from(recipe.len() as i32).write(&mut bytes).unwrap();
+    bytes.extend_from_slice(recipe);
+    let mut cursor = Cursor::new(bytes);
+    let pkt = DisplayedRecipePacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(pkt.recipe, "minecraft:stone");
+}
+
+#[test]
+fn decode_recipe_book_packet() {
+    let mut bytes = Vec::new();
+    VarInt::from(1).write(&mut bytes).unwrap();
+    bytes.write_all(&[1u8, 0u8]).unwrap();
+    let mut cursor = Cursor::new(bytes);
+    let pkt = RecipeBookPacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(pkt.book_id.0, 1);
+    assert!(pkt.open);
+    assert!(!pkt.filtering);
+}


### PR DESCRIPTION
## Summary
- define CraftRecipeRequestPacket, RecipeBookPacket, and DisplayedRecipePacket
- expose new packet events and register recipe packet tests
- document recipe book related packets

## Testing
- `cargo +nightly test -p ferrumc-tests` *(fails: Could not find key `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_689946d23fd083299b429411058ae59a