### PR TITLE
feat(world_gen): scaffold multi-step pipeline and structures

### DIFF
--- a/src/lib/world_gen/Cargo.toml
+++ b/src/lib/world_gen/Cargo.toml
@@ -11,3 +11,6 @@ rand = { workspace = true }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+insta = "1"

--- a/src/lib/world_gen/src/biomes/plains.rs
+++ b/src/lib/world_gen/src/biomes/plains.rs
@@ -110,14 +110,14 @@ mod test {
     #[test]
     fn test_is_ok() {
         let generator = PlainsBiome {};
-        let noise = NoiseGenerator::new(0);
+        let noise = NoiseGenerator::new(0, crate::noise_settings::OVERWORLD_NOISE_SETTINGS);
         assert!(generator.generate_chunk(0, 0, &noise).is_ok());
     }
 
     #[test]
     fn test_random_chunk_generation() {
         let generator = PlainsBiome {};
-        let noise = NoiseGenerator::new(0);
+        let noise = NoiseGenerator::new(0, crate::noise_settings::OVERWORLD_NOISE_SETTINGS);
         for _ in 0..100 {
             let x = rand::random::<i32>();
             let z = rand::random::<i32>();
@@ -128,17 +128,13 @@ mod test {
     #[test]
     fn test_very_high_coordinates() {
         let generator = PlainsBiome {};
-        let noise = NoiseGenerator::new(0);
-        assert!(
-            generator
-                .generate_chunk(1610612735, 1610612735, &noise)
-                .is_ok()
-        );
-        assert!(
-            generator
-                .generate_chunk(-1610612735, -1610612735, &noise)
-                .is_ok()
-        );
+        let noise = NoiseGenerator::new(0, crate::noise_settings::OVERWORLD_NOISE_SETTINGS);
+        assert!(generator
+            .generate_chunk(1610612735, 1610612735, &noise)
+            .is_ok());
+        assert!(generator
+            .generate_chunk(-1610612735, -1610612735, &noise)
+            .is_ok());
     }
 
     #[test]
@@ -146,7 +142,7 @@ mod test {
         for _ in 0..100 {
             let generator = PlainsBiome {};
             let seed = rand::random::<u64>();
-            let noise = NoiseGenerator::new(seed);
+            let noise = NoiseGenerator::new(seed, crate::noise_settings::OVERWORLD_NOISE_SETTINGS);
             assert!(generator.generate_chunk(0, 0, &noise).is_ok());
         }
     }

--- a/src/lib/world_gen/src/noise_settings.rs
+++ b/src/lib/world_gen/src/noise_settings.rs
@@ -1,0 +1,10 @@
+/// Placeholder for Minecraft 1.20.1 noise settings.
+///
+/// These values do not fully replicate the vanilla implementation but
+/// provide a hook for future expansion.
+#[derive(Clone, Copy)]
+pub struct NoiseSettings {
+    pub scale: f64,
+}
+
+pub const OVERWORLD_NOISE_SETTINGS: NoiseSettings = NoiseSettings { scale: 64.0 };

--- a/src/lib/world_gen/src/structures/mod.rs
+++ b/src/lib/world_gen/src/structures/mod.rs
@@ -1,0 +1,6 @@
+pub trait StructurePlacer {
+    fn place(&self, chunk: &mut ferrumc_world::chunk_format::Chunk);
+}
+
+pub mod temple;
+pub mod village;

--- a/src/lib/world_gen/src/structures/temple.rs
+++ b/src/lib/world_gen/src/structures/temple.rs
@@ -1,0 +1,16 @@
+use super::StructurePlacer;
+use ferrumc_world::chunk_format::Chunk;
+use ferrumc_world::vanilla_chunk_format::BlockData;
+
+pub struct Temple;
+
+impl StructurePlacer for Temple {
+    fn place(&self, chunk: &mut Chunk) {
+        let block = BlockData {
+            name: "minecraft:mossy_cobblestone".into(),
+            properties: None,
+        };
+        // Ignore placement errors; this implementation is a simplified placeholder.
+        let _ = chunk.set_block(1, 64, 1, block.to_block_id());
+    }
+}

--- a/src/lib/world_gen/src/structures/village.rs
+++ b/src/lib/world_gen/src/structures/village.rs
@@ -1,0 +1,16 @@
+use super::StructurePlacer;
+use ferrumc_world::chunk_format::Chunk;
+use ferrumc_world::vanilla_chunk_format::BlockData;
+
+pub struct Village;
+
+impl StructurePlacer for Village {
+    fn place(&self, chunk: &mut Chunk) {
+        let block = BlockData {
+            name: "minecraft:cobblestone".into(),
+            properties: None,
+        };
+        // Placement failures are ignored for now as the structure system is placeholder-only.
+        let _ = chunk.set_block(0, 64, 0, block.to_block_id());
+    }
+}

--- a/src/lib/world_gen/tests/generation.rs
+++ b/src/lib/world_gen/tests/generation.rs
@@ -1,0 +1,9 @@
+use ferrumc_world_gen::WorldGenerator;
+
+#[test]
+#[ignore]
+fn snapshot_chunk() {
+    let generator = WorldGenerator::new(0);
+    let chunk = generator.generate_chunk(0, 0).unwrap();
+    insta::assert_snapshot!(format!("{:?}", chunk));
+}


### PR DESCRIPTION
## Summary
- add placeholder 1.20.1 noise settings module
- scaffold generation pipeline with hooks for surface, carvers, features, and structures
- implement basic village and temple structure placers

## Testing
- `cargo +nightly test -p ferrumc-world-gen`

------
https://chatgpt.com/codex/tasks/task_b_689a51a4ef8c8329b65c22566b59d541