### PR TITLE
Add RGB/HEX color helpers for text components

### DIFF
--- a/src/lib/text/src/builders.rs
+++ b/src/lib/text/src/builders.rs
@@ -83,6 +83,18 @@ impl TextComponentBuilder {
     );
     make_bool_setters!(bold, italic, underlined, strikethrough, obfuscated);
 
+    /// Set a custom color using a hex string (e.g. "#ff00ff").
+    pub fn color_hex(mut self, hex: impl AsRef<str>) -> Result<Self, ColorError> {
+        self.color = Some(hex_color(hex)?);
+        Ok(self)
+    }
+
+    /// Set a custom color using RGB components.
+    pub fn color_rgb(mut self, r: u8, g: u8, b: u8) -> Self {
+        self.color = Some(rgb_color(r, g, b));
+        self
+    }
+
     pub fn space(self) -> Self {
         self.extra(ComponentBuilder::space())
     }

--- a/src/lib/text/src/impl.rs
+++ b/src/lib/text/src/impl.rs
@@ -88,6 +88,18 @@ impl TextComponent {
     );
     make_bool_setters!(bold, italic, underlined, strikethrough, obfuscated);
 
+    /// Set a custom color using a hex string (e.g. "#ff00ff").
+    pub fn color_hex(mut self, hex: impl AsRef<str>) -> Result<Self, ColorError> {
+        self.color = Some(hex_color(hex)?);
+        Ok(self)
+    }
+
+    /// Set a custom color using RGB components.
+    pub fn color_rgb(mut self, r: u8, g: u8, b: u8) -> Self {
+        self.color = Some(rgb_color(r, g, b));
+        self
+    }
+
     /// Convert this component into its JSON representation.
     pub fn to_json(&self) -> String {
         serde_json::to_string(self).unwrap_or_default()

--- a/src/lib/text/src/tests.rs
+++ b/src/lib/text/src/tests.rs
@@ -83,6 +83,27 @@ fn test_to_string() {
     assert_eq!(component.to_string(), Text::keybind("key.jump").to_string());
 }
 
+#[test]
+fn custom_color_builders() {
+    let named = ComponentBuilder::text("named")
+        .color(NamedColor::Red)
+        .build();
+    assert_eq!(named.color, Some("red".to_string()));
+
+    let hex = ComponentBuilder::text("hex")
+        .color_hex("#aabbcc")
+        .unwrap()
+        .build();
+    assert_eq!(hex.color, Some("#aabbcc".to_string()));
+
+    let rgb = ComponentBuilder::text("rgb")
+        .color_rgb(0xaa, 0xbb, 0xcc)
+        .build();
+    assert_eq!(rgb.color, Some("#aabbcc".to_string()));
+
+    assert!(ComponentBuilder::text("bad").color_hex("zzzzzz").is_err());
+}
+
 use ferrumc_macros::{packet, NetEncode};
 use ferrumc_nbt::NBTSerializable;
 use ferrumc_nbt::NBTSerializeOptions;

--- a/src/lib/text/src/utils.rs
+++ b/src/lib/text/src/utils.rs
@@ -45,18 +45,55 @@ macro_rules! make_setters {
     }
 }
 
-// TODO: better api for custom colors
-#[derive(Serialize, Deserialize, Debug, PartialEq, Clone, NBTSerialize)]
-#[serde(untagged)]
-#[nbt(tag_type = 8)]
-pub enum Color {
-    Named(NamedColor),
-    Hex(String),
+pub type Color = String;
+
+/// Errors that can occur when parsing custom colors.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ColorError {
+    /// Provided hex string was not valid.
+    InvalidHex,
 }
 
-impl From<NamedColor> for Color {
+/// Convert RGB values into a hex color string.
+pub fn rgb_color(r: u8, g: u8, b: u8) -> Color {
+    format!("#{r:02x}{g:02x}{b:02x}")
+}
+
+/// Validate and normalise a hex color string.
+pub fn hex_color<S: AsRef<str>>(hex: S) -> Result<Color, ColorError> {
+    let h = hex.as_ref();
+    let h = if let Some(stripped) = h.strip_prefix('#') {
+        stripped
+    } else {
+        h
+    };
+    if h.len() != 6 || !h.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(ColorError::InvalidHex);
+    }
+    Ok(format!("#{}", h.to_lowercase()))
+}
+
+impl From<NamedColor> for String {
     fn from(value: NamedColor) -> Self {
-        Self::Named(value)
+        match value {
+            NamedColor::Black => "black",
+            NamedColor::DarkBlue => "dark_blue",
+            NamedColor::DarkGreen => "dark_green",
+            NamedColor::DarkAqua => "dark_aqua",
+            NamedColor::DarkRed => "dark_red",
+            NamedColor::DarkPurple => "dark_purple",
+            NamedColor::Gold => "gold",
+            NamedColor::Gray => "gray",
+            NamedColor::DarkGray => "dark_gray",
+            NamedColor::Blue => "blue",
+            NamedColor::Green => "green",
+            NamedColor::Aqua => "aqua",
+            NamedColor::Red => "red",
+            NamedColor::LightPurple => "light_purple",
+            NamedColor::Yellow => "yellow",
+            NamedColor::White => "white",
+        }
+        .to_string()
     }
 }
 


### PR DESCRIPTION
## Summary
- replace Color enum with validated RGB/HEX helpers
- add custom color builder methods on TextComponent and its builder
- test named and custom color serialization

## Testing
- `cargo +nightly test -p ferrumc-text`

------
https://chatgpt.com/codex/tasks/task_b_689bf806f2b8832992be7188931a7286