### PR TITLE
Implement GlobalPos for death location

### DIFF
--- a/src/lib/net/crates/codec/src/net_types/global_pos.rs
+++ b/src/lib/net/crates/codec/src/net_types/global_pos.rs
@@ -1,0 +1,36 @@
+use crate::encode::{NetEncode, NetEncodeOpts};
+use crate::encode::errors::NetEncodeError;
+use crate::net_types::network_position::NetworkPosition;
+use std::io::Write;
+use tokio::io::AsyncWrite;
+
+/// Global position combining a dimension name and block position.
+#[derive(Debug, Clone)]
+pub struct GlobalPos<'a> {
+    pub dimension_name: &'a str,
+    pub position: NetworkPosition,
+}
+
+impl<'a> GlobalPos<'a> {
+    pub fn new(dimension_name: &'a str, position: NetworkPosition) -> Self {
+        Self { dimension_name, position }
+    }
+}
+
+impl NetEncode for GlobalPos<'_> {
+    fn encode<W: Write>(&self, writer: &mut W, opts: &NetEncodeOpts) -> Result<(), NetEncodeError> {
+        self.dimension_name.encode(writer, opts)?;
+        self.position.encode(writer, opts)?;
+        Ok(())
+    }
+
+    async fn encode_async<W: AsyncWrite + Unpin>(
+        &self,
+        writer: &mut W,
+        opts: &NetEncodeOpts,
+    ) -> Result<(), NetEncodeError> {
+        self.dimension_name.encode_async(writer, opts).await?;
+        self.position.encode_async(writer, opts).await?;
+        Ok(())
+    }
+}

--- a/src/lib/net/crates/codec/src/net_types/mod.rs
+++ b/src/lib/net/crates/codec/src/net_types/mod.rs
@@ -3,6 +3,7 @@ pub mod bitset;
 pub mod byte_array;
 pub mod length_prefixed_vec;
 pub mod network_position;
+pub mod global_pos;
 pub mod prefixed_optional;
 pub mod teleport_flags;
 pub mod var_int;

--- a/src/lib/net/src/conn_init/login.rs
+++ b/src/lib/net/src/conn_init/login.rs
@@ -216,8 +216,11 @@ pub(super) async fn login<R: AsyncRead + Unpin>(
 
     // =============================================================================================
     // 6 Send login_play packet to switch to Play state
-    let login_play =
-        crate::packets::outgoing::login_play::LoginPlayPacket::new(player_identity.short_uuid);
+    let login_play = crate::packets::outgoing::login_play::LoginPlayPacket::new(
+        player_identity.short_uuid,
+        "minecraft:overworld",
+        None,
+    );
     conn_write.send_packet(login_play)?;
 
     // =============================================================================================

--- a/src/lib/net/src/packets/outgoing/login_play.rs
+++ b/src/lib/net/src/packets/outgoing/login_play.rs
@@ -1,7 +1,10 @@
 use ferrumc_config::server_config::get_global_config;
 use ferrumc_macros::{NetEncode, packet};
 use ferrumc_net_codec::net_types::var_int::VarInt;
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
 use std::io::Write;
+
+pub use ferrumc_net_codec::net_types::global_pos::GlobalPos;
 
 #[derive(NetEncode)]
 #[packet(packet_id = "login", state = "play")]
@@ -23,16 +26,14 @@ pub struct LoginPlayPacket<'a> {
     pub previous_gamemode: i8,
     pub is_debug: bool,
     pub is_flat: bool,
-    pub has_death_location: bool,
-    pub death_dimension_name: Option<&'a str>,
-    pub death_location: Option<u8>, // change this to actual Position. this won't work!!
+    pub death_location: PrefixedOptional<GlobalPos<'a>>,
     pub portal_cooldown: VarInt,
     pub sea_level: VarInt,
     pub enforces_secure_chat: bool,
 }
 
-impl LoginPlayPacket<'_> {
-    pub fn new(conn_id: i32) -> Self {
+impl<'a> LoginPlayPacket<'a> {
+    pub fn new(conn_id: i32, dimension: &'a str, death: Option<GlobalPos<'a>>) -> Self {
         Self {
             entity_id: conn_id,
             is_hardcore: false,
@@ -45,15 +46,13 @@ impl LoginPlayPacket<'_> {
             enable_respawn_screen: true,
             do_limited_crafting: false,
             dimension_type: VarInt::new(0),
-            dimension_name: "minecraft:overworld",
+            dimension_name: dimension,
             seed_hash: 0,
             gamemode: 1,
             previous_gamemode: -1,
             is_debug: false,
             is_flat: false,
-            has_death_location: false,
-            death_dimension_name: None,
-            death_location: None,
+            death_location: PrefixedOptional::new(death),
             portal_cooldown: VarInt::from(0),
             sea_level: VarInt::from(63),
             enforces_secure_chat: false,

--- a/src/tests/src/net/login_respawn.rs
+++ b/src/tests/src/net/login_respawn.rs
@@ -1,0 +1,16 @@
+use ferrumc_net::packets::outgoing::login_play::{GlobalPos, LoginPlayPacket};
+use ferrumc_net_codec::net_types::network_position::NetworkPosition;
+
+#[test]
+fn login_packet_has_no_death_location() {
+    let packet = LoginPlayPacket::new(1, "minecraft:overworld", None);
+    assert!(packet.death_location.is_none());
+    assert_eq!(packet.dimension_name, "minecraft:overworld");
+}
+
+#[test]
+fn respawn_packet_contains_death_location() {
+    let death = GlobalPos::new("minecraft:overworld", NetworkPosition { x: 1, y: 2, z: 3 });
+    let packet = LoginPlayPacket::new(1, "minecraft:overworld", Some(death));
+    assert!(packet.death_location.is_some());
+}

--- a/src/tests/src/net/mod.rs
+++ b/src/tests/src/net/mod.rs
@@ -3,3 +3,4 @@ mod codec;
 mod encrypted_login;
 mod offline_login;
 mod recipe_packets;
+mod login_respawn;


### PR DESCRIPTION
## Summary
- align login play packet layout with protocol 763 using `PrefixedOptional<GlobalPos>` for death location
- add `GlobalPos` net type and expose through login packet
- populate login handshake with spawn dimension and optional death location
- add tests for login and respawn packet construction

## Testing
- `RUSTC_BOOTSTRAP=1 cargo test -p ferrumc-tests login_respawn --quiet` *(fails: Could not find key `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_68995f9930fc8329a27049177fa9a21e