### PR TITLE
Add default entity attributes and apply on spawn

### DIFF
--- a/src/lib/core/src/attributes.rs
+++ b/src/lib/core/src/attributes.rs
@@ -1,0 +1,39 @@
+use crate::ai::EntityKind;
+use crate::health::Health;
+use crate::movement::Speed;
+
+/// Default attribute set for a given entity type.
+#[derive(Debug, Clone)]
+pub struct Attributes {
+    pub health: Health,
+    pub speed: Speed,
+}
+
+/// Returns the default [`Attributes`] for the provided [`EntityKind`].
+///
+/// Only a handful of entities are explicitly mapped. Any unmapped entity
+/// will receive a reasonable default set of attributes.
+pub fn attributes_for(kind: EntityKind) -> Attributes {
+    match kind {
+        EntityKind::Player => Attributes {
+            health: Health::with_attributes(20.0, 0.0, 0.0),
+            speed: Speed(0.1),
+        },
+        EntityKind::Cow => Attributes {
+            health: Health::with_attributes(20.0, 0.0, 0.0),
+            speed: Speed(0.2),
+        },
+        EntityKind::Zombie => Attributes {
+            health: Health::with_attributes(20.0, 2.0, 0.0),
+            speed: Speed(0.23),
+        },
+        EntityKind::Skeleton => Attributes {
+            health: Health::with_attributes(20.0, 2.0, 0.0),
+            speed: Speed(0.25),
+        },
+        _ => Attributes {
+            health: Health::with_attributes(20.0, 0.0, 0.0),
+            speed: Speed::default(),
+        },
+    }
+}

--- a/src/lib/core/src/health.rs
+++ b/src/lib/core/src/health.rs
@@ -25,6 +25,19 @@ impl Health {
         }
     }
 
+    /// Creates a new [`Health`] component with the given stats.
+    ///
+    /// This is useful for initializing entities with predefined
+    /// health, armor and regeneration rate values.
+    pub fn with_attributes(max_hearts: f32, armor: f32, regen_rate: f32) -> Self {
+        Self {
+            hearts: max_hearts,
+            max_hearts,
+            armor,
+            regen_rate,
+        }
+    }
+
     /// Applies raw damage to the entity, reduced by its armor value.
     pub fn damage(&mut self, amount: f32) {
         let dmg = (amount - self.armor).max(0.0);

--- a/src/lib/core/src/lib.rs
+++ b/src/lib/core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod conn;
 pub mod entities;
 pub mod furnace;
 pub mod brewing;
+pub mod attributes;
 pub mod health;
 pub mod combat;
 pub mod effects;

--- a/src/lib/core/src/movement.rs
+++ b/src/lib/core/src/movement.rs
@@ -4,6 +4,16 @@ use typename::TypeName;
 
 use crate::{collisions::block::block_bounds, transform::position::Position};
 
+/// Base movement speed for an entity.
+#[derive(TypeName, Component, Debug, Clone, Copy)]
+pub struct Speed(pub f64);
+
+impl Default for Speed {
+    fn default() -> Self {
+        Speed(0.1)
+    }
+}
+
 #[derive(TypeName, Component, Debug, Clone, Copy, Default)]
 pub struct Movement {
     pub vx: f64,

--- a/src/lib/core/src/state.rs
+++ b/src/lib/core/src/state.rs
@@ -7,10 +7,11 @@ use serde::{Deserialize, Serialize};
 use tracing::error;
 
 use crate::ai::{AIGoal, EntityKind, Mob, PendingSpawn};
+use crate::attributes::attributes_for;
 use crate::collisions::bounds::CollisionBounds;
 use crate::entities::spawn_rules::{self, SpawnRule};
 use crate::identity::entity_id::EntityId;
-use crate::movement::Movement;
+use crate::movement::{Movement, Speed};
 use crate::transform::position::Position;
 use crate::transform::rotation::Rotation;
 use crate::furnace::{furnace_tick, Furnace};
@@ -67,12 +68,15 @@ pub fn spawn_entities_from_biomes(
     let rules = spawn_rules::rules_for_biome(biome);
     if let Some(kind) = select_weighted(rules) {
         let id = EntityId::new(rand::random::<u128>());
+        let attrs = attributes_for(kind);
         cmd.spawn((
             id,
             Mob { kind },
+            attrs.health,
             Position::default(),
             Rotation::default(),
             Movement::default(),
+            attrs.speed,
             CollisionBounds {
                 x_offset_start: -0.3,
                 x_offset_end: 0.3,


### PR DESCRIPTION
## Summary
- map `EntityKind` to default health and speed values
- attach attributes when spawning mobs
- expose new attributes module and speed component

## Testing
- `cargo test` *(fails: `ferrumc-macros` requires unstable feature `proc_macro_quote`)*

------
https://chatgpt.com/codex/tasks/task_b_689e4fb0c8088329a2724faeac44728b