### PR TITLE
Refine world generation with real noise settings and structure placement

### DIFF
--- a/src/lib/world_gen/src/nether.rs
+++ b/src/lib/world_gen/src/nether.rs
@@ -2,12 +2,15 @@ use crate::biomes::simple::{SimpleBiome, Veg};
 use crate::errors::WorldGenError;
 use crate::noise_settings::NETHER_NOISE_SETTINGS;
 use crate::{BiomeGenerator, NoiseGenerator};
+use crate::structures::StructurePlacer;
 use ferrumc_world::chunk_format::Chunk;
 
 /// Basic nether terrain generator.
 pub struct NetherGenerator {
     noise: NoiseGenerator,
     biome: SimpleBiome,
+    structures: Vec<Box<dyn StructurePlacer + Send + Sync>>,
+    seed: u64,
 }
 
 impl NetherGenerator {
@@ -24,10 +27,20 @@ impl NetherGenerator {
                 Veg::None,
                 32.0,
             ),
+            structures: vec![],
+            seed,
+        }
+    }
+
+    fn apply_structures(&self, chunk: &mut Chunk) {
+        for s in &self.structures {
+            s.place(chunk, self.seed);
         }
     }
 
     pub fn generate_chunk(&self, x: i32, z: i32) -> Result<Chunk, WorldGenError> {
-        self.biome.generate_chunk(x, z, &self.noise)
+        let mut chunk = self.biome.generate_chunk(x, z, &self.noise)?;
+        self.apply_structures(&mut chunk);
+        Ok(chunk)
     }
 }

--- a/src/lib/world_gen/src/noise_settings.rs
+++ b/src/lib/world_gen/src/noise_settings.rs
@@ -1,12 +1,49 @@
-/// Placeholder for Minecraft 1.20.1 noise settings.
+/// Noise configuration values matching the official Minecraft 1.20.1 settings.
 ///
-/// These values do not fully replicate the vanilla implementation but
-/// provide a hook for future expansion.
+/// Only a small subset of the full vanilla data is represented here but these
+/// values mirror the canonical datapack to give generators predictable output.
 #[derive(Clone, Copy)]
 pub struct NoiseSettings {
-    pub scale: f64,
+    /// Minimum Y coordinate of the noise grid.
+    pub min_y: i32,
+    /// Total vertical height of the noise grid.
+    pub height: i32,
+    /// Horizontal noise sampling scale.
+    pub xz_scale: f64,
+    /// Vertical noise sampling scale.
+    pub y_scale: f64,
+    /// Horizontal factor applied to the noise coordinates.
+    pub xz_factor: f64,
+    /// Vertical factor applied to the noise coordinates.
+    pub y_factor: f64,
 }
 
-pub const OVERWORLD_NOISE_SETTINGS: NoiseSettings = NoiseSettings { scale: 64.0 };
-pub const NETHER_NOISE_SETTINGS: NoiseSettings = NoiseSettings { scale: 32.0 };
-pub const END_NOISE_SETTINGS: NoiseSettings = NoiseSettings { scale: 32.0 };
+/// Overworld noise settings copied from the 1.20.1 data pack
+pub const OVERWORLD_NOISE_SETTINGS: NoiseSettings = NoiseSettings {
+    min_y: -64,
+    height: 384,
+    xz_scale: 1.0,
+    y_scale: 1.0,
+    xz_factor: 80.0,
+    y_factor: 160.0,
+};
+
+/// Nether noise settings copied from the 1.20.1 data pack
+pub const NETHER_NOISE_SETTINGS: NoiseSettings = NoiseSettings {
+    min_y: 0,
+    height: 128,
+    xz_scale: 1.0,
+    y_scale: 3.0,
+    xz_factor: 80.0,
+    y_factor: 60.0,
+};
+
+/// End noise settings copied from the 1.20.1 data pack
+pub const END_NOISE_SETTINGS: NoiseSettings = NoiseSettings {
+    min_y: 0,
+    height: 128,
+    xz_scale: 2.0,
+    y_scale: 1.0,
+    xz_factor: 80.0,
+    y_factor: 160.0,
+};

--- a/src/lib/world_gen/src/structures/mod.rs
+++ b/src/lib/world_gen/src/structures/mod.rs
@@ -1,6 +1,44 @@
 pub trait StructurePlacer {
-    fn place(&self, chunk: &mut ferrumc_world::chunk_format::Chunk);
+    /// Attempts to place the structure in the provided chunk.
+    ///
+    /// The `seed` is used for deterministic placement following the
+    /// vanilla structure spacing algorithm.
+    fn place(&self, chunk: &mut ferrumc_world::chunk_format::Chunk, seed: u64);
 }
 
 pub mod temple;
 pub mod village;
+
+use rand::{Rng, SeedableRng};
+
+fn floor_div(a: i32, b: i32) -> i32 {
+    let mut r = a / b;
+    if (a ^ b) < 0 && a % b != 0 {
+        r -= 1;
+    }
+    r
+}
+
+/// Determines whether a structure should attempt placement in the given chunk
+/// using the vanilla spacing and separation algorithm.
+pub fn should_place_structure(
+    seed: u64,
+    salt: u64,
+    spacing: i32,
+    separation: i32,
+    chunk_x: i32,
+    chunk_z: i32,
+) -> bool {
+    let region_x = floor_div(chunk_x, spacing);
+    let region_z = floor_div(chunk_z, spacing);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(
+        (region_x as i64 * 341_873_128_712 + region_z as i64 * 132_897_987_541
+            + seed as i64
+            + salt as i64) as u64,
+    );
+    let offset_x = rng.random_range(0..(spacing - separation));
+    let offset_z = rng.random_range(0..(spacing - separation));
+    let candidate_x = region_x * spacing + offset_x;
+    let candidate_z = region_z * spacing + offset_z;
+    chunk_x == candidate_x && chunk_z == candidate_z
+}

--- a/src/lib/world_gen/src/structures/temple.rs
+++ b/src/lib/world_gen/src/structures/temple.rs
@@ -1,11 +1,14 @@
-use super::StructurePlacer;
+use super::{should_place_structure, StructurePlacer};
 use ferrumc_world::chunk_format::Chunk;
 use ferrumc_world::vanilla_chunk_format::BlockData;
 
 pub struct Temple;
 
 impl StructurePlacer for Temple {
-    fn place(&self, chunk: &mut Chunk) {
+    fn place(&self, chunk: &mut Chunk, seed: u64) {
+        if !should_place_structure(seed, 14_357_617, 32, 8, chunk.x, chunk.z) {
+            return;
+        }
         let block = BlockData {
             name: "minecraft:mossy_cobblestone".into(),
             properties: None,

--- a/src/lib/world_gen/src/structures/village.rs
+++ b/src/lib/world_gen/src/structures/village.rs
@@ -1,11 +1,14 @@
-use super::StructurePlacer;
+use super::{should_place_structure, StructurePlacer};
 use ferrumc_world::chunk_format::Chunk;
 use ferrumc_world::vanilla_chunk_format::BlockData;
 
 pub struct Village;
 
 impl StructurePlacer for Village {
-    fn place(&self, chunk: &mut Chunk) {
+    fn place(&self, chunk: &mut Chunk, seed: u64) {
+        if !should_place_structure(seed, 10_387_312, 32, 8, chunk.x, chunk.z) {
+            return;
+        }
         let block = BlockData {
             name: "minecraft:cobblestone".into(),
             properties: None,


### PR DESCRIPTION
## Summary
- implement 1.20.1-derived noise settings and scale-aware noise sampling
- add surface, carver, feature passes and deterministic structure placement
- wire end and nether generators for structure hooks

## Testing
- `cargo +nightly test -p ferrumc-world-gen`

------
https://chatgpt.com/codex/tasks/task_b_689c0f0738a88329b54d19037e47f9bf