### PR TITLE
Add structure templates with randomized chunk placement

### DIFF
--- a/src/lib/world_gen/src/structures/mod.rs
+++ b/src/lib/world_gen/src/structures/mod.rs
@@ -6,6 +6,7 @@ pub trait StructurePlacer {
     fn place(&self, chunk: &mut ferrumc_world::chunk_format::Chunk, seed: u64);
 }
 
+pub mod template;
 pub mod temple;
 pub mod village;
 
@@ -32,7 +33,8 @@ pub fn should_place_structure(
     let region_x = floor_div(chunk_x, spacing);
     let region_z = floor_div(chunk_z, spacing);
     let mut rng = rand::rngs::StdRng::seed_from_u64(
-        (region_x as i64 * 341_873_128_712 + region_z as i64 * 132_897_987_541
+        (region_x as i64 * 341_873_128_712
+            + region_z as i64 * 132_897_987_541
             + seed as i64
             + salt as i64) as u64,
     );

--- a/src/lib/world_gen/src/structures/template.rs
+++ b/src/lib/world_gen/src/structures/template.rs
@@ -1,0 +1,119 @@
+use ferrumc_world::chunk_format::Chunk;
+use ferrumc_world::vanilla_chunk_format::BlockData;
+use rand::{Rng, SeedableRng};
+use serde::Deserialize;
+use tracing::warn;
+
+#[derive(Clone, Copy, Debug)]
+pub struct BoundingBox {
+    pub min_x: i32,
+    pub min_y: i32,
+    pub min_z: i32,
+    pub max_x: i32,
+    pub max_y: i32,
+    pub max_z: i32,
+}
+
+impl BoundingBox {
+    fn new() -> Self {
+        BoundingBox {
+            min_x: i32::MAX,
+            min_y: i32::MAX,
+            min_z: i32::MAX,
+            max_x: i32::MIN,
+            max_y: i32::MIN,
+            max_z: i32::MIN,
+        }
+    }
+
+    fn update(&mut self, x: i32, y: i32, z: i32) {
+        self.min_x = self.min_x.min(x);
+        self.min_y = self.min_y.min(y);
+        self.min_z = self.min_z.min(z);
+        self.max_x = self.max_x.max(x);
+        self.max_y = self.max_y.max(y);
+        self.max_z = self.max_z.max(z);
+    }
+}
+
+#[derive(Deserialize)]
+struct BlockDef {
+    x: i32,
+    y: i32,
+    z: i32,
+    block: String,
+}
+
+#[derive(Deserialize)]
+struct TemplateDef {
+    blocks: Vec<BlockDef>,
+}
+
+pub struct StructureTemplate {
+    blocks: Vec<BlockDef>,
+    bounding_box: BoundingBox,
+}
+
+impl StructureTemplate {
+    pub fn from_json(data: &[u8]) -> Self {
+        let def: TemplateDef =
+            serde_json::from_slice(data).expect("structure template must be valid json");
+        let mut bb = BoundingBox::new();
+        for b in &def.blocks {
+            bb.update(b.x, b.y, b.z);
+        }
+        StructureTemplate {
+            blocks: def.blocks,
+            bounding_box: bb,
+        }
+    }
+
+    pub fn bounding_box(&self) -> BoundingBox {
+        self.bounding_box
+    }
+
+    pub fn place_randomized(&self, chunk: &mut Chunk, seed: u64, origin_y: i32) {
+        let chunk_origin_x = chunk.x * 16;
+        let chunk_origin_z = chunk.z * 16;
+        let mut rng =
+            rand::rngs::StdRng::seed_from_u64(seed ^ ((chunk.x as u64) << 32) ^ chunk.z as u64);
+        let rotation = rng.random_range(0..4) as u8;
+
+        for block in &self.blocks {
+            let (rx, rz) = rotate(block.x, block.z, rotation);
+            let world_x = chunk_origin_x + rx;
+            let world_y = origin_y + block.y;
+            let world_z = chunk_origin_z + rz;
+
+            if world_x < chunk_origin_x
+                || world_x >= chunk_origin_x + 16
+                || world_z < chunk_origin_z
+                || world_z >= chunk_origin_z + 16
+            {
+                continue;
+            }
+
+            let block_data = BlockData {
+                name: block.block.clone(),
+                properties: None,
+            };
+            if let Err(e) = chunk.set_block(
+                world_x - chunk_origin_x,
+                world_y,
+                world_z - chunk_origin_z,
+                block_data.to_block_id(),
+            ) {
+                warn!("structure placement failed: {e}");
+            }
+        }
+    }
+}
+
+fn rotate(x: i32, z: i32, rotation: u8) -> (i32, i32) {
+    match rotation % 4 {
+        0 => (x, z),
+        1 => (-z, x),
+        2 => (-x, -z),
+        _ => (z, -x),
+    }
+}

--- a/src/lib/world_gen/src/structures/templates/temple.json
+++ b/src/lib/world_gen/src/structures/templates/temple.json
@@ -1,0 +1,7 @@
+{
+  "blocks": [
+    {"x":0, "y":0, "z":0, "block":"minecraft:mossy_cobblestone"},
+    {"x":1, "y":0, "z":0, "block":"minecraft:mossy_cobblestone"},
+    {"x":0, "y":0, "z":1, "block":"minecraft:stone_bricks"}
+  ]
+}

--- a/src/lib/world_gen/src/structures/templates/village.json
+++ b/src/lib/world_gen/src/structures/templates/village.json
@@ -1,0 +1,8 @@
+{
+  "blocks": [
+    {"x":0, "y":0, "z":0, "block":"minecraft:cobblestone"},
+    {"x":1, "y":0, "z":0, "block":"minecraft:oak_planks"},
+    {"x":0, "y":1, "z":0, "block":"minecraft:oak_log"},
+    {"x":0, "y":0, "z":1, "block":"minecraft:cobblestone"}
+  ]
+}

--- a/src/lib/world_gen/src/structures/temple.rs
+++ b/src/lib/world_gen/src/structures/temple.rs
@@ -1,6 +1,10 @@
-use super::{should_place_structure, StructurePlacer};
+use super::template::StructureTemplate;
+use super::{StructurePlacer, should_place_structure};
 use ferrumc_world::chunk_format::Chunk;
-use ferrumc_world::vanilla_chunk_format::BlockData;
+use once_cell::sync::Lazy;
+
+static TEMPLATE: Lazy<StructureTemplate> =
+    Lazy::new(|| StructureTemplate::from_json(include_bytes!("templates/temple.json")));
 
 pub struct Temple;
 
@@ -9,11 +13,6 @@ impl StructurePlacer for Temple {
         if !should_place_structure(seed, 14_357_617, 32, 8, chunk.x, chunk.z) {
             return;
         }
-        let block = BlockData {
-            name: "minecraft:mossy_cobblestone".into(),
-            properties: None,
-        };
-        // Ignore placement errors; this implementation is a simplified placeholder.
-        let _ = chunk.set_block(1, 64, 1, block.to_block_id());
+        TEMPLATE.place_randomized(chunk, seed, 64);
     }
 }

--- a/src/lib/world_gen/src/structures/village.rs
+++ b/src/lib/world_gen/src/structures/village.rs
@@ -1,6 +1,10 @@
-use super::{should_place_structure, StructurePlacer};
+use super::template::StructureTemplate;
+use super::{StructurePlacer, should_place_structure};
 use ferrumc_world::chunk_format::Chunk;
-use ferrumc_world::vanilla_chunk_format::BlockData;
+use once_cell::sync::Lazy;
+
+static TEMPLATE: Lazy<StructureTemplate> =
+    Lazy::new(|| StructureTemplate::from_json(include_bytes!("templates/village.json")));
 
 pub struct Village;
 
@@ -9,11 +13,6 @@ impl StructurePlacer for Village {
         if !should_place_structure(seed, 10_387_312, 32, 8, chunk.x, chunk.z) {
             return;
         }
-        let block = BlockData {
-            name: "minecraft:cobblestone".into(),
-            properties: None,
-        };
-        // Placement failures are ignored for now as the structure system is placeholder-only.
-        let _ = chunk.set_block(0, 64, 0, block.to_block_id());
+        TEMPLATE.place_randomized(chunk, seed, 64);
     }
 }


### PR DESCRIPTION
## Summary
- load structure templates from JSON for villages and temples
- compute bounding boxes and randomized rotation
- place structures only within the owning chunk

## Testing
- `cargo fmt -- src/lib/world_gen/src/structures/mod.rs src/lib/world_gen/src/structures/temple.rs src/lib/world_gen/src/structures/village.rs src/lib/world_gen/src/structures/template.rs`
- `cargo test -p ferrumc-world-gen` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_b_689c12e6283c8329b7c3f2356ad93cfd