### PR TITLE
Add block entity structs and furnace system

### DIFF
--- a/src/lib/core/src/furnace.rs
+++ b/src/lib/core/src/furnace.rs
@@ -1,0 +1,34 @@
+use crate::inventory::{Inventory, ItemStack};
+use bevy_ecs::prelude::{Component, Query};
+
+#[derive(Component, Debug, Clone, Default)]
+pub struct Furnace {
+    pub burn_time: i16,
+    pub cook_time: i16,
+    pub cook_time_total: i16,
+}
+
+/// Simple furnace smelting system. This is a placeholder and only decrements timers.
+pub fn furnace_tick(mut query: Query<(&mut Furnace, &mut Inventory)>) {
+    for (mut furnace, mut inv) in &mut query {
+        if furnace.burn_time > 0 {
+            furnace.burn_time -= 1;
+            furnace.cook_time += 1;
+            if furnace.cook_time >= furnace.cook_time_total {
+                furnace.cook_time = 0;
+                // Very primitive smelting: move input slot 0 to output slot 2.
+                if let Some(slot0) = inv.get_slot_mut(0) {
+                    if let Some(input) = slot0.take() {
+                        inv.set_slot(
+                            2,
+                            Some(ItemStack {
+                                count: input.count,
+                                ..input
+                            }),
+                        );
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/lib/core/src/lib.rs
+++ b/src/lib/core/src/lib.rs
@@ -1,13 +1,14 @@
 pub mod errors;
 
 // Core structs/types. Usually used in ECS Components.
+pub mod ai;
 pub mod chunks;
 pub mod collisions;
 pub mod conn;
+pub mod furnace;
+pub mod health;
 pub mod identity;
 pub mod inventory;
+pub mod movement;
 pub mod state;
 pub mod transform;
-pub mod health;
-pub mod ai;
-pub mod movement;

--- a/src/lib/world/src/block_entities/chest.rs
+++ b/src/lib/world/src/block_entities/chest.rs
@@ -1,0 +1,19 @@
+use ferrumc_macros::{NBTDeserialize, NBTSerialize};
+
+#[derive(NBTDeserialize, NBTSerialize, Debug, Clone, PartialEq, Default)]
+#[nbt(is_root)]
+#[nbt(rename = "")]
+pub struct ChestBlockEntity {
+    #[nbt(rename = "Items")]
+    pub items: Vec<ChestItem>,
+}
+
+#[derive(NBTDeserialize, NBTSerialize, Debug, Clone, PartialEq)]
+pub struct ChestItem {
+    #[nbt(rename = "Slot")]
+    pub slot: i8,
+    #[nbt(rename = "id")]
+    pub id: String,
+    #[nbt(rename = "Count")]
+    pub count: u8,
+}

--- a/src/lib/world/src/block_entities/furnace.rs
+++ b/src/lib/world/src/block_entities/furnace.rs
@@ -1,0 +1,25 @@
+use ferrumc_macros::{NBTDeserialize, NBTSerialize};
+
+#[derive(NBTDeserialize, NBTSerialize, Debug, Clone, PartialEq, Default)]
+#[nbt(is_root)]
+#[nbt(rename = "")]
+pub struct FurnaceBlockEntity {
+    #[nbt(rename = "Items")]
+    pub items: Vec<FurnaceItem>,
+    #[nbt(rename = "BurnTime")]
+    pub burn_time: i16,
+    #[nbt(rename = "CookTime")]
+    pub cook_time: i16,
+    #[nbt(rename = "CookTimeTotal")]
+    pub cook_time_total: i16,
+}
+
+#[derive(NBTDeserialize, NBTSerialize, Debug, Clone, PartialEq)]
+pub struct FurnaceItem {
+    #[nbt(rename = "Slot")]
+    pub slot: i8,
+    #[nbt(rename = "id")]
+    pub id: String,
+    #[nbt(rename = "Count")]
+    pub count: u8,
+}

--- a/src/lib/world/src/block_entities/mod.rs
+++ b/src/lib/world/src/block_entities/mod.rs
@@ -1,0 +1,2 @@
+pub mod chest;
+pub mod furnace;

--- a/src/lib/world/src/errors.rs
+++ b/src/lib/world/src/errors.rs
@@ -34,6 +34,8 @@ pub enum WorldError {
     BitcodeEncodeError(String),
     #[error("Chunk not found")]
     ChunkNotFound,
+    #[error("Block entity not found")]
+    BlockEntityNotFound,
     #[error("Anvil Decode Error: {0}")]
     AnvilDecodeError(AnvilError),
     #[error("Missing block mapping: {0}")]

--- a/src/lib/world/src/lib.rs
+++ b/src/lib/world/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod biome_id;
+pub mod block_entities;
 pub mod block_id;
 pub mod chunk_format;
 mod db_functions;
@@ -6,9 +7,9 @@ pub mod edit_batch;
 pub mod edits;
 pub mod errors;
 mod importing;
-pub mod vanilla_chunk_format;
-pub mod tick;
 pub mod redstone;
+pub mod tick;
+pub mod vanilla_chunk_format;
 
 use crate::chunk_format::Chunk;
 use crate::errors::WorldError;
@@ -110,10 +111,7 @@ impl World {
             move |key: Arc<(i32, i32, String)>, _: Arc<Chunk>, cause: RemovalCause| {
                 trace!("Evicting key: {:?}, cause: {:?}", key, cause);
                 let (cx, cz, dim) = &*key;
-                tm_clone
-                    .lock()
-                    .unwrap()
-                    .cleanup_chunk(*cx, *cz, dim);
+                tm_clone.lock().unwrap().cleanup_chunk(*cx, *cz, dim);
             };
 
         let cache = Cache::builder()
@@ -137,14 +135,7 @@ impl World {
     }
 
     /// Schedule a future tick for the block at the given position.
-    pub fn schedule_tick(
-        &self,
-        x: i32,
-        y: i32,
-        z: i32,
-        dimension: &str,
-        delay: u32,
-    ) {
+    pub fn schedule_tick(&self, x: i32, y: i32, z: i32, dimension: &str, delay: u32) {
         tick::schedule_block_tick(self, x, y, z, dimension, delay);
     }
 

--- a/src/lib/world/tests/block_entity_persist.rs
+++ b/src/lib/world/tests/block_entity_persist.rs
@@ -1,0 +1,64 @@
+use std::sync::Arc;
+use std::sync::Once;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use ferrumc_config::server_config::{set_global_config, DatabaseConfig, ServerConfig};
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use ferrumc_world::{
+    block_entities::chest::{ChestBlockEntity, ChestItem},
+    chunk_format::Chunk,
+    World,
+};
+
+fn init_config() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let mut base = std::env::temp_dir();
+        base.push("ferrumc_world_tests");
+        std::fs::create_dir_all(&base).unwrap();
+        let cfg = ServerConfig {
+            database: DatabaseConfig {
+                db_path: base.to_string_lossy().to_string(),
+                map_size: 1,
+                cache_ttl: 0,
+                cache_capacity: 0,
+                verify_chunk_data: false,
+            },
+            ..Default::default()
+        };
+        set_global_config(cfg);
+    });
+}
+
+#[test]
+fn chest_persist_reload() {
+    init_config();
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    path.push(format!("ferrumc_world_chest_{}", nanos));
+    std::fs::create_dir_all(&path).unwrap();
+
+    let world = World::new(&path);
+    let mut chunk = Chunk::new(0, 0, "overworld".to_string());
+
+    let chest = ChestBlockEntity {
+        items: vec![ChestItem {
+            slot: 0,
+            id: "minecraft:stone".to_string(),
+            count: 1,
+        }],
+    };
+    chunk.set_block_entity_data(0, 64, 0, VarInt::from(0), &chest);
+    world.save_chunk(Arc::new(chunk)).unwrap();
+    drop(world);
+
+    let world = World::new(&path);
+    let chunk = world.load_chunk_owned(0, 0, "overworld").unwrap();
+    let loaded: ChestBlockEntity = chunk.get_block_entity_data(0, 64, 0).expect("block entity");
+    assert_eq!(loaded.items.len(), 1);
+    assert_eq!(loaded.items[0].id, "minecraft:stone");
+    assert_eq!(loaded.items[0].count, 1);
+}


### PR DESCRIPTION
## Summary
- define `ChestBlockEntity` and `FurnaceBlockEntity` with NBT mappings
- support typed block-entity serialization and DB load/save helpers
- add basic furnace component and system with chest persistence test

## Testing
- `cargo +nightly test -p ferrumc-world -p ferrumc-core`


------
https://chatgpt.com/codex/tasks/task_b_689a4ce2b08883299b9d53aa7bfde0b1