### PR TITLE
feat: track advancement progress

### DIFF
--- a/src/lib/core/src/progression/mod.rs
+++ b/src/lib/core/src/progression/mod.rs
@@ -1,8 +1,39 @@
 use serde::Deserialize;
 use std::collections::HashMap;
 
+pub mod packets;
+pub mod player;
+
+pub use packets::AdvancementsPacket;
+pub use player::PlayerProgression;
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct Advancement(pub serde_json::Value);
+
+impl Advancement {
+    /// Returns all criteria names for this advancement.
+    pub fn criteria(&self) -> Vec<String> {
+        self.0
+            .get("criteria")
+            .and_then(|c| c.as_object())
+            .map(|o| o.keys().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    /// Returns recipe rewards associated with this advancement, if any.
+    pub fn recipe_rewards(&self) -> Vec<String> {
+        self.0
+            .get("rewards")
+            .and_then(|r| r.get("recipes"))
+            .and_then(|r| r.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct Recipe(pub serde_json::Value);
@@ -14,12 +45,8 @@ pub struct ProgressionRegistry {
 }
 
 impl ProgressionRegistry {
-    pub fn from_json(
-        advancements_json: &str,
-        recipes_json: &str,
-    ) -> serde_json::Result<Self> {
-        let advancements: HashMap<String, Advancement> =
-            serde_json::from_str(advancements_json)?;
+    pub fn from_json(advancements_json: &str, recipes_json: &str) -> serde_json::Result<Self> {
+        let advancements: HashMap<String, Advancement> = serde_json::from_str(advancements_json)?;
         let recipes: HashMap<String, Recipe> = serde_json::from_str(recipes_json)?;
         Ok(Self {
             advancements,
@@ -28,12 +55,8 @@ impl ProgressionRegistry {
     }
 
     pub fn load() -> Self {
-        const ADVANCEMENTS: &str = include_str!(
-            "../../../../../assets/data/advancements.json"
-        );
-        const RECIPES: &str = include_str!(
-            "../../../../../assets/data/recipes.json"
-        );
+        const ADVANCEMENTS: &str = include_str!("../../../../../assets/data/advancements.json");
+        const RECIPES: &str = include_str!("../../../../../assets/data/recipes.json");
         Self::from_json(ADVANCEMENTS, RECIPES).unwrap_or_default()
     }
 }

--- a/src/lib/core/src/progression/packets.rs
+++ b/src/lib/core/src/progression/packets.rs
@@ -1,0 +1,47 @@
+use ferrumc_macros::{packet, NetEncode};
+
+#[derive(NetEncode, Clone)]
+pub struct AdvancementProgressItem {
+    pub criterion_id: String,
+    pub achieved: bool,
+}
+
+#[derive(NetEncode, Clone)]
+pub struct AdvancementProgressData {
+    pub advancement_id: String,
+    pub progress: Vec<AdvancementProgressItem>,
+}
+
+#[derive(NetEncode, Clone)]
+#[packet(packet_id = "advancements", state = "play")]
+pub struct AdvancementsPacket {
+    pub reset: bool,
+    pub progress: Vec<AdvancementProgressData>,
+}
+
+impl AdvancementsPacket {
+    pub fn grant_single(id: impl Into<String>) -> Self {
+        Self {
+            reset: false,
+            progress: vec![AdvancementProgressData {
+                advancement_id: id.into(),
+                progress: Vec::new(),
+            }],
+        }
+    }
+}
+
+// Duplicates ferrumc-net's CraftedRecipePacket to avoid a cyclic dependency.
+#[derive(NetEncode, Clone)]
+#[packet(packet_id = "crafted_recipe", state = "play")]
+pub struct CraftedRecipePacket {
+    pub recipe_id: String,
+}
+
+impl CraftedRecipePacket {
+    pub fn new(recipe_id: impl Into<String>) -> Self {
+        Self {
+            recipe_id: recipe_id.into(),
+        }
+    }
+}

--- a/src/lib/core/src/progression/player.rs
+++ b/src/lib/core/src/progression/player.rs
@@ -1,0 +1,58 @@
+use std::collections::{HashMap, HashSet};
+
+use super::{packets::CraftedRecipePacket, AdvancementsPacket, ProgressionRegistry};
+
+/// Tracks advancement progress for a single player.
+#[derive(Debug, Default)]
+pub struct PlayerProgression {
+    completed: HashMap<String, HashSet<String>>,
+}
+
+impl PlayerProgression {
+    /// Marks a criterion as complete for the given advancement.
+    /// When all criteria are met, packets to notify the client are returned.
+    pub fn complete_criterion(
+        &mut self,
+        advancement_id: &str,
+        criterion: &str,
+        registry: &ProgressionRegistry,
+    ) -> (Vec<AdvancementsPacket>, Vec<CraftedRecipePacket>) {
+        let criteria = registry
+            .advancements
+            .get(advancement_id)
+            .map(|a| a.criteria())
+            .unwrap_or_default();
+        if !criteria.iter().any(|c| c == criterion) {
+            return (Vec::new(), Vec::new());
+        }
+
+        let entry = self
+            .completed
+            .entry(advancement_id.to_string())
+            .or_insert_with(HashSet::new);
+        entry.insert(criterion.to_string());
+
+        if entry.len() == criteria.len() {
+            let (adv_packets, recipe_packets) = self.trigger_rewards(advancement_id, registry);
+            self.completed.remove(advancement_id);
+            return (adv_packets, recipe_packets);
+        }
+        (Vec::new(), Vec::new())
+    }
+
+    fn trigger_rewards(
+        &self,
+        advancement_id: &str,
+        registry: &ProgressionRegistry,
+    ) -> (Vec<AdvancementsPacket>, Vec<CraftedRecipePacket>) {
+        let adv_packet = AdvancementsPacket::grant_single(advancement_id);
+
+        let mut recipe_packets = Vec::new();
+        if let Some(adv) = registry.advancements.get(advancement_id) {
+            for recipe in adv.recipe_rewards() {
+                recipe_packets.push(CraftedRecipePacket::new(recipe));
+            }
+        }
+        (vec![adv_packet], recipe_packets)
+    }
+}


### PR DESCRIPTION
## Summary
- expose criteria and recipe rewards for advancements
- track per-player advancement progress and produce reward packets
- add advancement and crafted recipe progression packets

## Testing
- `cargo test -p ferrumc-core` *(fails: `#![feature]` may not be used on the stable release channel)*

------
https://chatgpt.com/codex/tasks/task_b_68a00871a8448329a6aba0bf63f5279b