### PR TITLE
Add AI pathfinding and biome-based spawn rules

### DIFF
--- a/src/bin/src/systems/ai.rs
+++ b/src/bin/src/systems/ai.rs
@@ -1,33 +1,12 @@
-use bevy_ecs::prelude::{Commands, Query};
-use ferrumc_core::ai::{AIGoal, EntityKind, Mob, PendingSpawn};
-use ferrumc_core::collisions::bounds::CollisionBounds;
-use ferrumc_core::identity::entity_id::EntityId;
+use bevy_ecs::prelude::{Commands, Query, Res};
+use ferrumc_core::ai::{AIGoal, Mob};
 use ferrumc_core::movement::Movement;
-use ferrumc_core::transform::position::Position;
-use ferrumc_core::transform::rotation::Rotation;
+use ferrumc_core::state::spawn_entities_from_biomes;
+use ferrumc_state::GlobalStateResource;
 use rand::Rng;
 
-pub fn spawn_mobs(mut cmd: Commands, query: Query<&Mob>) {
-    if query.is_empty() {
-        let id = EntityId::new(rand::random::<u128>());
-        cmd.spawn((
-            id,
-            Mob { kind: EntityKind::Cow },
-            Position::default(),
-            Rotation::default(),
-            Movement::default(),
-            CollisionBounds {
-                x_offset_start: -0.3,
-                x_offset_end: 0.3,
-                y_offset_start: 0.0,
-                y_offset_end: 1.8,
-                z_offset_start: -0.3,
-                z_offset_end: 0.3,
-            },
-            AIGoal::Wander,
-            PendingSpawn,
-        ));
-    }
+pub fn spawn_mobs(cmd: Commands, state: Res<GlobalStateResource>, query: Query<&Mob>) {
+    spawn_entities_from_biomes(cmd, state, query);
 }
 
 pub fn update_ai(mut query: Query<(&AIGoal, &mut Movement)>) {

--- a/src/lib/core/Cargo.toml
+++ b/src/lib/core/Cargo.toml
@@ -14,6 +14,7 @@ uuid = { workspace = true }
 ferrumc-world = { workspace = true }
 ferrumc-macros = { workspace = true }
 ferrumc-state = { workspace = true }
+rand = { workspace = true }
 
 [dev-dependencies]
 criterion = { workspace = true }

--- a/src/lib/core/src/ai.rs
+++ b/src/lib/core/src/ai.rs
@@ -2,18 +2,27 @@ use bevy_ecs::prelude::Component;
 use typename::TypeName;
 
 use ferrumc_macros::get_registry_entry;
+use std::cmp::Ordering;
+use std::collections::{BinaryHeap, HashMap};
+use std::hash::Hash;
 
 #[derive(TypeName, Component, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EntityKind {
     Cow,
+    Zombie,
+    Skeleton,
 }
 
 const COW_ID: u64 = get_registry_entry!("minecraft:entity_type.entries.minecraft:cow");
+const ZOMBIE_ID: u64 = get_registry_entry!("minecraft:entity_type.entries.minecraft:zombie");
+const SKELETON_ID: u64 = get_registry_entry!("minecraft:entity_type.entries.minecraft:skeleton");
 
 impl EntityKind {
     pub fn network_id(self) -> i32 {
         match self {
             EntityKind::Cow => COW_ID as i32,
+            EntityKind::Zombie => ZOMBIE_ID as i32,
+            EntityKind::Skeleton => SKELETON_ID as i32,
         }
     }
 }
@@ -35,5 +44,167 @@ pub enum AIGoal {
 impl Default for AIGoal {
     fn default() -> Self {
         AIGoal::Idle
+    }
+}
+
+/// Basic interface for AI goals.
+pub trait Goal {
+    /// Returns `true` when the goal has been achieved.
+    fn is_complete(&self, pos: GridPos) -> bool;
+}
+
+/// A simple goal that moves an entity to a target position.
+#[derive(Debug, Clone, Copy)]
+pub struct MoveToGoal {
+    pub target: GridPos,
+}
+
+impl Goal for MoveToGoal {
+    fn is_complete(&self, pos: GridPos) -> bool {
+        pos == self.target
+    }
+}
+
+/// Trait representing a pathfinding strategy.
+pub trait Pathfinder {
+    type Node: Eq + Hash + Copy;
+
+    fn find_path(
+        &self,
+        start: Self::Node,
+        goal: Self::Node,
+        is_walkable: impl Fn(Self::Node) -> bool,
+    ) -> Option<Vec<Self::Node>>;
+}
+
+/// 2D grid position used by the default pathfinder.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct GridPos {
+    pub x: i32,
+    pub y: i32,
+}
+
+impl GridPos {
+    fn neighbors(self) -> [GridPos; 4] {
+        [
+            GridPos {
+                x: self.x + 1,
+                y: self.y,
+            },
+            GridPos {
+                x: self.x - 1,
+                y: self.y,
+            },
+            GridPos {
+                x: self.x,
+                y: self.y + 1,
+            },
+            GridPos {
+                x: self.x,
+                y: self.y - 1,
+            },
+        ]
+    }
+
+    fn manhattan(self, other: GridPos) -> i32 {
+        (self.x - other.x).abs() + (self.y - other.y).abs()
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+struct Node {
+    pos: GridPos,
+    score: i32,
+}
+
+impl Ord for Node {
+    fn cmp(&self, other: &Self) -> Ordering {
+        // Reverse order for min-heap behavior.
+        other
+            .score
+            .cmp(&self.score)
+            .then_with(|| self.pos.x.cmp(&other.pos.x))
+            .then_with(|| self.pos.y.cmp(&other.pos.y))
+    }
+}
+
+impl PartialOrd for Node {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+/// A* pathfinder operating on a 2D grid.
+pub struct AStarPathfinder;
+
+impl Pathfinder for AStarPathfinder {
+    type Node = GridPos;
+
+    fn find_path(
+        &self,
+        start: GridPos,
+        goal: GridPos,
+        is_walkable: impl Fn(GridPos) -> bool,
+    ) -> Option<Vec<GridPos>> {
+        let mut open = BinaryHeap::new();
+        open.push(Node {
+            pos: start,
+            score: 0,
+        });
+
+        let mut came_from: HashMap<GridPos, GridPos> = HashMap::new();
+        let mut g_score: HashMap<GridPos, i32> = HashMap::new();
+        g_score.insert(start, 0);
+
+        while let Some(Node { pos, .. }) = open.pop() {
+            if pos == goal {
+                let mut path = vec![pos];
+                let mut current = pos;
+                while let Some(&prev) = came_from.get(&current) {
+                    path.push(prev);
+                    current = prev;
+                }
+                path.reverse();
+                return Some(path);
+            }
+
+            let current_g = *g_score.get(&pos).unwrap_or(&i32::MAX);
+            for neighbor in pos.neighbors() {
+                if !is_walkable(neighbor) {
+                    continue;
+                }
+                let tentative_g = current_g + 1;
+                if tentative_g < *g_score.get(&neighbor).unwrap_or(&i32::MAX) {
+                    came_from.insert(neighbor, pos);
+                    g_score.insert(neighbor, tentative_g);
+                    let f_score = tentative_g + neighbor.manhattan(goal);
+                    open.push(Node {
+                        pos: neighbor,
+                        score: f_score,
+                    });
+                }
+            }
+        }
+
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn astar_finds_simple_path() {
+        let pf = AStarPathfinder;
+        let obstacles = [GridPos { x: 1, y: 0 }];
+        let path = pf
+            .find_path(GridPos { x: 0, y: 0 }, GridPos { x: 2, y: 0 }, |p| {
+                !obstacles.contains(&p)
+            })
+            .expect("Path should be found");
+        assert_eq!(path.first(), Some(&GridPos { x: 0, y: 0 }));
+        assert_eq!(path.last(), Some(&GridPos { x: 2, y: 0 }));
+        assert!(path.len() > 2); // Must route around the obstacle
     }
 }

--- a/src/lib/core/src/entities/mod.rs
+++ b/src/lib/core/src/entities/mod.rs
@@ -1,0 +1,13 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub struct Zombie;
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub struct Skeleton;
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub struct Cow;
+
+pub mod spawn_rules;

--- a/src/lib/core/src/entities/spawn_rules.rs
+++ b/src/lib/core/src/entities/spawn_rules.rs
@@ -1,0 +1,29 @@
+use crate::ai::EntityKind;
+
+pub struct SpawnRule {
+    pub kind: EntityKind,
+    pub weight: u32,
+}
+
+pub fn rules_for_biome(biome: u8) -> &'static [SpawnRule] {
+    match biome {
+        39 => PLAINS,
+        _ => DEFAULT,
+    }
+}
+
+static PLAINS: &[SpawnRule] = &[
+    SpawnRule {
+        kind: EntityKind::Zombie,
+        weight: 50,
+    },
+    SpawnRule {
+        kind: EntityKind::Skeleton,
+        weight: 50,
+    },
+];
+
+static DEFAULT: &[SpawnRule] = &[SpawnRule {
+    kind: EntityKind::Cow,
+    weight: 100,
+}];

--- a/src/lib/core/src/lib.rs
+++ b/src/lib/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod ai;
 pub mod chunks;
 pub mod collisions;
 pub mod conn;
+pub mod entities;
 pub mod furnace;
 pub mod health;
 pub mod identity;

--- a/src/lib/core/src/state.rs
+++ b/src/lib/core/src/state.rs
@@ -1,10 +1,69 @@
-use bevy_ecs::prelude::Res;
+use bevy_ecs::prelude::{Commands, Query, Res};
 use ferrumc_state::GlobalStateResource;
+use rand::Rng;
 use tracing::error;
+
+use crate::ai::{AIGoal, EntityKind, Mob, PendingSpawn};
+use crate::collisions::bounds::CollisionBounds;
+use crate::entities::spawn_rules::{self, SpawnRule};
+use crate::identity::entity_id::EntityId;
+use crate::movement::Movement;
+use crate::transform::position::Position;
+use crate::transform::rotation::Rotation;
 
 /// System that advances the world by one tick.
 pub fn tick_world(state: Res<GlobalStateResource>) {
     if let Err(e) = state.0.world.tick() {
         error!("World tick failed: {e}");
     }
+}
+
+/// Spawns entities based on biome-specific rules.
+pub fn spawn_entities_from_biomes(
+    mut cmd: Commands,
+    state: Res<GlobalStateResource>,
+    existing: Query<&Mob>,
+) {
+    if !existing.is_empty() {
+        return;
+    }
+
+    let biome = state.0.terrain_generator.biome_at(0, 0);
+    let rules = spawn_rules::rules_for_biome(biome);
+    if let Some(kind) = select_weighted(rules) {
+        let id = EntityId::new(rand::random::<u128>());
+        cmd.spawn((
+            id,
+            Mob { kind },
+            Position::default(),
+            Rotation::default(),
+            Movement::default(),
+            CollisionBounds {
+                x_offset_start: -0.3,
+                x_offset_end: 0.3,
+                y_offset_start: 0.0,
+                y_offset_end: 1.8,
+                z_offset_start: -0.3,
+                z_offset_end: 0.3,
+            },
+            AIGoal::Idle,
+            PendingSpawn,
+        ));
+    }
+}
+
+fn select_weighted(rules: &[SpawnRule]) -> Option<EntityKind> {
+    let total: u32 = rules.iter().map(|r| r.weight).sum();
+    if total == 0 {
+        return None;
+    }
+    let mut rng = rand::thread_rng();
+    let mut roll = rng.gen_range(0..total);
+    for rule in rules {
+        if roll < rule.weight {
+            return Some(rule.kind);
+        }
+        roll -= rule.weight;
+    }
+    None
 }


### PR DESCRIPTION
## Summary
- expand AI with A* pathfinding traits and test
- define zombie and skeleton entities and biome spawn tables
- spawn entities based on biome rules during world ticks

## Testing
- `cargo test` *(fails: `ferrumc-macros` uses `#![feature(proc_macro_quote)]`)*

------
https://chatgpt.com/codex/tasks/task_b_689a77cf6e248329b8a8393d03e216ac