### PR TITLE
feat: add basic item use and block break tracking

### DIFF
--- a/src/lib/core/src/chunks/block_break_progress.rs
+++ b/src/lib/core/src/chunks/block_break_progress.rs
@@ -1,0 +1,41 @@
+use bevy_ecs::prelude::Resource;
+use std::collections::HashMap;
+
+/// Tracks block breaking progress for positions in a chunk.
+#[derive(Resource, Default)]
+pub struct BlockBreakProgress {
+    progress: HashMap<(i32, i32, i32, String), f32>,
+}
+
+impl BlockBreakProgress {
+    fn key(x: i32, y: i32, z: i32, dimension: &str) -> (i32, i32, i32, String) {
+        (x, y, z, dimension.to_string())
+    }
+
+    /// Start tracking break progress for a block at the given position within the specified dimension.
+    pub fn start(&mut self, x: i32, y: i32, z: i32, dimension: String) {
+        self.progress
+            .entry(Self::key(x, y, z, &dimension))
+            .or_insert(0.0);
+    }
+
+    /// Update the progress for the block at the given position. Returns the new progress if tracked.
+    pub fn update(&mut self, x: i32, y: i32, z: i32, dimension: &str, delta: f32) -> Option<f32> {
+        self.progress
+            .get_mut(&Self::key(x, y, z, dimension))
+            .map(|p| {
+                *p = (*p + delta).clamp(0.0, 1.0);
+                *p
+            })
+    }
+
+    /// Stop tracking the block at the given position.
+    pub fn clear(&mut self, x: i32, y: i32, z: i32, dimension: &str) {
+        self.progress.remove(&Self::key(x, y, z, dimension));
+    }
+
+    /// Fetch the current progress for the given block position.
+    pub fn get(&self, x: i32, y: i32, z: i32, dimension: &str) -> Option<f32> {
+        self.progress.get(&Self::key(x, y, z, dimension)).copied()
+    }
+}

--- a/src/lib/core/src/chunks/mod.rs
+++ b/src/lib/core/src/chunks/mod.rs
@@ -1,3 +1,4 @@
+pub mod block_break_progress;
 pub mod chunk_receiver;
 pub mod cross_chunk_boundary_event;
 pub mod world_sync_tracker;

--- a/src/lib/net/src/packets/packet_events.rs
+++ b/src/lib/net/src/packets/packet_events.rs
@@ -60,3 +60,17 @@ pub struct PluginMessageEvent {
     pub channel: String,
     pub data: Vec<u8>,
 }
+
+#[derive(Event, Debug)]
+pub struct PlayerDiggingEvent {
+    pub entity: Entity,
+    pub status: i32,
+    pub position: Position,
+    pub face: u8,
+}
+
+#[derive(Event, Debug)]
+pub struct UseItemEvent {
+    pub entity: Entity,
+    pub hand: i32,
+}

--- a/src/tests/src/net/mod.rs
+++ b/src/tests/src/net/mod.rs
@@ -1,6 +1,7 @@
 mod chunk;
 mod codec;
 mod encrypted_login;
-mod offline_login;
-mod recipe_packets;
 mod login_respawn;
+mod offline_login;
+mod player_actions;
+mod recipe_packets;

--- a/src/tests/src/net/player_actions.rs
+++ b/src/tests/src/net/player_actions.rs
@@ -1,0 +1,60 @@
+use bevy_ecs::event::Events;
+use bevy_ecs::system::RunSystemOnce;
+use bevy_ecs::world::World;
+use ferrumc_core::chunks::block_break_progress::BlockBreakProgress;
+use ferrumc_core::inventory::{Inventory, ItemStack};
+use ferrumc_net::packets::packet_events::{PlayerDiggingEvent, UseItemEvent};
+use ferrumc_net::server::{handle_player_digging, handle_use_item};
+use ferrumc_world::block_id::BlockId;
+
+#[test]
+fn player_digging_progress_tracking() {
+    let mut world = World::new();
+    world.insert_resource(BlockBreakProgress::default());
+    world.insert_resource(Events::<PlayerDiggingEvent>::default());
+    let entity = world.spawn_empty().id();
+
+    {
+        let mut events = world.resource_mut::<Events<PlayerDiggingEvent>>();
+        events.send(PlayerDiggingEvent {
+            entity,
+            status: 0,
+            position: ferrumc_core::transform::position::Position {
+                x: 1.0,
+                y: 2.0,
+                z: 3.0,
+            },
+            face: 0,
+        });
+    }
+    world.run_system_once(handle_player_digging);
+    let tracker = world.resource::<BlockBreakProgress>();
+    assert!(tracker.get(1, 2, 3, "overworld").is_some());
+}
+
+#[test]
+fn use_item_consumes_stack() {
+    let mut world = World::new();
+    world.insert_resource(Events::<UseItemEvent>::default());
+    let entity = world
+        .spawn(Inventory {
+            hotbar: Default::default(),
+            main: Default::default(),
+            equipment: Default::default(),
+            offhand: None,
+        })
+        .id();
+
+    {
+        let mut inv = world.get_mut::<Inventory>(entity).unwrap();
+        inv.hotbar[0] = Some(ItemStack::new(BlockId(1), 1, 64, None));
+    }
+
+    {
+        let mut events = world.resource_mut::<Events<UseItemEvent>>();
+        events.send(UseItemEvent { entity, hand: 0 });
+    }
+    world.run_system_once(handle_use_item);
+    let inv = world.get::<Inventory>(entity).unwrap();
+    assert!(inv.hotbar[0].is_none());
+}


### PR DESCRIPTION
## Summary
- track per-block breaking progress in chunk system
- add inventory right-click handling and item use events
- wire digging and item use packets through server
- cover basic interactions with mocked packet tests

## Testing
- `cargo +nightly test` *(fails: Could not find key: `minecraft:chat_message` in the packet registry)*


------
https://chatgpt.com/codex/tasks/task_b_689a97883a308329951b62f62a1e45d9