### PR TITLE
feat: add permission levels and command feedback

### DIFF
--- a/src/bin/src/commands/mod.rs
+++ b/src/bin/src/commands/mod.rs
@@ -1,10 +1,19 @@
+//! Command handling built on Brigadier.
+//!
+//! # Examples
+//! ```
+//! use ferrumc::commands::{CommandDispatcher, help_command};
+//! let mut dispatcher = CommandDispatcher::new();
+//! dispatcher.register(help_command());
+//! ```
+
 use std::convert::Infallible;
 use std::marker::PhantomData;
 
+use bevy_ecs::prelude::{Entity, Query, Resource};
 use brigadier_rs::{
     float_64, integer_i32, literal, BuildExecute, CommandArgument, CommandParser, Then,
 };
-use bevy_ecs::prelude::{Entity, Query, Resource};
 use ferrumc_core::{
     identity::player_identity::PlayerIdentity,
     inventory::{Inventory, ItemStack},
@@ -23,6 +32,7 @@ use ferrumc_state::GlobalStateResource;
 use ferrumc_text::TextComponent;
 use ferrumc_world::{block_id::BlockId, vanilla_chunk_format::BlockData};
 use nom::IResult;
+use std::iter;
 use tracing::warn;
 
 use crate::systems::chat_message;
@@ -53,18 +63,22 @@ pub struct CommandContext<'a> {
 /// Dispatcher that routes parsed commands to their handlers.
 #[derive(Default, Resource)]
 pub struct CommandDispatcher {
-    commands:
-        Vec<Box<dyn for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync + 'static>>,
+    commands: Vec<Box<dyn for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync + 'static>>,
 }
 
 impl CommandDispatcher {
     /// Creates a new empty dispatcher.
     pub fn new() -> Self {
-        Self { commands: Vec::new() }
+        Self {
+            commands: Vec::new(),
+        }
     }
 
     /// Registers a command parser.
-    pub fn register(&mut self, parser: impl for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync + 'static) {
+    pub fn register(
+        &mut self,
+        parser: impl for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync + 'static,
+    ) {
         self.commands.push(Box::new(parser));
     }
 
@@ -76,7 +90,19 @@ impl CommandDispatcher {
                 return;
             }
         }
+        send_feedback(ctx, format!("Unknown command: {}", line));
         warn!("Unknown command: {}", line);
+    }
+}
+
+fn send_feedback(ctx: CommandContext, msg: String) {
+    unsafe {
+        let query = &mut *ctx.query;
+        let state = &*ctx.state;
+        if let Ok((_, conn, _, _, _)) = query.get_mut(ctx.sender) {
+            let text = TextComponent::from(msg);
+            chat_message::broadcast_text(text, iter::once((ctx.sender, conn)), state);
+        }
     }
 }
 
@@ -84,7 +110,11 @@ impl CommandDispatcher {
 pub struct WordArgument;
 
 impl<S> CommandArgument<S, String> for WordArgument {
-    fn parse<'a>(&self, _source: S, input: &'a str) -> IResult<&'a str, String, brigadier_rs::CommandError<'a>> {
+    fn parse<'a>(
+        &self,
+        _source: S,
+        input: &'a str,
+    ) -> IResult<&'a str, String, brigadier_rs::CommandError<'a>> {
         let input = input.trim_start();
         let mut end = 0;
         for (idx, ch) in input.char_indices() {
@@ -102,7 +132,10 @@ impl<S, E> Then<E> for WordArgument {
     type Output = brigadier_rs::parsers::CommandThen<Self, E, String, S>;
 
     fn then(self, executor: E) -> Self::Output {
-        brigadier_rs::parsers::CommandThen { argument: self, executor }
+        brigadier_rs::parsers::CommandThen {
+            argument: self,
+            executor,
+        }
     }
 }
 
@@ -114,7 +147,11 @@ pub fn word() -> WordArgument {
 pub struct RestArgument;
 
 impl<S> CommandArgument<S, String> for RestArgument {
-    fn parse<'a>(&self, _source: S, input: &'a str) -> IResult<&'a str, String, brigadier_rs::CommandError<'a>> {
+    fn parse<'a>(
+        &self,
+        _source: S,
+        input: &'a str,
+    ) -> IResult<&'a str, String, brigadier_rs::CommandError<'a>> {
         let input = input.trim_start();
         Ok(("", input.to_string()))
     }
@@ -124,7 +161,10 @@ impl<S, E> Then<E> for RestArgument {
     type Output = brigadier_rs::parsers::CommandThen<Self, E, String, S>;
 
     fn then(self, executor: E) -> Self::Output {
-        brigadier_rs::parsers::CommandThen { argument: self, executor }
+        brigadier_rs::parsers::CommandThen {
+            argument: self,
+            executor,
+        }
     }
 }
 
@@ -155,33 +195,41 @@ pub fn say_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Sen
 pub fn tp_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync {
     literal("tp")
         .then(
-            float_64("x").then(
-                float_64("y").then(
-                    float_64("z").build_exec(|ctx, x, y, z| {
-                        unsafe {
-                            let query = &mut *ctx.query;
-                            if let Ok((_, conn, mut pos, _, _)) = query.get_mut(ctx.sender) {
-                                pos.x = x;
-                                pos.y = y;
-                                pos.z = z;
-                                let teleport_id_i32 = (rand::random::<u32>() & 0x3FFF_FFFF) as i32;
-                                let packet = SynchronizePlayerPositionPacket::new(
-                                    (x, y, z),
-                                    (0.0, 0.0, 0.0),
-                                    0.0,
-                                    0.0,
-                                    0,
-                                    VarInt::new(teleport_id_i32),
-                                );
-                                let _ = conn.send_packet_ref(&packet);
-                            } else {
-                                warn!("Sender entity {:?} not found for tp", ctx.sender);
-                            }
+            float_64("x").then(float_64("y").then(float_64("z").build_exec(|ctx, x, y, z| {
+                unsafe {
+                    let query = &mut *ctx.query;
+                    let state = &*ctx.state;
+                    if let Ok((_, conn, mut pos, _, identity)) = query.get_mut(ctx.sender) {
+                        if identity.permission_level < 2 {
+                            let text = TextComponent::from("You do not have permission to use /tp");
+                            chat_message::broadcast_text(
+                                text,
+                                iter::once((ctx.sender, conn)),
+                                state,
+                            );
+                            return Ok::<(), Infallible>(());
                         }
-                        Ok::<(), Infallible>(())
-                    }),
-                ),
-            ),
+                        pos.x = x;
+                        pos.y = y;
+                        pos.z = z;
+                        let teleport_id_i32 = (rand::random::<u32>() & 0x3FFF_FFFF) as i32;
+                        let packet = SynchronizePlayerPositionPacket::new(
+                            (x, y, z),
+                            (0.0, 0.0, 0.0),
+                            0.0,
+                            0.0,
+                            0,
+                            VarInt::new(teleport_id_i32),
+                        );
+                        let _ = conn.send_packet_ref(&packet);
+                        let text = TextComponent::from(format!("Teleported to {x} {y} {z}"));
+                        chat_message::broadcast_text(text, iter::once((ctx.sender, conn)), state);
+                    } else {
+                        warn!("Sender entity {:?} not found for tp", ctx.sender);
+                    }
+                }
+                Ok::<(), Infallible>(())
+            }))),
         )
         .build_exec(|_ctx| Ok::<(), Infallible>(()))
 }
@@ -190,10 +238,13 @@ pub fn tp_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Send
 pub fn give_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync {
     literal("give")
         .then(
-            word().then(integer_i32("count").build_exec(|ctx, item: String, count: i32| {
-                give_handler(ctx, item, count as u8)
-            }))
-            .build_exec(|ctx, item: String| give_handler(ctx, item, 1)),
+            word()
+                .then(
+                    integer_i32("count").build_exec(|ctx, item: String, count: i32| {
+                        give_handler(ctx, item, count as u8)
+                    }),
+                )
+                .build_exec(|ctx, item: String| give_handler(ctx, item, 1)),
         )
         .build_exec(|_ctx| Ok::<(), Infallible>(()))
 }
@@ -201,17 +252,28 @@ pub fn give_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Se
 fn give_handler(ctx: CommandContext, item: String, count: u8) -> Result<(), Infallible> {
     unsafe {
         let query = &mut *ctx.query;
-        if let Ok((_, conn, _, mut inv, _)) = query.get_mut(ctx.sender) {
+        let state = &*ctx.state;
+        if let Ok((_, conn, _, mut inv, identity)) = query.get_mut(ctx.sender) {
+            if identity.permission_level < 2 {
+                let text = TextComponent::from("You do not have permission to use /give");
+                chat_message::broadcast_text(text, iter::once((ctx.sender, conn)), state);
+                return Ok(());
+            }
             let name = if item.contains(':') {
                 item
             } else {
                 format!("minecraft:{}", item)
             };
-            let block = BlockId::from_block_data(&BlockData { name, properties: None });
-            let stack = ItemStack::new(block, count);
+            let block = BlockId::from_block_data(&BlockData {
+                name: name.clone(),
+                properties: None,
+            });
+            let stack = ItemStack::new(block, count, 64, None);
             inv.hotbar[0] = Some(stack.clone());
             let packet = ContainerSetSlotPacket::new(0, 0, 0, Some(&stack));
             let _ = conn.send_packet_ref(&packet);
+            let text = TextComponent::from(format!("Gave {} x{}", name, count));
+            chat_message::broadcast_text(text, iter::once((ctx.sender, conn)), state);
         } else {
             warn!("Sender entity {:?} not found for give", ctx.sender);
         }
@@ -226,7 +288,13 @@ pub fn gamemode_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> 
             unsafe {
                 let query = &mut *ctx.query;
                 let state = &*ctx.state;
-                if let Ok((entity, _conn, _pos, _inv, identity)) = query.get_mut(ctx.sender) {
+                if let Ok((entity, conn, _pos, _inv, identity)) = query.get_mut(ctx.sender) {
+                    if identity.permission_level < 2 {
+                        let text =
+                            TextComponent::from("You do not have permission to use /gamemode");
+                        chat_message::broadcast_text(text, iter::once((ctx.sender, conn)), state);
+                        return Ok::<(), Infallible>(());
+                    }
                     let gm = match mode.as_str() {
                         "0" | "survival" => 0,
                         "1" | "creative" => 1,
@@ -239,12 +307,11 @@ pub fn gamemode_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> 
                     };
                     // drop borrow before iterating over all players
                     let uuid = identity.short_uuid;
-                    drop((entity, _conn, _pos, _inv, identity));
+                    drop((entity, conn, _pos, _inv, identity));
 
-                    let packet =
-                        PlayerInfoUpdatePacket::with_players(vec![PlayerWithActions::update_game_mode(
-                            uuid, gm,
-                        )]);
+                    let packet = PlayerInfoUpdatePacket::with_players(vec![
+                        PlayerWithActions::update_game_mode(uuid, gm),
+                    ]);
 
                     for (e, conn, _, _, _) in query.iter_mut() {
                         if !state.0.players.is_connected(e) {
@@ -256,8 +323,19 @@ pub fn gamemode_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> 
                     warn!("Sender entity {:?} not found for gamemode", ctx.sender);
                 }
             }
+            send_feedback(ctx, format!("Set own gamemode to {}", mode));
             Ok::<(), Infallible>(())
         }))
         .build_exec(|_ctx| Ok::<(), Infallible>(()))
 }
 
+/// `/help` command listing available commands.
+pub fn help_command() -> impl for<'a> CommandParser<CommandContext<'a>, ()> + Send + Sync {
+    literal("help").build_exec(|ctx| {
+        send_feedback(
+            ctx,
+            "Available commands: say, tp, give, gamemode, help".to_string(),
+        );
+        Ok::<(), Infallible>(())
+    })
+}

--- a/src/lib/core/src/identity/player_identity.rs
+++ b/src/lib/core/src/identity/player_identity.rs
@@ -1,11 +1,21 @@
 use bevy_ecs::prelude::Component;
 use typename::TypeName;
 
+/// Identity information for a player, including permission level.
+///
+/// # Examples
+/// ```
+/// use ferrumc_core::identity::player_identity::PlayerIdentity;
+/// let id = PlayerIdentity::new("Steve".into(), 42);
+/// assert_eq!(id.permission_level, 0);
+/// ```
 #[derive(TypeName, Debug, Component, Default, Clone)]
 pub struct PlayerIdentity {
     pub username: String,
     pub uuid: uuid::Uuid,
     pub short_uuid: i32,
+    /// Permission level of the player.
+    pub permission_level: u8,
 }
 
 impl PlayerIdentity {
@@ -14,6 +24,7 @@ impl PlayerIdentity {
             username,
             uuid: uuid::Uuid::from_u128(uuid),
             short_uuid: uuid as i32,
+            permission_level: 0,
         }
     }
 }

--- a/src/lib/net/src/conn_init/login.rs
+++ b/src/lib/net/src/conn_init/login.rs
@@ -1,4 +1,3 @@
-use crate::ConnState::*;
 use crate::auth::verify_session;
 use crate::compression::compress_packet;
 use crate::conn_init::VarInt;
@@ -10,6 +9,7 @@ use crate::packets::incoming::packet_skeleton::PacketSkeleton;
 use crate::packets::outgoing::container_set_content::ContainerSetContentPacket;
 use crate::packets::outgoing::known_packs::{ClientboundKnownPacks, KnownPack as ClientKnownPack};
 use crate::packets::outgoing::login_disconnect::LoginDisconnectPacket;
+use crate::ConnState::*;
 use ferrumc_config::server_config::get_global_config;
 use ferrumc_core::identity::player_identity::PlayerIdentity;
 use ferrumc_core::inventory::Inventory;
@@ -212,6 +212,7 @@ pub(super) async fn login<R: AsyncRead + Unpin>(
         uuid: Uuid::from_u128(player_uuid),
         username: login_start.username.clone(),
         short_uuid: player_uuid as i32,
+        permission_level: 0,
     };
 
     // =============================================================================================


### PR DESCRIPTION
## Summary
- add permission levels to player identity
- integrate permission checks and feedback for commands
- add `/help` command and documentation examples

## Testing
- `cargo +nightly test -p ferrumc-core`
- `cargo +nightly test -p ferrumc` *(fails: Could not find key: `minecraft:chat_message` in the packet registry)*

------
https://chatgpt.com/codex/tasks/task_b_689aaecb80a08329a22b87c7da2a7080