### PR TITLE
Add plugin messaging support

### DIFF
--- a/src/lib/core/src/conn/mod.rs
+++ b/src/lib/core/src/conn/mod.rs
@@ -1,3 +1,4 @@
 pub mod force_player_recount_event;
 pub mod keepalive;
 pub mod player_count_update_cooldown;
+pub mod plugin_message;

--- a/src/lib/core/src/conn/plugin_message.rs
+++ b/src/lib/core/src/conn/plugin_message.rs
@@ -1,0 +1,45 @@
+use bevy_ecs::prelude::{Entity, Event, EventWriter};
+
+/// Event fired when a plugin wishes to register a new plugin messaging channel
+/// for a player. The network layer forwards this as a `minecraft:register`
+/// custom payload packet.
+#[derive(Event, Debug)]
+pub struct PluginChannelRegisterEvent {
+    pub entity: Entity,
+    pub channel: String,
+}
+
+/// Event fired when a plugin wants to send data on a plugin channel to a
+/// player.
+#[derive(Event, Debug)]
+pub struct PluginMessageSendEvent {
+    pub entity: Entity,
+    pub channel: String,
+    pub data: Vec<u8>,
+}
+
+/// Registers a plugin messaging channel for the given player.
+pub fn register_plugin_channel(
+    mut writer: EventWriter<PluginChannelRegisterEvent>,
+    entity: Entity,
+    channel: impl Into<String>,
+) {
+    writer.write(PluginChannelRegisterEvent {
+        entity,
+        channel: channel.into(),
+    });
+}
+
+/// Sends raw plugin channel data to the given player.
+pub fn send_plugin_message(
+    mut writer: EventWriter<PluginMessageSendEvent>,
+    entity: Entity,
+    channel: impl Into<String>,
+    data: Vec<u8>,
+) {
+    writer.write(PluginMessageSendEvent {
+        entity,
+        channel: channel.into(),
+        data,
+    });
+}

--- a/src/lib/net/src/packets/incoming/custom_payload.rs
+++ b/src/lib/net/src/packets/incoming/custom_payload.rs
@@ -1,0 +1,11 @@
+use ferrumc_macros::{NetDecode, packet};
+
+/// Represents a plugin channel message sent from the client.
+#[derive(Debug, NetDecode)]
+#[packet(packet_id = "custom_payload", state = "play")]
+pub struct CustomPayloadPacket {
+    /// Namespaced plugin channel identifier (e.g. `minecraft:brand`).
+    pub channel: String,
+    /// Raw bytes carried by the payload. Contains the remaining packet data.
+    pub data: Vec<u8>,
+}

--- a/src/lib/net/src/packets/incoming/mod.rs
+++ b/src/lib/net/src/packets/incoming/mod.rs
@@ -13,6 +13,7 @@ pub mod packet_skeleton;
 
 pub mod place_block;
 pub mod player_command;
+pub mod custom_payload;
 pub mod set_player_position;
 pub mod set_player_position_and_rotation;
 pub mod set_player_rotation;

--- a/src/lib/net/src/packets/outgoing/custom_payload.rs
+++ b/src/lib/net/src/packets/outgoing/custom_payload.rs
@@ -1,0 +1,18 @@
+use ferrumc_macros::{NetEncode, packet};
+use std::io::Write;
+
+/// Sends a plugin channel message to the client.
+#[derive(NetEncode, Clone)]
+#[packet(packet_id = "custom_payload", state = "play")]
+pub struct CustomPayloadPacket {
+    /// Namespaced plugin channel identifier (e.g. `minecraft:register`).
+    pub channel: String,
+    /// Raw plugin channel data to forward.
+    pub data: Vec<u8>,
+}
+
+impl CustomPayloadPacket {
+    pub fn new(channel: String, data: Vec<u8>) -> Self {
+        Self { channel, data }
+    }
+}

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -16,6 +16,7 @@ pub mod login_success;
 pub mod ping_response;
 pub mod set_center_chunk;
 pub mod set_default_spawn_position;
+pub mod custom_payload;
 pub mod set_render_distance;
 pub mod status_response;
 pub mod synchronize_player_position;

--- a/src/lib/net/src/packets/packet_events.rs
+++ b/src/lib/net/src/packets/packet_events.rs
@@ -53,3 +53,10 @@ pub struct RecipeBookEvent {
 pub struct DisplayedRecipeEvent {
     pub recipe: String,
 }
+
+#[derive(Event, Debug)]
+pub struct PluginMessageEvent {
+    pub entity: Entity,
+    pub channel: String,
+    pub data: Vec<u8>,
+}

--- a/src/lib/net/src/server.rs
+++ b/src/lib/net/src/server.rs
@@ -1,7 +1,11 @@
 use crate::errors::NetError;
+use crate::packets::packet_events::PluginMessageEvent;
+use crate::{CustomPayloadPacketReceiver, connection::StreamWriter};
+use bevy_ecs::prelude::{EventReader, EventWriter, Query, Res};
 use ferrumc_config::server_config::get_global_config;
+use ferrumc_core::conn::plugin_message::{PluginChannelRegisterEvent, PluginMessageSendEvent};
 use tokio::net::TcpListener;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 pub async fn create_server_listener() -> Result<TcpListener, NetError> {
     let config = get_global_config();
@@ -21,4 +25,47 @@ pub async fn create_server_listener() -> Result<TcpListener, NetError> {
     debug!("Server listening on {}", server_addy);
 
     Ok(listener?)
+}
+
+/// Routes plugin channel traffic between the network layer and the ECS world.
+pub fn route_plugin_messages(
+    receiver: Res<CustomPayloadPacketReceiver>,
+    mut incoming_writer: EventWriter<PluginMessageEvent>,
+    mut register_events: EventReader<PluginChannelRegisterEvent>,
+    mut send_events: EventReader<PluginMessageSendEvent>,
+    mut query: Query<&StreamWriter>,
+) {
+    for (packet, entity) in receiver.0.try_iter() {
+        incoming_writer.write(PluginMessageEvent {
+            entity,
+            channel: packet.channel,
+            data: packet.data,
+        });
+    }
+
+    for evt in register_events.read() {
+        if let Ok(writer) = query.get(evt.entity) {
+            let mut data = evt.channel.clone().into_bytes();
+            data.push(0);
+            let packet = crate::packets::outgoing::custom_payload::CustomPayloadPacket::new(
+                "minecraft:register".to_string(),
+                data,
+            );
+            if let Err(e) = writer.send_packet(packet) {
+                warn!("Failed to send channel register packet: {:?}", e);
+            }
+        }
+    }
+
+    for evt in send_events.read() {
+        if let Ok(writer) = query.get(evt.entity) {
+            let packet = crate::packets::outgoing::custom_payload::CustomPayloadPacket::new(
+                evt.channel.clone(),
+                evt.data.clone(),
+            );
+            if let Err(e) = writer.send_packet(packet) {
+                warn!("Failed to send plugin message: {:?}", e);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- support custom payload packets for plugin channels
- route plugin channel traffic through `PluginMessageEvent`
- expose APIs for registering and sending plugin messages

## Testing
- `cargo +nightly test` *(fails: Could not find key `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_68995bd6cd808329b59b9fe6c038cf66