### PR TITLE
feat: add default ai goals

### DIFF
--- a/src/lib/core/src/ai.rs
+++ b/src/lib/core/src/ai.rs
@@ -1,3 +1,12 @@
+use bevy_ecs::prelude::Component;
+use typename::TypeName;
+
+use crate::transform::position::Position;
+
+mod passive;
+mod hostile;
+mod neutral;
+
 #[derive(TypeName, Component, Debug, Clone, Copy, Eq, PartialEq)]
 pub enum EntityKind {
     Allay,
@@ -124,6 +133,39 @@ pub enum EntityKind {
     ZombifiedPiglin,
     Player,
     FishingBobber,
+}
+
+#[derive(TypeName, Component, Debug, Clone)]
+pub enum AIGoal {
+    Idle,
+    Wander,
+    Graze,
+    Flee { from: Position },
+    Target { target: Position },
+    Attack { target: Position },
+    Trade,
+    Defend { target: Position },
+}
+
+#[derive(TypeName, Component, Debug, Clone, Copy)]
+pub struct Mob {
+    pub kind: EntityKind,
+}
+
+#[derive(TypeName, Component, Debug, Default, Clone, Copy)]
+pub struct PendingSpawn;
+
+pub fn default_goals(kind: EntityKind) -> Vec<AIGoal> {
+    if let Some(goals) = passive::goals(kind) {
+        return goals;
+    }
+    if let Some(goals) = hostile::goals(kind) {
+        return goals;
+    }
+    if let Some(goals) = neutral::goals(kind) {
+        return goals;
+    }
+    vec![AIGoal::Idle]
 }
 
 const ALLAY_ID: u64 = get_registry_entry!("minecraft:entity_type.entries.minecraft:allay");

--- a/src/lib/core/src/ai/hostile.rs
+++ b/src/lib/core/src/ai/hostile.rs
@@ -1,0 +1,53 @@
+use super::{AIGoal, EntityKind};
+use crate::transform::position::Position;
+
+const HOSTILE_MOBS: &[EntityKind] = &[
+    EntityKind::Blaze,
+    EntityKind::CaveSpider,
+    EntityKind::Creeper,
+    EntityKind::Drowned,
+    EntityKind::Endermite,
+    EntityKind::Evoker,
+    EntityKind::Ghast,
+    EntityKind::Guardian,
+    EntityKind::Hoglin,
+    EntityKind::Husk,
+    EntityKind::Illusioner,
+    EntityKind::MagmaCube,
+    EntityKind::Phantom,
+    EntityKind::PiglinBrute,
+    EntityKind::Pillager,
+    EntityKind::Ravager,
+    EntityKind::Shulker,
+    EntityKind::Silverfish,
+    EntityKind::Skeleton,
+    EntityKind::SkeletonHorse,
+    EntityKind::Slime,
+    EntityKind::Spider,
+    EntityKind::Stray,
+    EntityKind::Vex,
+    EntityKind::Vindicator,
+    EntityKind::Witch,
+    EntityKind::WitherSkeleton,
+    EntityKind::Zoglin,
+    EntityKind::Zombie,
+    EntityKind::ZombieHorse,
+    EntityKind::ZombieVillager,
+    EntityKind::Giant,
+    EntityKind::ElderGuardian,
+    EntityKind::EnderDragon,
+    EntityKind::Warden,
+    EntityKind::Wither,
+];
+
+pub fn goals(kind: EntityKind) -> Option<Vec<AIGoal>> {
+    if HOSTILE_MOBS.contains(&kind) {
+        Some(vec![
+            AIGoal::Target { target: Position::default() },
+            AIGoal::Attack { target: Position::default() },
+        ])
+    } else {
+        None
+    }
+}
+

--- a/src/lib/core/src/ai/neutral.rs
+++ b/src/lib/core/src/ai/neutral.rs
@@ -1,0 +1,43 @@
+use super::{AIGoal, EntityKind};
+use crate::transform::position::Position;
+
+const TRADERS: &[EntityKind] = &[
+    EntityKind::Villager,
+    EntityKind::WanderingTrader,
+];
+
+const DEFENDERS: &[EntityKind] = &[
+    EntityKind::IronGolem,
+    EntityKind::SnowGolem,
+];
+
+const TERRITORIAL: &[EntityKind] = &[
+    EntityKind::Bee,
+    EntityKind::Enderman,
+    EntityKind::Llama,
+    EntityKind::PolarBear,
+    EntityKind::Piglin,
+    EntityKind::ZombifiedPiglin,
+    EntityKind::Wolf,
+];
+
+pub fn goals(kind: EntityKind) -> Option<Vec<AIGoal>> {
+    let pos = Position::default();
+    if TRADERS.contains(&kind) {
+        return Some(vec![AIGoal::Trade, AIGoal::Flee { from: pos }]);
+    }
+    if DEFENDERS.contains(&kind) {
+        return Some(vec![
+            AIGoal::Defend { target: pos },
+            AIGoal::Attack { target: pos },
+        ]);
+    }
+    if TERRITORIAL.contains(&kind) {
+        return Some(vec![
+            AIGoal::Wander,
+            AIGoal::Defend { target: pos },
+        ]);
+    }
+    None
+}
+

--- a/src/lib/core/src/ai/passive.rs
+++ b/src/lib/core/src/ai/passive.rs
@@ -1,0 +1,50 @@
+use super::{AIGoal, EntityKind};
+use crate::transform::position::Position;
+
+const PASSIVE_MOBS: &[EntityKind] = &[
+    EntityKind::Allay,
+    EntityKind::Axolotl,
+    EntityKind::Bat,
+    EntityKind::Camel,
+    EntityKind::Cat,
+    EntityKind::Chicken,
+    EntityKind::Cod,
+    EntityKind::Cow,
+    EntityKind::Dolphin,
+    EntityKind::Donkey,
+    EntityKind::Fox,
+    EntityKind::Frog,
+    EntityKind::GlowSquid,
+    EntityKind::Horse,
+    EntityKind::Mooshroom,
+    EntityKind::Mule,
+    EntityKind::Ocelot,
+    EntityKind::Panda,
+    EntityKind::Parrot,
+    EntityKind::Pig,
+    EntityKind::Rabbit,
+    EntityKind::Salmon,
+    EntityKind::Sheep,
+    EntityKind::Sniffer,
+    EntityKind::Squid,
+    EntityKind::Strider,
+    EntityKind::Tadpole,
+    EntityKind::TropicalFish,
+    EntityKind::Turtle,
+    EntityKind::TraderLlama,
+    EntityKind::Goat,
+    EntityKind::Pufferfish,
+];
+
+pub fn goals(kind: EntityKind) -> Option<Vec<AIGoal>> {
+    if PASSIVE_MOBS.contains(&kind) {
+        Some(vec![
+            AIGoal::Wander,
+            AIGoal::Graze,
+            AIGoal::Flee { from: Position::default() },
+        ])
+    } else {
+        None
+    }
+}
+


### PR DESCRIPTION
## Summary
- add AI goal enum and goal stack function
- define passive, hostile and neutral goal presets

## Testing
- `cargo test -p ferrumc-core` *(fails: `#![feature(proc_macro_quote)] may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_b_689e81cad73c8329998cb7d73cecaca0