### PR TITLE
feat(world): add random tick handlers

### DIFF
--- a/src/lib/world/src/lib.rs
+++ b/src/lib/world/src/lib.rs
@@ -7,10 +7,10 @@ pub mod edit_batch;
 pub mod edits;
 pub mod errors;
 mod importing;
+pub mod recipes;
 pub mod redstone;
 pub mod tick;
 pub mod vanilla_chunk_format;
-pub mod recipes;
 
 use crate::chunk_format::Chunk;
 use crate::errors::WorldError;
@@ -183,8 +183,8 @@ impl World {
     }
 
     /// Register a block position for random ticking.
-    pub fn schedule_random_tick(&self, x: i32, y: i32, z: i32, dimension: &str) {
-        tick::schedule_random_tick(self, x, y, z, dimension);
+    pub fn schedule_random_tick(&self, x: i32, y: i32, z: i32, dimension: &str, chance: f32) {
+        tick::schedule_random_tick(self, x, y, z, dimension, chance);
     }
 
     /// Get cached redstone power level at position.

--- a/src/lib/world/tests/tick.rs
+++ b/src/lib/world/tests/tick.rs
@@ -3,9 +3,9 @@ use std::collections::BTreeMap;
 mod common;
 use common::setup_world;
 
-use ferrumc_world::vanilla_chunk_format::BlockData;
 use ferrumc_world::block_id::BlockId;
-use ferrumc_world::tick::{TickManager, ScheduledTick, BlockPos};
+use ferrumc_world::tick::{BlockPos, ScheduledTick, TickManager};
+use ferrumc_world::vanilla_chunk_format::BlockData;
 
 #[test]
 #[ignore]
@@ -13,8 +13,13 @@ fn water_spreads_downward() {
     let world = setup_world();
     let mut props = BTreeMap::new();
     props.insert("level".to_string(), "0".to_string());
-    let water = BlockData { name: "minecraft:water".to_string(), properties: Some(props) };
-    world.set_block_and_fetch(0, 1, 0, "overworld", water).unwrap();
+    let water = BlockData {
+        name: "minecraft:water".to_string(),
+        properties: Some(props),
+    };
+    world
+        .set_block_and_fetch(0, 1, 0, "overworld", water)
+        .unwrap();
     world.schedule_tick(0, 1, 0, "overworld", 0);
     world.tick().unwrap();
     let below = world.get_block_and_fetch(0, 0, 0, "overworld").unwrap();
@@ -28,9 +33,14 @@ fn crops_grow_over_time() {
     let world = setup_world();
     let mut props = BTreeMap::new();
     props.insert("age".to_string(), "0".to_string());
-    let wheat = BlockData { name: "minecraft:wheat".to_string(), properties: Some(props) };
-    world.set_block_and_fetch(0, 1, 0, "overworld", wheat).unwrap();
-    world.schedule_random_tick(0, 1, 0, "overworld");
+    let wheat = BlockData {
+        name: "minecraft:wheat".to_string(),
+        properties: Some(props),
+    };
+    world
+        .set_block_and_fetch(0, 1, 0, "overworld", wheat)
+        .unwrap();
+    world.schedule_random_tick(0, 1, 0, "overworld", 1.0);
     for _ in 0..3 {
         world.tick().unwrap();
     }
@@ -48,9 +58,18 @@ fn crops_grow_over_time() {
 #[test]
 fn cleanup_chunk_removes_entries() {
     let mut tm = TickManager::default();
-    let pos = BlockPos { x: 0, y: 0, z: 0, dimension: "overworld".to_string() };
-    tm.schedule(ScheduledTick { pos: pos.clone(), block: BlockId::default(), delay: 0 });
-    tm.schedule_random(pos.clone());
+    let pos = BlockPos {
+        x: 0,
+        y: 0,
+        z: 0,
+        dimension: "overworld".to_string(),
+    };
+    tm.schedule(ScheduledTick {
+        pos: pos.clone(),
+        block: BlockId::default(),
+        delay: 0,
+    });
+    tm.schedule_random(pos.clone(), 1.0);
     let key = (0, 0, "overworld".to_string());
     assert!(tm.scheduled.contains_key(&key));
     assert!(tm.random.contains_key(&key));
@@ -62,12 +81,30 @@ fn cleanup_chunk_removes_entries() {
 #[test]
 fn cleanup_dimension_removes_all_matches() {
     let mut tm = TickManager::default();
-    let over = BlockPos { x: 0, y: 0, z: 0, dimension: "overworld".to_string() };
-    let nether = BlockPos { x: 0, y: 0, z: 0, dimension: "nether".to_string() };
-    tm.schedule(ScheduledTick { pos: over.clone(), block: BlockId::default(), delay: 0 });
-    tm.schedule_random(over.clone());
-    tm.schedule(ScheduledTick { pos: nether.clone(), block: BlockId::default(), delay: 0 });
-    tm.schedule_random(nether.clone());
+    let over = BlockPos {
+        x: 0,
+        y: 0,
+        z: 0,
+        dimension: "overworld".to_string(),
+    };
+    let nether = BlockPos {
+        x: 0,
+        y: 0,
+        z: 0,
+        dimension: "nether".to_string(),
+    };
+    tm.schedule(ScheduledTick {
+        pos: over.clone(),
+        block: BlockId::default(),
+        delay: 0,
+    });
+    tm.schedule_random(over.clone(), 1.0);
+    tm.schedule(ScheduledTick {
+        pos: nether.clone(),
+        block: BlockId::default(),
+        delay: 0,
+    });
+    tm.schedule_random(nether.clone(), 1.0);
     tm.cleanup_dimension("overworld");
     let key_over = (0, 0, "overworld".to_string());
     let key_nether = (0, 0, "nether".to_string());


### PR DESCRIPTION
## Summary
- add RandomTick struct with probability-based execution and cross-chunk scheduling
- handle sapling growth, leaf decay, and farmland hydration during ticks
- expose chance parameter when registering random ticks

## Testing
- `cargo +nightly test -p ferrumc-world --all-features` *(fails: non-exhaustive pattern matches in redstone components)*

------
https://chatgpt.com/codex/tasks/task_b_68a0013251cc8329b80b5d637a09d63d