### PR TITLE
Add missing login and handshake packets

### DIFF
--- a/src/lib/net/src/packets/incoming/custom_query_answer.rs
+++ b/src/lib/net/src/packets/incoming/custom_query_answer.rs
@@ -1,0 +1,11 @@
+use ferrumc_macros::{packet, NetDecode};
+use ferrumc_net_codec::net_types::length_prefixed_vec::LengthPrefixedVec;
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
+use ferrumc_net_codec::net_types::var_int::VarInt;
+
+#[derive(Debug, NetDecode)]
+#[packet(packet_id = "custom_query_answer", state = "login")]
+pub struct CustomQueryAnswerPacket {
+    pub transaction_id: VarInt,
+    pub data: PrefixedOptional<LengthPrefixedVec<u8>>,
+}

--- a/src/lib/net/src/packets/incoming/legacy_server_list_ping.rs
+++ b/src/lib/net/src/packets/incoming/legacy_server_list_ping.rs
@@ -1,0 +1,5 @@
+use ferrumc_macros::{packet, NetDecode};
+
+#[derive(Debug, NetDecode)]
+#[packet(packet_id = "legacy_server_list_ping", state = "handshake")]
+pub struct LegacyServerListPingPacket;

--- a/src/lib/net/src/packets/incoming/mod.rs
+++ b/src/lib/net/src/packets/incoming/mod.rs
@@ -1,7 +1,9 @@
 pub mod handshake;
+pub mod legacy_server_list_ping;
 pub mod known_packs;
 pub mod login_encryption_response;
 pub mod login_start;
+pub mod custom_query_answer;
 pub mod ping;
 pub mod status_request;
 

--- a/src/lib/net/src/packets/outgoing/custom_query.rs
+++ b/src/lib/net/src/packets/outgoing/custom_query.rs
@@ -1,0 +1,22 @@
+use ferrumc_macros::{packet, NetEncode};
+use ferrumc_net_codec::net_types::byte_array::ByteArray;
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use std::io::Write;
+
+#[derive(NetEncode)]
+#[packet(packet_id = "custom_query", state = "login")]
+pub struct CustomQueryPacket<'a> {
+    pub transaction_id: VarInt,
+    pub channel: &'a str,
+    pub data: ByteArray,
+}
+
+impl<'a> CustomQueryPacket<'a> {
+    pub fn new(transaction_id: VarInt, channel: &'a str, data: Vec<u8>) -> Self {
+        Self {
+            transaction_id,
+            channel,
+            data: ByteArray::new(data),
+        }
+    }
+}

--- a/src/lib/net/src/packets/outgoing/mod.rs
+++ b/src/lib/net/src/packets/outgoing/mod.rs
@@ -17,6 +17,7 @@ pub mod login_disconnect;
 pub mod login_encryption_request;
 pub mod login_play;
 pub mod login_success;
+pub mod custom_query;
 pub mod ping_response;
 pub mod set_center_chunk;
 pub mod set_default_spawn_position;

--- a/src/tests/src/net/handshake_legacy_ping.rs
+++ b/src/tests/src/net/handshake_legacy_ping.rs
@@ -1,0 +1,9 @@
+use ferrumc_net::packets::incoming::legacy_server_list_ping::LegacyServerListPingPacket;
+use ferrumc_net_codec::decode::{NetDecode, NetDecodeOpts};
+use std::io::Cursor;
+
+#[test]
+fn decode_legacy_server_list_ping() {
+    let mut cursor = Cursor::new(Vec::<u8>::new());
+    let _pkt = LegacyServerListPingPacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+}

--- a/src/tests/src/net/login_custom_query.rs
+++ b/src/tests/src/net/login_custom_query.rs
@@ -1,0 +1,38 @@
+use ferrumc_net::packets::incoming::custom_query_answer::CustomQueryAnswerPacket;
+use ferrumc_net::packets::outgoing::custom_query::CustomQueryPacket;
+use ferrumc_net_codec::decode::{NetDecode, NetDecodeOpts};
+use ferrumc_net_codec::encode::{NetEncode, NetEncodeOpts};
+use ferrumc_net_codec::net_types::prefixed_optional::PrefixedOptional;
+use ferrumc_net_codec::net_types::var_int::VarInt;
+use std::io::{Cursor, Write};
+
+#[test]
+fn decode_custom_query_answer() {
+    let mut bytes = Vec::new();
+    VarInt::from(5)
+        .encode(&mut bytes, &NetEncodeOpts::None)
+        .unwrap();
+    true.encode(&mut bytes, &NetEncodeOpts::None).unwrap();
+    VarInt::from(3)
+        .encode(&mut bytes, &NetEncodeOpts::None)
+        .unwrap();
+    bytes.extend_from_slice(&[1, 2, 3]);
+    let mut cursor = Cursor::new(bytes);
+    let pkt = CustomQueryAnswerPacket::decode(&mut cursor, &NetDecodeOpts::None).unwrap();
+    assert_eq!(pkt.transaction_id, VarInt::from(5));
+    match pkt.data {
+        PrefixedOptional::Some(ref v) => {
+            assert_eq!(v.length, VarInt::from(3));
+            assert_eq!(v.data, vec![1, 2, 3]);
+        }
+        PrefixedOptional::None => panic!("expected data"),
+    }
+}
+
+#[test]
+fn encode_custom_query_packet() {
+    let pkt = CustomQueryPacket::new(VarInt::from(7), "minecraft:brand", vec![1, 2, 3]);
+    let mut buf = Vec::new();
+    pkt.encode(&mut buf, &NetEncodeOpts::WithLength).unwrap();
+    assert!(!buf.is_empty());
+}

--- a/src/tests/src/net/mod.rs
+++ b/src/tests/src/net/mod.rs
@@ -7,3 +7,5 @@ pub mod login_utils;
 mod offline_login;
 mod player_actions;
 mod recipe_packets;
+mod handshake_legacy_ping;
+mod login_custom_query;


### PR DESCRIPTION
## Summary
- implement serverbound `custom_query_answer` and `legacy_server_list_ping` packets
- add clientbound `custom_query` packet
- test login custom query and legacy ping decoding

## Testing
- `cargo +nightly test` *(fails: non-exhaustive patterns in `ferrumc-world`)*

------
https://chatgpt.com/codex/tasks/task_b_68a0133683588329877462833e4319bb