### PR TITLE
feat(chat): add signatures and filters

### DIFF
--- a/src/lib/core/src/conn/chat_filter.rs
+++ b/src/lib/core/src/conn/chat_filter.rs
@@ -1,0 +1,36 @@
+use bevy_ecs::entity::Entity;
+use once_cell::sync::Lazy;
+use std::sync::RwLock;
+
+/// Trait for filtering chat messages from clients.
+/// Return `None` to drop the message, or `Some` to continue with a possibly
+/// modified version.
+pub trait ChatFilter: Send + Sync + 'static {
+    fn filter(&self, entity: Entity, message: &str) -> Option<String>;
+}
+
+static CHAT_FILTERS: Lazy<RwLock<Vec<Box<dyn ChatFilter>>>> = Lazy::new(|| RwLock::new(Vec::new()));
+
+/// Register a new chat filter. Filters are executed in the order they are
+/// registered.
+pub fn register_filter<F: ChatFilter>(filter: F) {
+    if let Ok(mut filters) = CHAT_FILTERS.write() {
+        filters.push(Box::new(filter));
+    }
+}
+
+/// Apply all registered chat filters to a message.
+/// If any filter returns `None`, the chain is aborted and `None` is returned.
+pub fn filter_message(entity: Entity, message: &str) -> Option<String> {
+    let mut current = Some(message.to_string());
+    if let Ok(filters) = CHAT_FILTERS.read() {
+        for f in filters.iter() {
+            if let Some(ref msg) = current {
+                current = f.filter(entity, msg);
+            } else {
+                break;
+            }
+        }
+    }
+    current
+}

--- a/src/lib/core/src/conn/mod.rs
+++ b/src/lib/core/src/conn/mod.rs
@@ -2,3 +2,6 @@ pub mod force_player_recount_event;
 pub mod keepalive;
 pub mod player_count_update_cooldown;
 pub mod plugin_message;
+pub mod chat_filter;
+
+pub use chat_filter::{filter_message, register_filter, ChatFilter};

--- a/src/lib/net/crates/codec/src/net_types/prefixed_optional.rs
+++ b/src/lib/net/crates/codec/src/net_types/prefixed_optional.rs
@@ -6,7 +6,7 @@ use bitcode::{Decode, Encode};
 use std::io::{Read, Write};
 use tokio::io::{AsyncRead, AsyncWrite};
 
-#[derive(Encode, Decode)]
+#[derive(Encode, Decode, Clone, Debug)]
 pub enum PrefixedOptional<T> {
     None,
     Some(T),

--- a/src/lib/net/src/packets/incoming/chat_ack.rs
+++ b/src/lib/net/src/packets/incoming/chat_ack.rs
@@ -1,5 +1,8 @@
 use ferrumc_macros::{packet, NetDecode};
+use ferrumc_net_codec::net_types::var_int::VarInt;
 
 #[derive(NetDecode)]
 #[packet(packet_id = "chat_ack", state = "play")]
-pub struct ChatAckPacket;
+pub struct ChatAckPacket {
+    pub count: VarInt,
+}

--- a/src/lib/net/src/packets/incoming/chat_message.rs
+++ b/src/lib/net/src/packets/incoming/chat_message.rs
@@ -1,7 +1,9 @@
 use ferrumc_macros::{NetDecode, packet};
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
 
 #[derive(NetDecode, Debug)]
 #[packet(packet_id = "chat_message", state = "play")]
 pub struct IncomingChatMessagePacket {
     pub message: String,
+    pub signature: PrefixedOptional<String>,
 }

--- a/src/lib/net/src/packets/outgoing/chat_message.rs
+++ b/src/lib/net/src/packets/outgoing/chat_message.rs
@@ -1,4 +1,5 @@
 use ferrumc_macros::{NetEncode, packet};
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
 use ferrumc_text::TextComponent;
 use std::io::Write;
 
@@ -6,10 +7,15 @@ use std::io::Write;
 #[packet(packet_id = "chat_message", state = "play")]
 pub struct OutgoingChatMessagePacket {
     pub message: TextComponent,
+    pub signature: PrefixedOptional<String>,
 }
 
 impl OutgoingChatMessagePacket {
     pub fn new(message: TextComponent) -> Self {
-        Self { message }
+        Self { message, signature: PrefixedOptional::None }
+    }
+
+    pub fn with_signature(message: TextComponent, signature: Option<String>) -> Self {
+        Self { message, signature: PrefixedOptional::new(signature) }
     }
 }

--- a/src/lib/text/src/impl.rs
+++ b/src/lib/text/src/impl.rs
@@ -88,6 +88,21 @@ impl TextComponent {
     );
     make_bool_setters!(bold, italic, underlined, strikethrough, obfuscated);
 
+    /// Convert this component into its JSON representation.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string(self).unwrap_or_default()
+    }
+
+    /// Create a component from a JSON string.
+    pub fn from_json<S: AsRef<str>>(s: S) -> serde_json::Result<Self> {
+        serde_json::from_str(s.as_ref())
+    }
+
+    /// Convenience method to create a translation component.
+    pub fn translate_key<S: Into<String>>(key: S, with: Vec<TextComponent>) -> Self {
+        ComponentBuilder::translate(key, with)
+    }
+
     pub fn serialize_nbt(&self) -> Vec<u8> {
         let mut vec = Vec::new();
         NBTSerializable::serialize(self, &mut vec, &NBTSerializeOptions::Network);

--- a/src/lib/text/src/tests.rs
+++ b/src/lib/text/src/tests.rs
@@ -177,3 +177,14 @@ fn test_serialize_to_nbt() {
         bytes_to_readable_string(&cursor.get_ref()[cursor.position() as usize..])
     );
 }
+
+#[test]
+fn json_roundtrip_and_translation() {
+    let component = TextComponent::translate_key(
+        "chat.type.text",
+        vec![TextComponent::from("Alice"), TextComponent::from("Hello")],
+    );
+    let json = component.to_json();
+    let parsed = TextComponent::from_json(&json).unwrap();
+    assert_eq!(component, parsed);
+}

--- a/src/tests/Cargo.toml
+++ b/src/tests/Cargo.toml
@@ -11,6 +11,7 @@ ferrumc-net = { workspace = true }
 ferrumc-config = { workspace = true }
 bevy_ecs = { workspace = true}
 ferrumc-core = { workspace = true }
+ferrumc-text = { workspace = true }
 flate2 = { workspace = true }
 tokio = { workspace = true }
 maplit = { workspace = true }

--- a/src/tests/src/net/chat.rs
+++ b/src/tests/src/net/chat.rs
@@ -1,0 +1,37 @@
+use ferrumc_net::packets::incoming::{chat_ack::ChatAckPacket, chat_message::IncomingChatMessagePacket};
+use ferrumc_net::packets::outgoing::chat_message::OutgoingChatMessagePacket;
+use ferrumc_net_codec::decode::{NetDecode, NetDecodeOpts};
+use ferrumc_net_codec::encode::{NetEncode, NetEncodeOpts};
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use ferrumc_text::TextComponent;
+use std::io::{Cursor, Write};
+
+#[test]
+fn encode_signed_outgoing_message() {
+    let msg = TextComponent::from("hi");
+    let pkt = OutgoingChatMessagePacket::with_signature(msg, Some("sig".into()));
+    let mut buf = Vec::new();
+    pkt.encode(&mut buf, &NetEncodeOpts::WithLength).unwrap();
+    assert!(!buf.is_empty());
+}
+
+#[test]
+fn decode_signed_incoming_message_and_ack() {
+    let mut bytes = Vec::new();
+    // message length + bytes
+    VarInt::new(2).encode(&mut bytes, &NetEncodeOpts::None).unwrap();
+    bytes.write_all(b"hi").unwrap();
+    // signature present + value
+    true.encode(&mut bytes, &NetEncodeOpts::None).unwrap();
+    "sig".encode(&mut bytes, &NetEncodeOpts::None).unwrap();
+    let mut cursor = Cursor::new(bytes);
+    let pkt = IncomingChatMessagePacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(pkt.message, "hi");
+    assert!(pkt.signature.is_some());
+
+    let mut ack_bytes = Vec::new();
+    VarInt::new(1).encode(&mut ack_bytes, &NetEncodeOpts::None).unwrap();
+    let mut cursor = Cursor::new(ack_bytes);
+    let ack = ChatAckPacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(ack.count.0, 1);
+}

--- a/src/tests/src/net/mod.rs
+++ b/src/tests/src/net/mod.rs
@@ -5,3 +5,4 @@ mod login_respawn;
 mod offline_login;
 mod player_actions;
 mod recipe_packets;
+mod chat;


### PR DESCRIPTION
## Summary
- support optional chat signatures and acknowledgement counts in packet types
- add server-side chat filter hooks for customizable moderation
- expose JSON helpers and translation-key builders for text components
- add tests for signed chat and formatted JSON text

## Testing
- `cargo +nightly test -p ferrumc-text`
- `cargo +nightly test -p ferrumc-tests` *(fails: missing field `block_entities` in existing chunk test)*

------
https://chatgpt.com/codex/tasks/task_b_689ac8a272cc8329a336b5624b81ca3a